### PR TITLE
Clean up utils

### DIFF
--- a/include/lemlib/util.hpp
+++ b/include/lemlib/util.hpp
@@ -33,7 +33,7 @@ float slew(float target, float current, float maxChange);
  * @param rad radians
  * @return float degrees
  */
-constexpr float lemlib::radToDeg(float rad) {
+constexpr float radToDeg(float rad) {
 	return rad * 180 / M_PI;
 }
 
@@ -43,7 +43,7 @@ constexpr float lemlib::radToDeg(float rad) {
  * @param deg degrees
  * @return float radians
  */
-constexpr float lemlib::degToRad(float deg) {
+constexpr float degToRad(float deg) {
 	return deg * M_PI / 180;
 }
 

--- a/include/lemlib/util.hpp
+++ b/include/lemlib/util.hpp
@@ -59,10 +59,7 @@ float angleError(float angle1, float angle2, bool radians = false);
  * @param x the number to get the sign of
  * @return int - -1 if negative, 1 if positive
  */
-template <typename T>
-constexpr T sgn(T value) {
-	return value < 0 ? -1 : 1;
-}
+template <typename T> constexpr T sgn(T value) { return value < 0 ? -1 : 1; }
 
 /**
  * @brief Return the average of a vector of numbers

--- a/include/lemlib/util.hpp
+++ b/include/lemlib/util.hpp
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <vector>
+#include <math.h>
 #include "lemlib/pose.hpp"
 
 namespace lemlib {
@@ -32,7 +33,9 @@ float slew(float target, float current, float maxChange);
  * @param rad radians
  * @return float degrees
  */
-float radToDeg(float rad);
+constexpr float lemlib::degToRad(float deg) {
+	return deg * 180 / M_PI;
+}
 
 /**
  * @brief Convert degrees to radians
@@ -40,7 +43,9 @@ float radToDeg(float rad);
  * @param deg degrees
  * @return float radians
  */
-float degToRad(float deg);
+constexpr float lemlib::degToRad(float deg) {
+	return deg * M_PI / 180;
+}
 
 /**
  * @brief Calculate the error between 2 angles. Useful when calculating the error between 2 headings
@@ -58,7 +63,10 @@ float angleError(float angle1, float angle2, bool radians = false);
  * @param x the number to get the sign of
  * @return int - -1 if negative, 1 if positive
  */
-int sgn(float x);
+template <typename T>
+constexpr T sgn(T value) {
+	return value < 0 ? -1 : 1;
+}
 
 /**
  * @brief Return the average of a vector of numbers

--- a/include/lemlib/util.hpp
+++ b/include/lemlib/util.hpp
@@ -33,8 +33,8 @@ float slew(float target, float current, float maxChange);
  * @param rad radians
  * @return float degrees
  */
-constexpr float lemlib::degToRad(float deg) {
-	return deg * 180 / M_PI;
+constexpr float lemlib::radToDeg(float rad) {
+	return rad * 180 / M_PI;
 }
 
 /**

--- a/include/lemlib/util.hpp
+++ b/include/lemlib/util.hpp
@@ -33,9 +33,7 @@ float slew(float target, float current, float maxChange);
  * @param rad radians
  * @return float degrees
  */
-constexpr float radToDeg(float rad) {
-	return rad * 180 / M_PI;
-}
+constexpr float radToDeg(float rad) { return rad * 180 / M_PI; }
 
 /**
  * @brief Convert degrees to radians
@@ -43,9 +41,7 @@ constexpr float radToDeg(float rad) {
  * @param deg degrees
  * @return float radians
  */
-constexpr float degToRad(float deg) {
-	return deg * M_PI / 180;
-}
+constexpr float degToRad(float deg) { return deg * M_PI / 180; }
 
 /**
  * @brief Calculate the error between 2 angles. Useful when calculating the error between 2 headings

--- a/src/lemlib/util.cpp
+++ b/src/lemlib/util.cpp
@@ -30,22 +30,6 @@ float lemlib::slew(float target, float current, float maxChange) {
 }
 
 /**
- * @brief Convert radians to degrees
- *
- * @param rad radians
- * @return float degrees
- */
-float lemlib::radToDeg(float rad) { return rad * 180 / M_PI; }
-
-/**
- * @brief Convert degrees to radians
- *
- * @param deg degrees
- * @return float radians
- */
-float lemlib::degToRad(float deg) { return deg * M_PI / 180; }
-
-/**
  * @brief Calculate the error between 2 angles. Useful when calculating the error between 2 headings
  *
  * @param angle1
@@ -54,25 +38,7 @@ float lemlib::degToRad(float deg) { return deg * M_PI / 180; }
  * @return float wrapped angle
  */
 float lemlib::angleError(float angle1, float angle2, bool radians) {
-    float max = radians ? 2 * M_PI : 360;
-    float half = radians ? M_PI : 180;
-    angle1 = fmod(angle1, max);
-    angle2 = fmod(angle2, max);
-    float error = angle1 - angle2;
-    if (error > half) error -= max;
-    else if (error < -half) error += max;
-    return error;
-}
-
-/**
- * @brief Return the sign of a number
- *
- * @param x the number to get the sign of
- * @return int - -1 if negative, 1 if positive
- */
-int lemlib::sgn(float x) {
-    if (x < 0) return -1;
-    else return 1;
+    return std::remainder(angle1 - angle2, radians ? 2_* M_PI : 360);
 }
 
 /**

--- a/src/lemlib/util.cpp
+++ b/src/lemlib/util.cpp
@@ -38,7 +38,7 @@ float lemlib::slew(float target, float current, float maxChange) {
  * @return float wrapped angle
  */
 float lemlib::angleError(float angle1, float angle2, bool radians) {
-    return std::remainder(angle1 - angle2, radians ? 2_* M_PI : 360);
+    return std::remainder(angle1 - angle2, radians ? 2 * M_PI : 360);
 }
 
 /**


### PR DESCRIPTION
#### Summary
Refactors some utility functions in `utils.cpp` and `utils.h`.
- Uses `constexpr` where possible.
- Makes `sgn` templated to support integer types and whatnot.
- Changes `angleError` to use `std::remainder`.

#### Motivation
Takes advantage of newer cpp features to either simplify or improve the existing utilities.

#### Test Plan
TBD

#### Additional Notes
Nope