### PR TITLE
[FEATURE] GPS sensor support

### DIFF
--- a/docs/tutorials/2_setting_up_the_chassis.md
+++ b/docs/tutorials/2_setting_up_the_chassis.md
@@ -71,7 +71,7 @@ Hold on, how far away from the tracking center is the tracking wheel? Turns out,
 
 Remember, vertical tracking wheels should have a negative offset if on the left of the tracking center, and horizontal tracking wheels should have a negative offset if in front of the tracking center.
 
-Now, we can put all the tracking wheels together into a struct with `lemlib::OdomSensors_t`. This struct will be passed to the LemLib chassis. Below is an example of how to do this:
+Now, we can put all the tracking wheels together into a struct with `lemlib::OdomSensors`. This struct will be passed to the LemLib chassis. Below is an example of how to do this:
 ```cpp
 // left tracking wheel encoder
 pros::ADIEncoder left_enc('A', 'B', true); // ports A and B, reversed
@@ -90,7 +90,7 @@ lemlib::TrackingWheel back_tracking_wheel(&back_enc, 2.75, 4.5); // 2.75" wheel 
 pros::Imu inertial_sensor(2); // port 2
 
 // odometry struct
-lemlib::OdomSensors_t sensors {
+lemlib::OdomSensors sensors {
 	&left_tracking_wheel, // vertical tracking wheel 1
 	&right_tracking_wheel, // vertical tracking wheel 2
 	&back_tracking_wheel, // horizontal tracking wheel 1
@@ -167,7 +167,7 @@ lemlib::TrackingWheel back_tracking_wheel(&back_enc, 2.75, 4.5); // 2.75" wheel 
 pros::Imu inertial_sensor(2); // port 2
 
 // odometry struct
-lemlib::OdomSensors_t sensors {
+lemlib::OdomSensors sensors {
 	&left_tracking_wheel, // vertical tracking wheel 1
 	&right_tracking_wheel, // vertical tracking wheel 2
 	&back_tracking_wheel, // horizontal tracking wheel 1

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -237,7 +237,6 @@ class Chassis {
         OdomSensors odomSensors;
         DriveCurveFunction_t driveCurve;
 
-        void calibrateGPS();
         void calibrateWheels();
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -13,6 +13,7 @@
 
 #include "pros/motors.hpp"
 #include "pros/imu.hpp"
+#include "pros/gps.hpp"
 #include <functional>
 #include "lemlib/asset.hpp"
 #include "lemlib/chassis/trackingWheel.hpp"
@@ -25,20 +26,34 @@ namespace lemlib {
  * The sensors are stored in a struct so that they can be easily passed to the chassis class
  * The variables are pointers so that they can be set to nullptr if they are not used
  * Otherwise the chassis class would have to have a constructor for each possible combination of sensors
- *
- * @param vertical1 pointer to the first vertical tracking wheel
- * @param vertical2 pointer to the second vertical tracking wheel
- * @param horizontal1 pointer to the first horizontal tracking wheel
- * @param horizontal2 pointer to the second horizontal tracking wheel
- * @param imu pointer to the IMU
  */
-typedef struct {
-        TrackingWheel* vertical1;
-        TrackingWheel* vertical2;
-        TrackingWheel* horizontal1;
-        TrackingWheel* horizontal2;
-        pros::Imu* imu;
-} OdomSensors_t;
+struct OdomSensors {
+        pros::Gps* gps = nullptr;
+        TrackingWheel* vertical1 = nullptr;
+        TrackingWheel* vertical2 = nullptr;
+        TrackingWheel* horizontal1 = nullptr;
+        TrackingWheel* horizontal2 = nullptr;
+        pros::Imu* imu = nullptr;
+
+        OdomSensors() = default;
+
+        /**
+         * Constructor for odometry with wheels.
+         * @param vertical1 pointer to the first vertical tracking wheel
+         * @param vertical2 pointer to the second vertical tracking wheel
+         * @param horizontal1 pointer to the first horizontal tracking wheel
+         * @param horizontal2 pointer to the second horizontal tracking wheel
+         * @param imu pointer to the IMU
+         */
+        OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
+                    TrackingWheel* horizontal2, pros::Imu* imu);
+
+        /**
+         * Constructor for odometry with a gps.
+         * @param gps pointer to the GPS
+         */
+        OdomSensors(pros::Gps* gps);
+};
 
 /**
  * @brief Struct containing constants for a chassis controller
@@ -118,7 +133,7 @@ class Chassis {
          * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
          */
         Chassis(Drivetrain_t drivetrain, ChassisController_t lateralSettings, ChassisController_t angularSettings,
-                OdomSensors_t sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
+                OdomSensors sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
         /**
          * @brief Calibrate the chassis sensors
          *
@@ -219,7 +234,10 @@ class Chassis {
         ChassisController_t lateralSettings;
         ChassisController_t angularSettings;
         Drivetrain_t drivetrain;
-        OdomSensors_t odomSensors;
+        OdomSensors odomSensors;
         DriveCurveFunction_t driveCurve;
+
+        void calibrateGPS();
+        void calibrateWheels();
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/odom.hpp
+++ b/include/lemlib/chassis/odom.hpp
@@ -20,9 +20,8 @@ namespace lemlib {
  * @brief Set the sensors to be used for odometry
  *
  * @param sensors the sensors to be used
- * @param drivetrain drivetrain to be used
  */
-void setSensors(lemlib::OdomSensors_t sensors, lemlib::Drivetrain_t drivetrain);
+void setSensors(lemlib::OdomSensors sensors);
 /**
  * @brief Get the pose of the robot
  *

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -18,6 +18,30 @@
 #include "trackingWheel.hpp"
 
 /**
+ * Constructor for odometry with wheels.
+ * @param vertical1 pointer to the first vertical tracking wheel
+ * @param vertical2 pointer to the second vertical tracking wheel
+ * @param horizontal1 pointer to the first horizontal tracking wheel
+ * @param horizontal2 pointer to the second horizontal tracking wheel
+ * @param imu pointer to the IMU
+ */
+lemlib::OdomSensors::OdomSensors(lemlib::TrackingWheel* vertical1, lemlib::TrackingWheel* vertical2,
+                                 lemlib::TrackingWheel* horizontal1, lemlib::TrackingWheel* horizontal2,
+                                 pros::Imu* imu) {
+    this->vertical1 = vertical1;
+    this->vertical2 = vertical2;
+    this->horizontal1 = horizontal1;
+    this->horizontal1 = horizontal1;
+    this->imu = imu;
+}
+
+/**
+ * Constructor for odometry with a gps.
+ * @param gps pointer to the GPS
+ */
+lemlib::OdomSensors::OdomSensors(pros::Gps* gps) { this->gps = gps; }
+
+/**
  * @brief Construct a new Chassis
  *
  * @param drivetrain drivetrain to be used for the chassis
@@ -27,7 +51,7 @@
  * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
  */
 lemlib::Chassis::Chassis(Drivetrain_t drivetrain, ChassisController_t lateralSettings,
-                         ChassisController_t angularSettings, OdomSensors_t sensors, DriveCurveFunction_t driveCurve) {
+                         ChassisController_t angularSettings, OdomSensors sensors, DriveCurveFunction_t driveCurve) {
     this->drivetrain = drivetrain;
     this->lateralSettings = lateralSettings;
     this->angularSettings = angularSettings;
@@ -35,11 +59,9 @@ lemlib::Chassis::Chassis(Drivetrain_t drivetrain, ChassisController_t lateralSet
     this->driveCurve = driveCurve;
 }
 
-/**
- * @brief Calibrate the chassis sensors
- *
- */
-void lemlib::Chassis::calibrate() {
+void lemlib::Chassis::calibrateGPS() { odomSensors.gps->set_position(0, 0, 0); }
+
+void lemlib::Chassis::calibrateWheels() {
     // calibrate the imu if it exists
     if (odomSensors.imu != nullptr) {
         odomSensors.imu->reset(true);
@@ -61,8 +83,24 @@ void lemlib::Chassis::calibrate() {
     odomSensors.vertical2->reset();
     if (odomSensors.horizontal1 != nullptr) odomSensors.horizontal1->reset();
     if (odomSensors.horizontal2 != nullptr) odomSensors.horizontal2->reset();
-    lemlib::setSensors(odomSensors, drivetrain);
+    lemlib::setSensors(odomSensors);
     lemlib::init();
+}
+
+/**
+ * @brief Calibrate the chassis sensors
+ *
+ */
+void lemlib::Chassis::calibrate() {
+    if (odomSensors.gps == nullptr) {
+        calibrateWheels();
+    } else {
+        calibrateGPS();
+    }
+
+    lemlib::setSensors(odomSensors);
+    lemlib::init();
+
     // rumble to controller to indicate success
     pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, ".");
 }

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -90,9 +90,7 @@ void lemlib::Chassis::calibrateWheels() {
  *
  */
 void lemlib::Chassis::calibrate() {
-    if (odomSensors.gps == nullptr) {
-        calibrateWheels();
-    }
+    if (odomSensors.gps == nullptr) { calibrateWheels(); }
 
     lemlib::setSensors(odomSensors);
     lemlib::init();

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -59,8 +59,6 @@ lemlib::Chassis::Chassis(Drivetrain_t drivetrain, ChassisController_t lateralSet
     this->driveCurve = driveCurve;
 }
 
-void lemlib::Chassis::calibrateGPS() { odomSensors.gps->set_position(0, 0, 0); }
-
 void lemlib::Chassis::calibrateWheels() {
     // calibrate the imu if it exists
     if (odomSensors.imu != nullptr) {
@@ -94,8 +92,6 @@ void lemlib::Chassis::calibrateWheels() {
 void lemlib::Chassis::calibrate() {
     if (odomSensors.gps == nullptr) {
         calibrateWheels();
-    } else {
-        calibrateGPS();
     }
 
     lemlib::setSensors(odomSensors);

--- a/src/lemlib/chassis/odom.cpp
+++ b/src/lemlib/chassis/odom.cpp
@@ -15,6 +15,8 @@
 // http://thepilons.ca/wp-content/uploads/2018/10/Tracking.pdf
 
 #include <math.h>
+#include "lemlib/logger.hpp"
+#include "lemlib/pose.hpp"
 #include "pros/rtos.hpp"
 #include "lemlib/util.hpp"
 #include "lemlib/chassis/odom.hpp"
@@ -25,8 +27,8 @@
 pros::Task* trackingTask = nullptr;
 
 // global variables
-lemlib::OdomSensors_t odomSensors; // the sensors to be used for odometry
-lemlib::Drivetrain_t drive; // the drivetrain to be used for odometry
+lemlib::OdomSensors odomSensors; // the sensors to be used for odometry
+// lemlib::Drivetrain_t drive; // the drivetrain to be used for odometry
 lemlib::Pose odomPose(0, 0, 0); // the pose of the robot
 
 float prevVertical = 0;
@@ -37,16 +39,16 @@ float prevHorizontal1 = 0;
 float prevHorizontal2 = 0;
 float prevImu = 0;
 
+float prevGpsX = 0;
+float prevGpsY = 0;
+float prevGpsRotation = 0;
+
 /**
  * @brief Set the sensors to be used for odometry
  *
  * @param sensors the sensors to be used
- * @param drivetrain drivetrain to be used
  */
-void lemlib::setSensors(lemlib::OdomSensors_t sensors, lemlib::Drivetrain_t drivetrain) {
-    odomSensors = sensors;
-    drive = drivetrain;
-}
+void lemlib::setSensors(lemlib::OdomSensors sensors) { odomSensors = sensors; }
 
 /**
  * @brief Get the pose of the robot
@@ -55,8 +57,7 @@ void lemlib::setSensors(lemlib::OdomSensors_t sensors, lemlib::Drivetrain_t driv
  * @return Pose
  */
 lemlib::Pose lemlib::getPose(bool radians) {
-    if (radians) return odomPose;
-    else return lemlib::Pose(odomPose.x, odomPose.y, radToDeg(odomPose.theta));
+    return lemlib::Pose(odomPose.x, odomPose.y, radians ? odomPose.theta : degToRad(odomPose.theta));
 }
 
 /**
@@ -66,17 +67,33 @@ lemlib::Pose lemlib::getPose(bool radians) {
  * @param radians true if theta is in radians, false if in degrees. False by default
  */
 void lemlib::setPose(lemlib::Pose pose, bool radians) {
-    if (radians) odomPose = pose;
-    else odomPose = lemlib::Pose(pose.x, pose.y, degToRad(pose.theta));
+    odomPose = lemlib::Pose(pose.x, pose.y, radians ? pose.theta : degToRad(pose.theta));
 }
 
-/**
- * @brief Update the pose of the robot
- *
- */
-void lemlib::update() {
-    // TODO: add particle filter
-    // get the current sensor values
+static void updateGPS() {
+    pros::c::gps_status_s_t status = odomSensors.gps->get_status();
+
+    float gpsRawX = status.x;
+    float gpsRawY = status.y;
+    float gpsRawRotation = lemlib::degToRad(odomSensors.gps->get_rotation());
+
+    // calculate the change in sensor values
+    float deltaGpsX = gpsRawX - prevGpsX;
+    float deltaGpsY = gpsRawY - prevGpsY;
+    float deltaGpsRotation = gpsRawRotation - prevGpsRotation;
+
+    // update the previous sensor values
+    prevGpsX = gpsRawX;
+    prevGpsY = gpsRawY;
+    prevGpsRotation = gpsRawRotation;
+
+    // update the pose
+    odomPose.x += deltaGpsX;
+    odomPose.y += deltaGpsY;
+    odomPose.theta += deltaGpsRotation;
+}
+
+static void updateWheels() {
     float vertical1Raw = 0;
     float vertical2Raw = 0;
     float horizontal1Raw = 0;
@@ -86,7 +103,7 @@ void lemlib::update() {
     if (odomSensors.vertical2 != nullptr) vertical2Raw = odomSensors.vertical2->getDistanceTraveled();
     if (odomSensors.horizontal1 != nullptr) horizontal1Raw = odomSensors.horizontal1->getDistanceTraveled();
     if (odomSensors.horizontal2 != nullptr) horizontal2Raw = odomSensors.horizontal2->getDistanceTraveled();
-    if (odomSensors.imu != nullptr) imuRaw = degToRad(odomSensors.imu->get_rotation());
+    if (odomSensors.imu != nullptr) imuRaw = lemlib::degToRad(odomSensors.imu->get_rotation());
 
     // calculate the change in sensor values
     float deltaVertical1 = vertical1Raw - prevVertical1;
@@ -169,6 +186,18 @@ void lemlib::update() {
     odomPose.x += localX * -cos(avgHeading);
     odomPose.y += localX * sin(avgHeading);
     odomPose.theta = heading;
+}
+
+/**
+ * @brief Update the pose of the robot
+ *
+ */
+void lemlib::update() {
+    if (odomSensors.gps == nullptr) {
+        updateWheels();
+    } else {
+        updateGPS();
+    }
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ lemlib::ChassisController_t lateralController {10, 30, 1, 100, 3, 500, 20};
 lemlib::ChassisController_t angularController {2, 10, 1, 100, 3, 500, 20};
 
 // sensors for odometry
-lemlib::OdomSensors_t sensors {nullptr, nullptr, &horizontal, nullptr, &imu};
+lemlib::OdomSensors sensors {nullptr, nullptr, &horizontal, nullptr, &imu};
 
 lemlib::Chassis chassis(drivetrain, lateralController, angularController, sensors);
 


### PR DESCRIPTION
#### Summary
This PR adds support for the GPS sensor in the odometry code.

#### Motivation
For some users, it might not be feasible to use tracking wheels. Adding GPS sensor support allows users to track the pose of their robot without any tracking wheels.

#### Test Plan
The PR has not been tested.
