### PR TITLE
Change stdout logger structure

### DIFF
--- a/include/lemlib/logger/infoSink.hpp
+++ b/include/lemlib/logger/infoSink.hpp
@@ -30,7 +30,7 @@ class InfoSink : public BaseSink {
         InfoSink();
     private:
         /**
-         * @brief Sends log message to the Stdout buffer.
+         * @brief Log the given message
          *
          * @param message
          */

--- a/include/lemlib/logger/stdout.hpp
+++ b/include/lemlib/logger/stdout.hpp
@@ -13,21 +13,22 @@ namespace lemlib {
  * rate, no matter how many different threads are trying to use the logger. This is a concern  because not every type of
  * connection to the brain has the same amount of bandwidth.
  */
-class Stdout : protected Buffer {
+class BufferedStdout : public Buffer {
     public:
-        Stdout(const Stdout&) = delete;
-        Stdout operator=(const Stdout&) = delete;
+        BufferedStdout();
 
         /**
          * @brief Print a string (thread-safe).
          *
          */
-        template <typename... T> static void print(fmt::format_string<T...> format, T&&... args) {
-            static Stdout theStdout;
-            theStdout.pushToBuffer(fmt::format(format, std::forward<T>(args)...));
+        template <typename... T> void print(fmt::format_string<T...> format, T&&... args) {
+            pushToBuffer(fmt::format(format, std::forward<T>(args)...));
         }
-    private:
-        Stdout();
-        ~Stdout() = default;
 };
+
+/**
+ * @brief Get the buffered stdout.
+ *
+ */
+BufferedStdout& bufferedStdout();
 } // namespace lemlib

--- a/src/lemlib/logger/infoSink.cpp
+++ b/src/lemlib/logger/infoSink.cpp
@@ -17,6 +17,6 @@ static std::string getColor(Level level) {
 }
 
 void InfoSink::sendMessage(const Message& message) {
-    Stdout::print("{}{}\033[0m\n", getColor(message.level), message.message);
+    bufferedStdout().print("{}{}\033[0m\n", getColor(message.level), message.message);
 }
 } // namespace lemlib

--- a/src/lemlib/logger/stdout.cpp
+++ b/src/lemlib/logger/stdout.cpp
@@ -4,5 +4,12 @@
 #include "lemlib/logger/stdout.hpp"
 
 namespace lemlib {
-Stdout::Stdout() : Buffer([](const std::string& text) { std::cout << text << std::flush; }) { setRate(50); }
+BufferedStdout::BufferedStdout() : Buffer([](const std::string& text) { std::cout << text << std::flush; }) {
+    setRate(50);
+}
+
+BufferedStdout& bufferedStdout() {
+    static BufferedStdout bufferedStdout;
+    return bufferedStdout;
+}
 } // namespace lemlib

--- a/src/lemlib/logger/telemetrySink.cpp
+++ b/src/lemlib/logger/telemetrySink.cpp
@@ -6,5 +6,7 @@
 namespace lemlib {
 TelemetrySink::TelemetrySink() { setFormat("TELE_{level}:{message}TELE_END"); }
 
-void TelemetrySink::sendMessage(const Message& message) { Stdout::print("\033[s{}\033[u\033[0J", message.message); }
+void TelemetrySink::sendMessage(const Message& message) {
+    bufferedStdout().print("\033[s{}\033[u\033[0J", message.message);
+}
 } // namespace lemlib

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include "main.h"
 #include "lemlib/api.hpp"
+#include "lemlib/logger/stdout.hpp"
 
 // drive motors
 pros::Motor lF(-9, pros::E_MOTOR_GEARSET_06); // left front motor. port 9, reversed
@@ -42,6 +43,10 @@ lemlib::Chassis chassis(drivetrain, lateralController, angularController, sensor
 void initialize() {
     pros::lcd::initialize();
     chassis.calibrate(); // calibrate sensors
+
+    // the default rate is 50. however, if you need to change the rate, you
+    // can do the following.
+    // lemlib::bufferedStdout().setRate(...);
 
     // for more information on how the formatting for the loggers
     // works, refer to the fmtlib docs


### PR DESCRIPTION
#### Summary
Change the stdout logger structure.

#### Motivation
It's important that users are actually able to do stuff with the underlying buffer.

#### Additional Notes
bruh so many logger prs