### PR TITLE
Add calibrateIMU parameter to chassis calibration method

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -124,10 +124,11 @@ class Chassis {
         Chassis(Drivetrain_t drivetrain, ChassisController_t lateralSettings, ChassisController_t angularSettings,
                 OdomSensors_t sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
         /**
-         * @brief Calibrate the chassis sensors
-         *
-         */
-        void calibrate();
+        * @brief Calibrate the chassis sensors
+        *
+        * @param calibrateIMU whether the IMU should be calibrated. true by default
+        */
+        void calibrate(bool calibrateIMU = true);
         /**
          * @brief Set the pose of the chassis
          *

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -124,10 +124,10 @@ class Chassis {
         Chassis(Drivetrain_t drivetrain, ChassisController_t lateralSettings, ChassisController_t angularSettings,
                 OdomSensors_t sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
         /**
-        * @brief Calibrate the chassis sensors
-        *
-        * @param calibrateIMU whether the IMU should be calibrated. true by default
-        */
+         * @brief Calibrate the chassis sensors
+         *
+         * @param calibrateIMU whether the IMU should be calibrated. true by default
+         */
         void calibrate(bool calibrateIMU = true);
         /**
          * @brief Set the pose of the chassis

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -39,10 +39,11 @@ lemlib::Chassis::Chassis(Drivetrain_t drivetrain, ChassisController_t lateralSet
 /**
  * @brief Calibrate the chassis sensors
  *
+ * @param calibrateIMU whether the IMU should be calibrated. true by default
  */
-void lemlib::Chassis::calibrate() {
-    // calibrate the imu if it exists
-    if (odomSensors.imu != nullptr) {
+void lemlib::Chassis::calibrate(bool calibrateIMU) {
+    // calibrate the IMU if it exists and the user doesn't specify otherwise
+    if (odomSensors.imu != nullptr && calibrateIMU) {
         int attempt = 1;
         // calibrate inertial, and if calibration fails, then repeat 5 times or until successful
         while (odomSensors.imu->reset(true) != 1 && (errno == PROS_ERR || errno == ENODEV || errno == ENXIO) &&


### PR DESCRIPTION
#### Summary
This PR allows the user to instruct LemLib to skip IMU calibration in the `lemlib::Chassis::calibrate` method.

#### Motivation
229V's autonomous skills program uses both EZ-Template and LemLib. As such, both libraries do not need to calibrate the IMU. While LemLib is still not complete in the features it offers (though it is getting really close), a change like this is beneficial to those using multiple motion libraries.

#### Test Plan
- [x] Tested on a physical robot

#### Additional Notes
this pr is longer than the code that was changed 💀
