### PR TITLE
Switch to enum for wheel sizes and add half-cuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ EXCLUDE_COLD_LIBRARIES:=
 IS_LIBRARY:=1
 # TODO: CHANGE THIS!
 LIBNAME:=LemLib
-VERSION:=0.4.7
+VERSION:=0.4.8
 
 # EXCLUDE_SRC_FROM_LIB= $(SRCDIR)/unpublishedfile.c
 # this line excludes opcontrol.c and similar files

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -71,14 +71,14 @@ typedef struct {
  * @param leftMotors pointer to the left motors
  * @param rightMotors pointer to the right motors
  * @param trackWidth the track width of the robot
- * @param wheelDiameter the diameter of the wheels (2.75, 3.25, 4, 4.125)
+ * @param wheelType the type of omni-wheel used for the drivetrain
  * @param rpm the rpm of the wheels
  */
 typedef struct {
         pros::Motor_Group* leftMotors;
         pros::Motor_Group* rightMotors;
         float trackWidth;
-        float wheelDiameter;
+        Omniwheel wheelType;
         float rpm;
 } Drivetrain_t;
 

--- a/include/lemlib/chassis/trackingWheel.hpp
+++ b/include/lemlib/chassis/trackingWheel.hpp
@@ -16,35 +16,44 @@
 #include "pros/rotation.hpp"
 
 namespace lemlib {
+
+/**
+ * @brief An omni-wheel enumeration.
+ *
+ * @note These enumerations are equal to the virtual diameter of a wheel which would have a circumference equal to the real loop length of the given wheel in thous.
+ * 
+ */
+enum class Omniwheel { NEW_275 = 2750, OLD_275 = 2750, NEW_275_HALF = 2744, OLD_275_HALF = 2740, NEW_325 = 3250, OLD_325 = 3250, NEW_325_HALF = 3246, OLD_325_HALF = 3246, NEW_4 = 4000, OLD_4 = 4180, NEW_4_HALF = 3995, OLD_4_HALF = 4175 };
+
 class TrackingWheel {
     public:
         /**
          * @brief Create a new tracking wheel
          *
          * @param encoder the optical shaft encoder to use
-         * @param diameter diameter of the tracking wheel in inches
+         * @param wheel the omni-wheel to use
          * @param distance distance between the tracking wheel and the center of rotation in inches
          * @param gearRatio gear ratio of the tracking wheel, defaults to 1
          */
-        TrackingWheel(pros::ADIEncoder* encoder, float diameter, float distance, float gearRatio = 1);
+        TrackingWheel(pros::ADIEncoder* encoder, Omniwheel wheel, float distance, float gearRatio = 1);
         /**
          * @brief Create a new tracking wheel
          *
          * @param encoder the v5 rotation sensor to use
-         * @param diameter diameter of the tracking wheel in inches
+         * @param wheel the omni-wheel to use
          * @param distance distance between the tracking wheel and the center of rotation in inches
          * @param gearRatio gear ratio of the tracking wheel, defaults to 1
          */
-        TrackingWheel(pros::Rotation* encoder, float diameter, float distance, float gearRatio = 1);
+        TrackingWheel(pros::Rotation* encoder, Omniwheel wheel, float distance, float gearRatio = 1);
         /**
          * @brief Create a new tracking wheel
          *
          * @param motors the motor group to use
-         * @param diameter diameter of the drivetrain wheels in inches
+         * @param wheel the omni-wheel to use
          * @param distance half the track width of the drivetrain in inches
          * @param rpm theoretical maximum rpm of the drivetrain wheels
          */
-        TrackingWheel(pros::Motor_Group* motors, float diameter, float distance, float rpm);
+        TrackingWheel(pros::Motor_Group* motors, Omniwheel wheel, float distance, float rpm);
         /**
          * @brief Reset the tracking wheel position to 0
          *

--- a/include/lemlib/chassis/trackingWheel.hpp
+++ b/include/lemlib/chassis/trackingWheel.hpp
@@ -20,10 +20,24 @@ namespace lemlib {
 /**
  * @brief An omni-wheel enumeration.
  *
- * @note These enumerations are equal to the virtual diameter of a wheel which would have a circumference equal to the real loop length of the given wheel in thous.
- * 
+ * @note These enumerations are equal to the virtual diameter of a wheel which would have a circumference equal to the
+ * real loop length of the given wheel in thous.
+ *
  */
-enum class Omniwheel { NEW_275 = 2750, OLD_275 = 2750, NEW_275_HALF = 2744, OLD_275_HALF = 2740, NEW_325 = 3250, OLD_325 = 3250, NEW_325_HALF = 3246, OLD_325_HALF = 3246, NEW_4 = 4000, OLD_4 = 4180, NEW_4_HALF = 3995, OLD_4_HALF = 4175 };
+enum class Omniwheel {
+    NEW_275 = 2750,
+    OLD_275 = 2750,
+    NEW_275_HALF = 2744,
+    OLD_275_HALF = 2740,
+    NEW_325 = 3250,
+    OLD_325 = 3250,
+    NEW_325_HALF = 3246,
+    OLD_325_HALF = 3246,
+    NEW_4 = 4000,
+    OLD_4 = 4180,
+    NEW_4_HALF = 3995,
+    OLD_4_HALF = 4175
+};
 
 class TrackingWheel {
     public:

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -50,10 +50,10 @@ void lemlib::Chassis::calibrate() {
     }
     // initialize odom
     if (odomSensors.vertical1 == nullptr)
-        odomSensors.vertical1 = new lemlib::TrackingWheel(drivetrain.leftMotors, drivetrain.wheelDiameter,
+        odomSensors.vertical1 = new lemlib::TrackingWheel(drivetrain.leftMotors, drivetrain.wheelType,
                                                           -(drivetrain.trackWidth / 2), drivetrain.rpm);
     if (odomSensors.vertical2 == nullptr)
-        odomSensors.vertical2 = new lemlib::TrackingWheel(drivetrain.rightMotors, drivetrain.wheelDiameter,
+        odomSensors.vertical2 = new lemlib::TrackingWheel(drivetrain.rightMotors, drivetrain.wheelType,
                                                           drivetrain.trackWidth / 2, drivetrain.rpm);
     odomSensors.vertical1->reset();
     odomSensors.vertical2->reset();

--- a/src/lemlib/chassis/trackingWheel.cpp
+++ b/src/lemlib/chassis/trackingWheel.cpp
@@ -24,7 +24,7 @@
  */
 lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, Omniwheel wheel, float distance, float gearRatio) {
     this->encoder = encoder;
-    this->diameter = (double) wheel / 1000.0;
+    this->diameter = (double)wheel / 1000.0;
     this->distance = distance;
     this->gearRatio = gearRatio;
 }
@@ -39,7 +39,7 @@ lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, Omniwheel wheel,
  */
 lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, Omniwheel wheel, float distance, float gearRatio) {
     this->rotation = encoder;
-    this->diameter = (double) wheel / 1000.0;
+    this->diameter = (double)wheel / 1000.0;
     this->distance = distance;
     this->gearRatio = gearRatio;
 }
@@ -55,7 +55,7 @@ lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, Omniwheel wheel, f
 lemlib::TrackingWheel::TrackingWheel(pros::Motor_Group* motors, Omniwheel wheel, float distance, float rpm) {
     this->motors = motors;
     this->motors->set_encoder_units(pros::E_MOTOR_ENCODER_ROTATIONS);
-    this->diameter = (double) wheel / 1000.0;
+    this->diameter = (double)wheel / 1000.0;
     this->distance = distance;
     this->rpm = rpm;
 }

--- a/src/lemlib/chassis/trackingWheel.cpp
+++ b/src/lemlib/chassis/trackingWheel.cpp
@@ -18,13 +18,13 @@
  * @brief Create a new tracking wheel
  *
  * @param encoder the optical shaft encoder to use
- * @param diameter diameter of the tracking wheel in inches
+ * @param wheel the omni-wheel to use
  * @param distance distance between the tracking wheel and the center of rotation in inches
  * @param gearRatio gear ratio of the tracking wheel, defaults to 1
  */
-lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, float diameter, float distance, float gearRatio) {
+lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, Omniwheel wheel, float distance, float gearRatio) {
     this->encoder = encoder;
-    this->diameter = diameter;
+    this->diameter = (double) wheel / 1000.0;
     this->distance = distance;
     this->gearRatio = gearRatio;
 }
@@ -33,13 +33,13 @@ lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, float diameter, 
  * @brief Create a new tracking wheel
  *
  * @param encoder the v5 rotation sensor to use
- * @param diameter diameter of the tracking wheel in inches
+ * @param wheel the omni-wheel to use
  * @param distance distance between the tracking wheel and the center of rotation in inches
  * @param gearRatio gear ratio of the tracking wheel, defaults to 1
  */
-lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, float diameter, float distance, float gearRatio) {
+lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, Omniwheel wheel, float distance, float gearRatio) {
     this->rotation = encoder;
-    this->diameter = diameter;
+    this->diameter = (double) wheel / 1000.0;
     this->distance = distance;
     this->gearRatio = gearRatio;
 }
@@ -48,14 +48,14 @@ lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, float diameter, fl
  * @brief Create a new tracking wheel
  *
  * @param motors the motor group to use
- * @param diameter diameter of the drivetrain wheels in inches
+ * @param wheel the omni-wheel to use
  * @param distance half the track width of the drivetrain in inches
  * @param rpm theoretical maximum rpm of the drivetrain wheels
  */
-lemlib::TrackingWheel::TrackingWheel(pros::Motor_Group* motors, float diameter, float distance, float rpm) {
+lemlib::TrackingWheel::TrackingWheel(pros::Motor_Group* motors, Omniwheel wheel, float distance, float rpm) {
     this->motors = motors;
     this->motors->set_encoder_units(pros::E_MOTOR_ENCODER_ROTATIONS);
-    this->diameter = diameter;
+    this->diameter = (double) wheel / 1000.0;
     this->distance = distance;
     this->rpm = rpm;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,6 @@
 #include "main.h"
 #include "lemlib/api.hpp"
 
-
 // drive motors
 pros::Motor lF(-3, pros::E_MOTOR_GEARSET_06); // left front motor. port 3, reversed
 pros::Motor lM(-14, pros::E_MOTOR_GEARSET_06); // left middle motor. port 14, reversed
@@ -22,50 +21,21 @@ pros::ADIEncoder verticalEnc('A', 'B', false);
 // vertical tracking wheel. 2.75" diameter, 2.2" offset
 lemlib::TrackingWheel vertical(&verticalEnc, lemlib::Omniwheel::NEW_275, 2.2);
 
-
 // drivetrain
 lemlib::Drivetrain_t drivetrain {
-	&leftMotors,
-	&rightMotors,
-	10,
-	lemlib::Omniwheel::NEW_325,
-	360,
+    &leftMotors, &rightMotors, 10, lemlib::Omniwheel::NEW_325, 360,
 };
 
 // lateral motion controller
-lemlib::ChassisController_t lateralController {
-	10,
-	30,
-	1,
-	100,
-	3,
-	500,
-	20
-};
+lemlib::ChassisController_t lateralController {10, 30, 1, 100, 3, 500, 20};
 
 // angular motion controller
-lemlib::ChassisController_t angularController {
-	2,
-	10,
-	1,
-	100,
-	3,
-	500,
-	3
-};
+lemlib::ChassisController_t angularController {2, 10, 1, 100, 3, 500, 3};
 
 // sensors for odometry
-lemlib::OdomSensors_t sensors {
-	nullptr,
-	nullptr,
-	nullptr,
-	nullptr,
-	&imu
-};
-
+lemlib::OdomSensors_t sensors {nullptr, nullptr, nullptr, nullptr, &imu};
 
 lemlib::Chassis chassis(drivetrain, lateralController, angularController, sensors);
-
 
 /**
  * Runs initialization code. This occurs as soon as the program is started.
@@ -74,17 +44,16 @@ lemlib::Chassis chassis(drivetrain, lateralController, angularController, sensor
  * to keep execution time for this mode under a few seconds.
  */
 void initialize() {
-	pros::lcd::initialize();
-	// calibrate sensors
-	chassis.calibrate();
-	while (true) {
-		pros::lcd::print(0, "X: %f", chassis.getPose().x);
-		pros::lcd::print(1, "Y: %f", chassis.getPose().y);
-		pros::lcd::print(2, "Theta: %f", chassis.getPose().theta);
-		pros::delay(10);
-	}
+    pros::lcd::initialize();
+    // calibrate sensors
+    chassis.calibrate();
+    while (true) {
+        pros::lcd::print(0, "X: %f", chassis.getPose().x);
+        pros::lcd::print(1, "Y: %f", chassis.getPose().y);
+        pros::lcd::print(2, "Theta: %f", chassis.getPose().theta);
+        pros::delay(10);
+    }
 }
-
 
 /**
  * Runs while the robot is in the disabled state of Field Management System or
@@ -92,7 +61,6 @@ void initialize() {
  * the robot is enabled, this task will exit.
  */
 void disabled() {}
-
 
 /**
  * Runs after initialize(), and before autonomous when connected to the Field
@@ -105,7 +73,6 @@ void disabled() {}
  */
 void competition_initialize() {}
 
-
 /**
  * Runs the user autonomous code. This function will be started in its own task
  * with the default priority and stack size whenever the robot is enabled via
@@ -117,10 +84,7 @@ void competition_initialize() {}
  * will be stopped. Re-enabling the robot will restart the task, not re-start it
  * from where it left off.
  */
-void autonomous() {
-	chassis.moveTo(20, 0, 4000);
-}
-
+void autonomous() { chassis.moveTo(20, 0, 4000); }
 
 /**
  * Runs the operator control code. This function will be started in its own task
@@ -135,5 +99,4 @@ void autonomous() {
  * operator control task will be stopped. Re-enabling the robot will restart the
  * task, not resume it from where it left off.
  */
-void opcontrol() {
-}
+void opcontrol() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ pros::Imu imu(6);
 // tracking wheels
 pros::ADIEncoder verticalEnc('A', 'B', false);
 // vertical tracking wheel. 2.75" diameter, 2.2" offset
-lemlib::TrackingWheel vertical(&verticalEnc, 2.75, 0);
+lemlib::TrackingWheel vertical(&verticalEnc, lemlib::Omniwheel::NEW_275, 2.2);
 
 
 // drivetrain
@@ -28,7 +28,7 @@ lemlib::Drivetrain_t drivetrain {
 	&leftMotors,
 	&rightMotors,
 	10,
-	3.25,
+	lemlib::Omniwheel::NEW_325,
 	360,
 };
 


### PR DESCRIPTION
#### Summary
 - Added `lemlib::Omniwheel` enum. This enum contains the diameters of all VRC legal VEX omni-wheels in thous (thousandths of an inch).
 - `lemlib::Drivetrain_t` struct now takes a `lemlib::Omniwheel wheelType` instead of a `float wheelDiameter`.
 - `lemlib::TrackingWheel` constructors now take a `lemlib::Omniwheel wheel` instead of a `float diameter`. The diameter value of `wheel` is casted to a double and converted from thous to inches by dividing by 1000.0. `diameter` is still in use internally.
 - Bumped version from `0.4.7` to `0.4.8`.
 - Doxygen documentation added for `lemlib::Omniwheel` and updated for `lemlib::Drivetrain_t` and `lemlib::TrackingWheel`.

#### Motivation
Half-cut wheels are often used when there is not enough space to fit a full-size tracking wheel where one needs it. By switching to an enum to represent all omni-wheels in LemLib, the library is able to fully support half-cut wheels, which have a different effective circumference due to the missing rollers. Another benefit is that both new and old wheels are available in the `lemlib::Omniwheel` enum in addition to full- and half-cuts. This will reduce confusion and potentially erroneous user values (for example, old 4" omni-wheels are 4.18" in reality, while new 4" omni-wheels are actually 4" in reality).

#### Test Plan
 - [x] Compiles with no errors or warnings
 - [x] Tested on a physical robot

#### Additional Notes
the things we have to do because the build team doesn't think about tracking wheels until the end and then they don't fit smh