### PR TITLE
:memo: Correct the release link in the getting started tutorial

### DIFF
--- a/docs/tutorials/1_getting_started.md
+++ b/docs/tutorials/1_getting_started.md
@@ -25,7 +25,7 @@ Now we can install LemLib!
 ## Installation - LemLib Template
 
 
-To install LemLib, you need to download the `LemLib@0.4.7.zip` from [here](https://github.com/SizzinSeal/LemLib/releases/latest/). Next you need to drag the zip file into your pros project folder. Once you have done that, open the pros integrated terminal by selecting the pros icon on the left, and clicking `Integrated Terminal`.
+To install LemLib, you need to download the `LemLib@0.4.7.zip` from [here](https://github.com/LemLib/LemLib/releases/tag/v0.4.7). Next you need to drag the zip file into your pros project folder. Once you have done that, open the pros integrated terminal by selecting the pros icon on the left, and clicking `Integrated Terminal`.
 <br>
 <img src="./assets/1_getting_started/integrated_terminal.png" height=800 style="display: block;margin-left: auto;margin-right: auto;">
 


### PR DESCRIPTION
#### Summary
I corrected the link in the getting started tutorial to point to the correct release on the correct repository.

(This time on the stable branch)
