### PR TITLE
Add methods for opcontrol on the chassis

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -172,9 +172,7 @@ class Chassis {
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
          * of 1 disables the curve entirely.
          */
-
         void tank(int left, int right, float curveGain = 1.0);
-
         /**
          * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
          * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis
@@ -195,7 +193,6 @@ class Chassis {
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
          * of 1 disables the curve entirely.
          */
-
         void curvature(int throttle, int curvature, float cureGain = 1.0);
     private:
         ChassisController_t lateralSettings;

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -193,7 +193,7 @@ class Chassis {
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
          * of 1 disables the curve entirely.
          */
-        void curvature(int throttle, int curvature, float cureGain = 1.0);
+        void curvature(int throttle, int turn, float cureGain = 1.0);
     private:
         ChassisController_t lateralSettings;
         ChassisController_t angularSettings;

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -182,7 +182,7 @@ class Chassis {
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
          * of 1 disables the curve entirely.
          */
-        void arcade(int throttle, int turn, float cureveGain = 1.0);
+        void arcade(int throttle, int turn, float curveGain = 1.0);
         /**
          * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
          * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -179,24 +179,24 @@ class Chassis {
          * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
          * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis
          * controls  the robot's turning
-         * @param forward speed to move forward. Takes an input from -127 to 127.
+         * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
          * @param turn speed to turn. Takes an input from -127 to 127.
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
          * of 1 disables the curve entirely.
          */
-        void arcade(int forward, int turn, float cureveGain = 1.0);
+        void arcade(int throttle, int turn, float cureveGain = 1.0);
         /**
          * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
          * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the
          * drivetrain makes, rather than the speed. This means that the driver can accelerate in a turn without changing
          * the radius of that turn. This control scheme defaults to arcade when forward is zero.
-         * @param forward speed to move forward. Takes an input from -127 to 127.
+         * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
          * @param turn speed to turn. Takes an input from -127 to 127.
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
          * of 1 disables the curve entirely.
          */
 
-        void curvature(int forward, int curvature, float cureGain = 1.0);
+        void curvature(int throttle, int curvature, float cureGain = 1.0);
     private:
         ChassisController_t lateralSettings;
         ChassisController_t angularSettings;

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -164,9 +164,38 @@ class Chassis {
          */
         void follow(const char* filePath, int timeout, float lookahead, bool reverse = false, float maxSpeed = 127,
                     bool log = false);
+        /**
+         * @brief Control the robot during the driver control period using the tank drive control scheme. In this
+         * control scheme one joystick axis controls one half of the robot, and another joystick axis controls another.
+         * @param left speed of the left side of the drivetrain. Takes an input from -127 to 127.
+         * @param right speed of the right side of the drivetrain. Takes an input from -127 to 127.
+         * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
+         * of 1 disables the curve entirely.
+         */
 
         void tank(int left, int right, float curveGain = 1.0);
+
+        /**
+         * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
+         * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis
+         * controls  the robot's turning
+         * @param forward speed to move forward. Takes an input from -127 to 127.
+         * @param turn speed to turn. Takes an input from -127 to 127.
+         * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
+         * of 1 disables the curve entirely.
+         */
         void arcade(int forward, int turn, float cureveGain = 1.0);
+        /**
+         * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
+         * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the
+         * drivetrain makes, rather than the speed. This means that the driver can accelerate in a turn without changing
+         * the radius of that turn. This control scheme defaults to arcade when forward is zero.
+         * @param forward speed to move forward. Takes an input from -127 to 127.
+         * @param turn speed to turn. Takes an input from -127 to 127.
+         * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
+         * of 1 disables the curve entirely.
+         */
+
         void curvature(int forward, int curvature, float cureGain = 1.0);
     private:
         ChassisController_t lateralSettings;

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -180,9 +180,9 @@ class Chassis {
          * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
          * @param turn speed to turn. Takes an input from -127 to 127.
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
-         * of 1 disables the curve entirely.
+         * of 0 disables the curve entirely.
          */
-        void arcade(int throttle, int turn, float curveGain = 1.0);
+        void arcade(int throttle, int turn, float curveGain = 0.0);
         /**
          * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
          * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the
@@ -191,9 +191,9 @@ class Chassis {
          * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
          * @param turn speed to turn. Takes an input from -127 to 127.
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
-         * of 1 disables the curve entirely.
+         * of 0 disables the curve entirely.
          */
-        void curvature(int throttle, int turn, float cureGain = 1.0);
+        void curvature(int throttle, int turn, float cureGain = 0.0);
     private:
         ChassisController_t lateralSettings;
         ChassisController_t angularSettings;

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -165,9 +165,9 @@ class Chassis {
         void follow(const char* filePath, int timeout, float lookahead, bool reverse = false, float maxSpeed = 127,
                     bool log = false);
 
-        void tank(int left, int right, float gain);
-        void arcade(int forward, int turn, float gain);
-        void curvature(int forward, int turn, float gain);
+        void tank(int left, int right, float curveGain = 1.0);
+        void arcade(int forward, int turn, float cureveGain = 1.0);
+        void curvature(int forward, int curvature, float cureGain = 1.0);
     private:
         ChassisController_t lateralSettings;
         ChassisController_t angularSettings;

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -164,6 +164,10 @@ class Chassis {
          */
         void follow(const char* filePath, int timeout, float lookahead, bool reverse = false, float maxSpeed = 127,
                     bool log = false);
+
+        void tank(int left, int right, float gain);
+        void arcade(int forward, int turn, float gain);
+        void curvature(int forward, int turn, float gain);
     private:
         ChassisController_t lateralSettings;
         ChassisController_t angularSettings;

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -1,0 +1,30 @@
+#include "lemlib/chassis/chassis.hpp"
+#include <algorithm>
+#include <math.h>
+
+namespace lemlib {
+
+double calcDriveCurve(double input, double scale) {
+    if (scale != 0) {
+        return (powf(2.718, -(scale / 10)) + powf(2.718, (fabs(input) - 127) / 10) * (1 - powf(2.718, -(scale / 10)))) *
+               input;
+    }
+    return input;
+}
+
+void Chassis::tank(int left, int right, float gain) {
+    drivetrain.leftMotors->move(calcDriveCurve(left, gain));
+    drivetrain.rightMotors->move(calcDriveCurve(right, gain));
+};
+
+void Chassis::arcade(int forward, int turn, float gain) {
+    int leftPower = calcDriveCurve(forward - turn, gain);
+    int rightPower = calcDriveCurve(forward + turn, gain);
+    drivetrain.leftMotors->move(leftPower);
+    drivetrain.rightMotors->move(rightPower);
+};
+
+void Chassis::curvature(int forward, int turn, float gain) {
+    // TODO: implement this
+};
+} // namespace lemlib

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -40,7 +40,7 @@ void Chassis::tank(int left, int right, float curveGain) {
  * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
  * @param turn speed to turn. Takes an input from -127 to 127.
  * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
- * of 1 disables the curve entirely.
+ * of 0 disables the curve entirely.
  */
 void Chassis::arcade(int throttle, int turn, float curveGain) {
     int leftPower = calcDriveCurve(throttle + turn, curveGain);
@@ -57,7 +57,7 @@ void Chassis::arcade(int throttle, int turn, float curveGain) {
  * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
  * @param turn speed to turn. Takes an input from -127 to 127.
  * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
- * of 1 disables the curve entirely.
+ * of 0 disables the curve entirely.
  */
 void Chassis::curvature(int throttle, int turn, float curveGain) {
     // If we're not moving forwards change to arcade drive

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -12,27 +12,30 @@ double calcDriveCurve(double input, double scale) {
     return input;
 }
 
-void Chassis::tank(int left, int right, float gain) {
-    drivetrain.leftMotors->move(calcDriveCurve(left, gain));
-    drivetrain.rightMotors->move(calcDriveCurve(right, gain));
+void Chassis::tank(int left, int right, float curveGain) {
+    drivetrain.leftMotors->move(calcDriveCurve(left, curveGain));
+    drivetrain.rightMotors->move(calcDriveCurve(right, curveGain));
 };
 
-void Chassis::arcade(int forward, int turn, float gain) {
-    int leftPower = calcDriveCurve(forward + turn, gain);
-    int rightPower = calcDriveCurve(forward - turn, gain);
+void Chassis::arcade(int forward, int turn, float curveGain) {
+    int leftPower = calcDriveCurve(forward + turn, curveGain);
+    int rightPower = calcDriveCurve(forward - turn, curveGain);
     drivetrain.leftMotors->move(leftPower);
     drivetrain.rightMotors->move(rightPower);
 };
 
-void Chassis::curvature(int forward, int curvature, float gain) {
+void Chassis::curvature(int forward, int curvature, float cureveGain) {
     // If we're not moving forwards change to arcade drive
     if (forward == 0) {
-        arcade(forward, curvature, gain);
+        arcade(forward, curvature, cureveGain);
         return;
     }
 
-    double leftPower = forward + std::abs(forward) * curvature;
-    double rightPower = forward - std::abs(forward) * curvature;
+    double leftPower = forward + (std::abs(forward) * curvature) / 127.0;
+    double rightPower = forward - (std::abs(forward) * curvature) / 127.0;
+
+    leftPower = calcDriveCurve(leftPower, cureveGain);
+    rightPower = calcDriveCurve(rightPower, cureveGain);
 
     drivetrain.leftMotors->move(leftPower);
     drivetrain.rightMotors->move(rightPower);

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -17,22 +17,22 @@ void Chassis::tank(int left, int right, float curveGain) {
     drivetrain.rightMotors->move(calcDriveCurve(right, curveGain));
 };
 
-void Chassis::arcade(int forward, int turn, float curveGain) {
-    int leftPower = calcDriveCurve(forward + turn, curveGain);
-    int rightPower = calcDriveCurve(forward - turn, curveGain);
+void Chassis::arcade(int throttle, int turn, float curveGain) {
+    int leftPower = calcDriveCurve(throttle + turn, curveGain);
+    int rightPower = calcDriveCurve(throttle - turn, curveGain);
     drivetrain.leftMotors->move(leftPower);
     drivetrain.rightMotors->move(rightPower);
 };
 
-void Chassis::curvature(int forward, int curvature, float cureveGain) {
+void Chassis::curvature(int throttle, int curvature, float cureveGain) {
     // If we're not moving forwards change to arcade drive
-    if (forward == 0) {
-        arcade(forward, curvature, cureveGain);
+    if (throttle == 0) {
+        arcade(throttle, curvature, cureveGain);
         return;
     }
 
-    double leftPower = forward + (std::abs(forward) * curvature) / 127.0;
-    double rightPower = forward - (std::abs(forward) * curvature) / 127.0;
+    double leftPower = throttle + (std::abs(throttle) * curvature) / 127.0;
+    double rightPower = throttle - (std::abs(throttle) * curvature) / 127.0;
 
     leftPower = calcDriveCurve(leftPower, cureveGain);
     rightPower = calcDriveCurve(rightPower, cureveGain);

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -59,15 +59,15 @@ void Chassis::arcade(int throttle, int turn, float curveGain) {
  * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
  * of 1 disables the curve entirely.
  */
-void Chassis::curvature(int throttle, int curvature, float cureveGain) {
+void Chassis::curvature(int throttle, int turn, float cureveGain) {
     // If we're not moving forwards change to arcade drive
     if (throttle == 0) {
-        arcade(throttle, curvature, cureveGain);
+        arcade(throttle, turn, cureveGain);
         return;
     }
 
-    double leftPower = throttle + (std::abs(throttle) * curvature) / 127.0;
-    double rightPower = throttle - (std::abs(throttle) * curvature) / 127.0;
+    double leftPower = throttle + (std::abs(throttle) * turn) / 127.0;
+    double rightPower = throttle - (std::abs(throttle) * turn) / 127.0;
 
     leftPower = calcDriveCurve(leftPower, cureveGain);
     rightPower = calcDriveCurve(rightPower, cureveGain);

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -59,18 +59,18 @@ void Chassis::arcade(int throttle, int turn, float curveGain) {
  * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
  * of 1 disables the curve entirely.
  */
-void Chassis::curvature(int throttle, int turn, float cureveGain) {
+void Chassis::curvature(int throttle, int turn, float curveGain) {
     // If we're not moving forwards change to arcade drive
     if (throttle == 0) {
-        arcade(throttle, turn, cureveGain);
+        arcade(throttle, turn, curveGain);
         return;
     }
 
     double leftPower = throttle + (std::abs(throttle) * turn) / 127.0;
     double rightPower = throttle - (std::abs(throttle) * turn) / 127.0;
 
-    leftPower = calcDriveCurve(leftPower, cureveGain);
-    rightPower = calcDriveCurve(rightPower, cureveGain);
+    leftPower = calcDriveCurve(leftPower, curveGain);
+    rightPower = calcDriveCurve(rightPower, curveGain);
 
     drivetrain.leftMotors->move(leftPower);
     drivetrain.rightMotors->move(rightPower);

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -18,13 +18,23 @@ void Chassis::tank(int left, int right, float gain) {
 };
 
 void Chassis::arcade(int forward, int turn, float gain) {
-    int leftPower = calcDriveCurve(forward - turn, gain);
-    int rightPower = calcDriveCurve(forward + turn, gain);
+    int leftPower = calcDriveCurve(forward + turn, gain);
+    int rightPower = calcDriveCurve(forward - turn, gain);
     drivetrain.leftMotors->move(leftPower);
     drivetrain.rightMotors->move(rightPower);
 };
 
-void Chassis::curvature(int forward, int turn, float gain) {
-    // TODO: implement this
+void Chassis::curvature(int forward, int curvature, float gain) {
+    // If we're not moving forwards change to arcade drive
+    if (forward == 0) {
+        arcade(forward, curvature, gain);
+        return;
+    }
+
+    double leftPower = forward + std::abs(forward) * curvature;
+    double rightPower = forward - std::abs(forward) * curvature;
+
+    drivetrain.leftMotors->move(leftPower);
+    drivetrain.rightMotors->move(rightPower);
 };
 } // namespace lemlib

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -4,6 +4,13 @@
 
 namespace lemlib {
 
+/**
+ * @brief  Modify the input with an exponential curve. If the input is 127, the function will always output 127, no
+ * matter the value of scale, likewise for -127. This curve was inspired by team 5225, the Pilons. A Desmos graph of
+ * this curve can be found here: https://www.desmos.com/calculator/rcfjjg83zx
+ * @param input value from -127 to 127
+ * @param scale how steep the curve should be.
+ */
 double calcDriveCurve(double input, double scale) {
     if (scale != 0) {
         return (powf(2.718, -(scale / 10)) + powf(2.718, (fabs(input) - 127) / 10) * (1 - powf(2.718, -(scale / 10)))) *
@@ -12,11 +19,29 @@ double calcDriveCurve(double input, double scale) {
     return input;
 }
 
+/**
+ * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
+ * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis
+ * controls  the robot's turning
+ * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
+ * @param turn speed to turn. Takes an input from -127 to 127.
+ * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
+ * of 1 disables the curve entirely.
+ */
 void Chassis::tank(int left, int right, float curveGain) {
     drivetrain.leftMotors->move(calcDriveCurve(left, curveGain));
     drivetrain.rightMotors->move(calcDriveCurve(right, curveGain));
 };
 
+/**
+ * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
+ * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis
+ * controls  the robot's turning
+ * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
+ * @param turn speed to turn. Takes an input from -127 to 127.
+ * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
+ * of 1 disables the curve entirely.
+ */
 void Chassis::arcade(int throttle, int turn, float curveGain) {
     int leftPower = calcDriveCurve(throttle + turn, curveGain);
     int rightPower = calcDriveCurve(throttle - turn, curveGain);
@@ -24,6 +49,16 @@ void Chassis::arcade(int throttle, int turn, float curveGain) {
     drivetrain.rightMotors->move(rightPower);
 };
 
+/**
+ * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
+ * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the
+ * drivetrain makes, rather than the speed. This means that the driver can accelerate in a turn without changing
+ * the radius of that turn. This control scheme defaults to arcade when forward is zero.
+ * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
+ * @param turn speed to turn. Takes an input from -127 to 127.
+ * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
+ * of 1 disables the curve entirely.
+ */
 void Chassis::curvature(int throttle, int curvature, float cureveGain) {
     // If we're not moving forwards change to arcade drive
     if (throttle == 0) {


### PR DESCRIPTION
#### Summary

This pull request adds methods to the chassis that allow the robot to controlled during opcontrol.

Currently three different move methods are planned:

- tank drive
- arcade drive
- curvature drive

All of these movement methods can be modified with a drive curve

#### Test Plan

Upload the code to a robot, and drive around.

#### Additional Notes

This PR is obviously incomplete, and requires some work. This is because I wanted to ask if I should add support for the following features that I've seen mentioned:
- deadzones
- negative inertia accumulator (mentioned [here](https://wiki.purduesigbots.com/software/competition-specific/curvature-cheesy-drive))
- active braking
