### PR TITLE
Fix incorrect drive curve default for tank drive

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -170,9 +170,9 @@ class Chassis {
          * @param left speed of the left side of the drivetrain. Takes an input from -127 to 127.
          * @param right speed of the right side of the drivetrain. Takes an input from -127 to 127.
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
-         * of 1 disables the curve entirely.
+         * of 0 disables the curve entirely.
          */
-        void tank(int left, int right, float curveGain = 1.0);
+        void tank(int left, int right, float curveGain = 0.0);
         /**
          * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
          * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -26,7 +26,7 @@ double calcDriveCurve(double input, double scale) {
  * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
  * @param turn speed to turn. Takes an input from -127 to 127.
  * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
- * of 1 disables the curve entirely.
+ * of 0 disables the curve entirely.
  */
 void Chassis::tank(int left, int right, float curveGain) {
     drivetrain.leftMotors->move(calcDriveCurve(left, curveGain));


### PR DESCRIPTION
#### Summary

During the implementation of #50 I forgot to change the default constant for the drive curve to 0. This PR fixes that, and changes the documentation to match.