### PR TITLE
Use constants for wheel diameters instead of an enum.

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -73,14 +73,14 @@ typedef struct {
  * @param leftMotors pointer to the left motors
  * @param rightMotors pointer to the right motors
  * @param trackWidth the track width of the robot
- * @param wheelType the type of omni-wheel used for the drivetrain
+ * @param wheelDiameter the diameter of the wheel used on the drivetrain
  * @param rpm the rpm of the wheels
  */
 typedef struct {
         pros::Motor_Group* leftMotors;
         pros::Motor_Group* rightMotors;
         float trackWidth;
-        Omniwheel wheelType;
+        double wheelDiameter;
         float rpm;
 } Drivetrain_t;
 

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -80,7 +80,7 @@ typedef struct {
         pros::Motor_Group* leftMotors;
         pros::Motor_Group* rightMotors;
         float trackWidth;
-        double wheelDiameter;
+        float wheelDiameter;
         float rpm;
 } Drivetrain_t;
 

--- a/include/lemlib/chassis/trackingWheel.hpp
+++ b/include/lemlib/chassis/trackingWheel.hpp
@@ -18,26 +18,22 @@
 namespace lemlib {
 
 /**
- * @brief An omni-wheel enumeration.
- *
- * @note These enumerations are equal to the virtual diameter of a wheel which would have a circumference equal to the
- * real loop length of the given wheel in thous.
- *
+ * @brief A namespace representing the size of omniwheels.
  */
-enum class Omniwheel {
-    NEW_275 = 2750,
-    OLD_275 = 2750,
-    NEW_275_HALF = 2744,
-    OLD_275_HALF = 2740,
-    NEW_325 = 3250,
-    OLD_325 = 3250,
-    NEW_325_HALF = 3246,
-    OLD_325_HALF = 3246,
-    NEW_4 = 4000,
-    OLD_4 = 4180,
-    NEW_4_HALF = 3995,
-    OLD_4_HALF = 4175
-};
+namespace Omniwheel {
+constexpr float NEW_275 = 2.75;
+constexpr float OLD_275 = 2.75;
+constexpr float NEW_275_HALF = 2.744;
+constexpr float OLD_275_HALF = 2.74;
+constexpr float NEW_325 = 3.25;
+constexpr float OLD_325 = 3.25;
+constexpr float NEW_325_HALF = 3.246;
+constexpr float OLD_325_HALF = 3.246;
+constexpr float NEW_4 = 4;
+constexpr float OLD_4 = 4.18;
+constexpr float NEW_4_HALF = 3.995;
+constexpr float OLD_4_HALF = 4.175;
+} // namespace Omniwheel
 
 class TrackingWheel {
     public:
@@ -45,29 +41,29 @@ class TrackingWheel {
          * @brief Create a new tracking wheel
          *
          * @param encoder the optical shaft encoder to use
-         * @param wheel the omni-wheel to use
+         * @param wheelDiameter the diameter of the wheel
          * @param distance distance between the tracking wheel and the center of rotation in inches
          * @param gearRatio gear ratio of the tracking wheel, defaults to 1
          */
-        TrackingWheel(pros::ADIEncoder* encoder, Omniwheel wheel, float distance, float gearRatio = 1);
+        TrackingWheel(pros::ADIEncoder* encoder, float wheelDiameter, float distance, float gearRatio = 1);
         /**
          * @brief Create a new tracking wheel
          *
          * @param encoder the v5 rotation sensor to use
-         * @param wheel the omni-wheel to use
+         * @param wheelDiameter the diameter of the wheel
          * @param distance distance between the tracking wheel and the center of rotation in inches
          * @param gearRatio gear ratio of the tracking wheel, defaults to 1
          */
-        TrackingWheel(pros::Rotation* encoder, Omniwheel wheel, float distance, float gearRatio = 1);
+        TrackingWheel(pros::Rotation* encoder, float wheelDiameter, float distance, float gearRatio = 1);
         /**
          * @brief Create a new tracking wheel
          *
          * @param motors the motor group to use
-         * @param wheel the omni-wheel to use
+         * @param wheelDiameter the diameter of the wheel
          * @param distance half the track width of the drivetrain in inches
          * @param rpm theoretical maximum rpm of the drivetrain wheels
          */
-        TrackingWheel(pros::Motor_Group* motors, Omniwheel wheel, float distance, float rpm);
+        TrackingWheel(pros::Motor_Group* motors, float wheelDiameter, float distance, float rpm);
         /**
          * @brief Reset the tracking wheel position to 0
          *

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -52,10 +52,10 @@ void lemlib::Chassis::calibrate() {
     }
     // initialize odom
     if (odomSensors.vertical1 == nullptr)
-        odomSensors.vertical1 = new lemlib::TrackingWheel(drivetrain.leftMotors, drivetrain.wheelType,
+        odomSensors.vertical1 = new lemlib::TrackingWheel(drivetrain.leftMotors, drivetrain.wheelDiameter,
                                                           -(drivetrain.trackWidth / 2), drivetrain.rpm);
     if (odomSensors.vertical2 == nullptr)
-        odomSensors.vertical2 = new lemlib::TrackingWheel(drivetrain.rightMotors, drivetrain.wheelType,
+        odomSensors.vertical2 = new lemlib::TrackingWheel(drivetrain.rightMotors, drivetrain.wheelDiameter,
                                                           drivetrain.trackWidth / 2, drivetrain.rpm);
     odomSensors.vertical1->reset();
     odomSensors.vertical2->reset();

--- a/src/lemlib/chassis/trackingWheel.cpp
+++ b/src/lemlib/chassis/trackingWheel.cpp
@@ -18,13 +18,13 @@
  * @brief Create a new tracking wheel
  *
  * @param encoder the optical shaft encoder to use
- * @param wheel the omni-wheel to use
+ * @param wheelDiameter the diameter of the wheel
  * @param distance distance between the tracking wheel and the center of rotation in inches
  * @param gearRatio gear ratio of the tracking wheel, defaults to 1
  */
-lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, Omniwheel wheel, float distance, float gearRatio) {
+lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, float wheelDiameter, float distance, float gearRatio) {
     this->encoder = encoder;
-    this->diameter = (double)wheel / 1000.0;
+    this->diameter = wheelDiameter;
     this->distance = distance;
     this->gearRatio = gearRatio;
 }
@@ -33,13 +33,13 @@ lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, Omniwheel wheel,
  * @brief Create a new tracking wheel
  *
  * @param encoder the v5 rotation sensor to use
- * @param wheel the omni-wheel to use
+ * @param wheelDiameter the diameter of the wheel
  * @param distance distance between the tracking wheel and the center of rotation in inches
  * @param gearRatio gear ratio of the tracking wheel, defaults to 1
  */
-lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, Omniwheel wheel, float distance, float gearRatio) {
+lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, float wheelDiameter, float distance, float gearRatio) {
     this->rotation = encoder;
-    this->diameter = (double)wheel / 1000.0;
+    this->diameter = wheelDiameter;
     this->distance = distance;
     this->gearRatio = gearRatio;
 }
@@ -48,14 +48,14 @@ lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, Omniwheel wheel, f
  * @brief Create a new tracking wheel
  *
  * @param motors the motor group to use
- * @param wheel the omni-wheel to use
+ * @param wheelDiameter the diameter of the wheel
  * @param distance half the track width of the drivetrain in inches
  * @param rpm theoretical maximum rpm of the drivetrain wheels
  */
-lemlib::TrackingWheel::TrackingWheel(pros::Motor_Group* motors, Omniwheel wheel, float distance, float rpm) {
+lemlib::TrackingWheel::TrackingWheel(pros::Motor_Group* motors, float wheelDiameter, float distance, float rpm) {
     this->motors = motors;
     this->motors->set_encoder_units(pros::E_MOTOR_ENCODER_ROTATIONS);
-    this->diameter = (double)wheel / 1000.0;
+    this->diameter = wheelDiameter;
     this->distance = distance;
     this->rpm = rpm;
 }


### PR DESCRIPTION
#### Summary
Switch to using constants for wheel diameters instead of an enum.

#### Motivation
Using enums restricts the user and isn't the right approach in this case. We should define the constants for the user to use, but not restrict them from using other wheel diameters, too. 

#### Test Plan
This PR has not been tested.
