### PR TITLE
add optional encoder gear ratio

### DIFF
--- a/include/lemlib/chassis/trackingWheel.hpp
+++ b/include/lemlib/chassis/trackingWheel.hpp
@@ -24,16 +24,18 @@ class TrackingWheel {
          * @param encoder the optical shaft encoder to use
          * @param diameter diameter of the tracking wheel in inches
          * @param distance distance between the tracking wheel and the center of rotation in inches
+         * @param gearRatio gear ratio of the tracking wheel, defaults to 1
          */
-        TrackingWheel(pros::ADIEncoder* encoder, float diameter, float distance);
+        TrackingWheel(pros::ADIEncoder* encoder, float diameter, float distance, float gearRatio = 1);
         /**
          * @brief Create a new tracking wheel
          *
          * @param encoder the v5 rotation sensor to use
          * @param diameter diameter of the tracking wheel in inches
          * @param distance distance between the tracking wheel and the center of rotation in inches
+         * @param gearRatio gear ratio of the tracking wheel, defaults to 1
          */
-        TrackingWheel(pros::Rotation* encoder, float diameter, float distance);
+        TrackingWheel(pros::Rotation* encoder, float diameter, float distance, float gearRatio = 1);
         /**
          * @brief Create a new tracking wheel
          *
@@ -73,5 +75,6 @@ class TrackingWheel {
         pros::ADIEncoder* encoder = nullptr;
         pros::Rotation* rotation = nullptr;
         pros::Motor_Group* motors = nullptr;
+        float gearRatio = 1;
 };
 } // namespace lemlib

--- a/src/lemlib/chassis/trackingWheel.cpp
+++ b/src/lemlib/chassis/trackingWheel.cpp
@@ -21,10 +21,11 @@
  * @param diameter diameter of the tracking wheel in inches
  * @param distance distance between the tracking wheel and the center of rotation in inches
  */
-lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, float diameter, float distance) {
+lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, float diameter, float distance, float gearRatio) {
     this->encoder = encoder;
     this->diameter = diameter;
     this->distance = distance;
+    this->gearRatio = gearRatio;
 }
 
 /**
@@ -34,10 +35,11 @@ lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, float diameter, 
  * @param diameter diameter of the tracking wheel in inches
  * @param distance distance between the tracking wheel and the center of rotation in inches
  */
-lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, float diameter, float distance) {
+lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, float diameter, float distance, float gearRatio) {
     this->rotation = encoder;
     this->diameter = diameter;
     this->distance = distance;
+    this->gearRatio = gearRatio;
 }
 
 /**
@@ -73,9 +75,9 @@ void lemlib::TrackingWheel::reset() {
  */
 float lemlib::TrackingWheel::getDistanceTraveled() {
     if (this->encoder != nullptr) {
-        return float(this->encoder->get_value()) * this->diameter * M_PI / 360;
+        return (float(this->encoder->get_value()) * this->diameter * M_PI / 360) / this->gearRatio;
     } else if (this->rotation != nullptr) {
-        return float(this->rotation->get_position()) * this->diameter * M_PI / 36000;
+        return (float(this->rotation->get_position()) * this->diameter * M_PI / 36000) / this->gearRatio;
     } else if (this->motors != nullptr) {
         // get distance traveled by each motor
         std::vector<pros::motor_gearset_e_t> gearsets = this->motors->get_gearing();


### PR DESCRIPTION
#### Summary
When initializing, you can optionally provide an encoder gear ratio.
Example:
```CPP
lemlib::TrackingWheel wheel(&encoder, 2.75, 0, 2 /* gear ratio of 2:1 */);
```

#### Motivation
People were talking about gearing their odometry pods, which would cause issues in LemLib making it think it traveled more than it actually did.

#### Test Plan
This has not been tested, but it should work. All it does is divide the distance traveled by the gear ratio.

#### Additional Notes
None