### PR TITLE
Optimization to the pure pursuit algorithm

### DIFF
--- a/src/lemlib/chassis/pursuit.cpp
+++ b/src/lemlib/chassis/pursuit.cpp
@@ -156,7 +156,7 @@ lemlib::Pose lookaheadPoint(lemlib::Pose lastLookahead, lemlib::Pose pose, std::
         lemlib::Pose lastPathPose = path.at(i - 1);
         lemlib::Pose currentPathPose = path.at(i);
 
-        double t = circleIntersect(lastPathPose, currentPathPose, pose, lookaheadDist);
+        float t = circleIntersect(lastPathPose, currentPathPose, pose, lookaheadDist);
 
         if (t != -1) {
             lemlib::Pose lookahead = lastPathPose.lerp(currentPathPose, t);


### PR DESCRIPTION
#### Summary
This PR optimizes the calculations needed to find the lookahead point for the pure pursuit algorithm.

#### Motivation
Paths can often get really long, and having to search through all of the line segments that make up the path can be computationally expensive, for a platform like v5. Instead of doing this, the algorithm I implemented searches the path in reverse, and when we find the intersection, it's gaurunteed to be the farthest intersection along the path, and we can just immeadeately stop searching.

#### Test Plan
This PR was not tested.

#### Additional Notes
i already opened a pr like this but with my high iq i closed it up and i can't figure out how to open it back up :crying: