### PR TITLE
Add Unit System and Overloads

### DIFF
--- a/include/lemlib/chassis/trackingWheel.hpp
+++ b/include/lemlib/chassis/trackingWheel.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "lemlib/units.hpp"
 #include "pros/motors.hpp"
 #include "pros/adi.hpp"
 #include "pros/rotation.hpp"
@@ -46,6 +47,17 @@ class TrackingWheel {
          * @param gearRatio gear ratio of the tracking wheel, defaults to 1
          */
         TrackingWheel(pros::ADIEncoder* encoder, float wheelDiameter, float distance, float gearRatio = 1);
+
+        /**
+         * @brief Create a new tracking wheel
+         *
+         * @param encoder the optical shaft encoder to use
+         * @param wheelDiameter the diameter of the wheel
+         * @param distance distance between the tracking wheel and the center of rotation in inches
+         * @param gearRatio gear ratio of the tracking wheel, defaults to 1
+         */
+        TrackingWheel(pros::ADIEncoder* encoder, Length wheelDiameter, Length distance, float gearRatio = 1);
+
         /**
          * @brief Create a new tracking wheel
          *
@@ -58,12 +70,31 @@ class TrackingWheel {
         /**
          * @brief Create a new tracking wheel
          *
+         * @param encoder the v5 rotation sensor to use
+         * @param wheelDiameter the diameter of the wheel
+         * @param distance distance between the tracking wheel and the center of rotation in inches
+         * @param gearRatio gear ratio of the tracking wheel, defaults to 1
+         */
+        TrackingWheel(pros::Rotation* encoder, Length wheelDiameter, Length distance, float gearRatio = 1);
+
+        /**
+         * @brief Create a new tracking wheel
+         *
          * @param motors the motor group to use
          * @param wheelDiameter the diameter of the wheel
          * @param distance half the track width of the drivetrain in inches
          * @param rpm theoretical maximum rpm of the drivetrain wheels
          */
         TrackingWheel(pros::Motor_Group* motors, float wheelDiameter, float distance, float rpm);
+        /**
+         * @brief Create a new tracking wheel
+         *
+         * @param motors the motor group to use
+         * @param wheelDiameter the diameter of the wheel
+         * @param distance half the track width of the drivetrain in inches
+         * @param rpm theoretical maximum rpm of the drivetrain wheels
+         */
+        TrackingWheel(pros::Motor_Group* motors, Length wheelDiameter, Length distance, AngularVelocity rpm);
         /**
          * @brief Reset the tracking wheel position to 0
          *

--- a/include/lemlib/pose.hpp
+++ b/include/lemlib/pose.hpp
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "units.hpp"
 #include <string>
 
 namespace lemlib {
@@ -94,6 +95,97 @@ class Pose {
          */
         Pose rotate(float angle);
 };
+
+class UnitPose {
+    public:
+        /** @brief x value*/
+        Length x;
+        /** @brief y value*/
+        Length y;
+        /** @brief theta value*/
+        Angle theta;
+        /**
+         * @brief Create a new pose
+         *
+         * @param x component
+         * @param y component
+         * @param theta heading. Defaults to 0
+         */
+        UnitPose(Length x, Length y, Angle theta = 0_rad);
+        /**
+         * @brief Add a pose to this pose
+         *
+         * @param other other pose
+         * @return Pose
+         */
+        UnitPose operator+(const UnitPose& other);
+        /**
+         * @brief Subtract a pose from this pose
+         *
+         * @param other other pose
+         * @return Pose
+         */
+        UnitPose operator-(const UnitPose& other);
+        /**
+         * @brief Multiply a pose by this pose
+         *
+         * @param other other pose
+         * @return Pose
+         */
+        Length operator*(const UnitPose& other);
+        /**
+         * @brief Multiply a pose by a float
+         *
+         * @param other float
+         * @return Pose
+         */
+        UnitPose operator*(const float& other);
+        /**
+         * @brief Divide a pose by a float
+         *
+         * @param other float
+         * @return Pose
+         */
+        UnitPose operator/(const float& other);
+        /**
+         * @brief Linearly interpolate between two poses
+         *
+         * @param other the other pose
+         * @param t t value
+         * @return Pose
+         */
+        UnitPose lerp(UnitPose other, float t);
+        /**
+         * @brief Get the distance between two poses
+         *
+         * @param other the other pose
+         * @return float
+         */
+        Length distance(UnitPose other);
+        /**
+         * @brief Get the angle between two poses
+         *
+         * @param other the other pose
+         * @return Length
+         */
+        Angle angle(UnitPose other);
+        /**
+         * @brief Rotate a pose by an angle
+         *
+         * @param angle angle in radians
+         * @return Pose
+         */
+        UnitPose rotate(Angle angle);
+};
+
+// Isomorphism between Pose and UnitPose
+inline Pose withoutUnits(const UnitPose& pose) {
+    return lemlib::Pose(to_in(pose.x), to_in(pose.y), to_rad(pose.theta));
+}
+
+inline UnitPose withUnits(const Pose& pose) {
+    return lemlib::UnitPose(from_in(pose.x), from_in(pose.y), from_rad(pose.theta));
+}
 
 /**
  * @brief Format a pose

--- a/include/lemlib/timer.hpp
+++ b/include/lemlib/timer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include "lemlib/units.hpp"
 
 namespace lemlib {
 class Timer {
@@ -11,6 +12,7 @@ class Timer {
          * @param time how long to wait, in milliseconds
          */
         Timer(uint32_t time);
+        Timer(Time time);
         /**
          * @brief Get the amount of time the timer was set to
          *
@@ -42,6 +44,14 @@ class Timer {
          * @param time time in milliseconds
          */
         void set(uint32_t time);
+
+        /**
+         * @brief Set the amount of time the timer should count down. Resets the timer
+         *
+         * @param time time in milliseconds
+         */
+        void set(Time time);
+
         /**
          * @brief reset the timer
          *

--- a/include/lemlib/units.hpp
+++ b/include/lemlib/units.hpp
@@ -1,0 +1,565 @@
+#pragma once
+
+// Don't crash your Mars Orbiter
+// Coherent unit system based on SI
+
+#include <cmath>
+#include <ratio>
+#include <algorithm>
+#include <iostream>
+#include <type_traits>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+using Zero = std::ratio<0>;
+using One = std::ratio<1>;
+
+template <typename Mass, typename Length, typename Time, typename Angle, typename Tag = Zero>
+struct Dimensions {
+    Mass mass;
+    Length length;
+    Time time;
+    Angle angle;
+    Tag tag;
+};
+
+// The units used internally are:
+// Kilograms for Mass
+// Meters for Length
+// Seconds for Time
+// Radians for Angle
+
+template <typename Mass, typename Length, typename Time, typename Angle, typename Rep = double>
+class Quantity {
+    double value;
+public:
+    // A proxy to be able to extract dimension units with decltype
+    // Not used at runtime
+    inline static Dimensions<Mass, Length, Time, Angle> dim{};
+    
+    explicit constexpr inline Quantity() : value(0) {
+    }
+
+    explicit constexpr inline Quantity(double val) : value(val) {
+    }
+
+    constexpr inline double raw() {
+        return value;
+    }
+
+    constexpr inline Quantity const& operator+=(const Quantity& rhs) {
+        value += rhs.value;
+        return *this;
+    }
+
+    constexpr inline Quantity const& operator-=(const Quantity& rhs) {
+        value -= rhs.value;
+        return *this;
+    }
+
+    constexpr inline Quantity operator-() {
+        return Quantity(value * -1);
+    }
+
+    constexpr inline Quantity const& operator*=(const double rhs) {
+        value *= rhs;
+        return *this;
+    }
+
+    constexpr inline Quantity const& operator/=(const double rhs) {
+        value /= rhs;
+        return *this;
+    }
+
+    // Returns the value of the quantity in multiples of the specified unit
+    constexpr inline double convert(const Quantity unit) const {
+        return value / unit.raw();
+    }
+
+    // returns the raw value of the quantity (this breaks the type-safety of the unit system)
+    constexpr inline double raw() const {
+        return value;
+    }
+};
+
+template<typename Q1, typename Q2>
+constexpr inline Q1 unit_cast(Q2 quantity) {
+    return Q1(quantity.raw());
+}
+
+template <typename Q1, typename Q2>
+using Multiplication = Quantity<std::ratio_add<decltype(Q1::dim.mass), decltype(Q2::dim.mass)>, 
+    std::ratio_add<decltype(Q1::dim.length), decltype(Q2::dim.length)>,
+    std::ratio_add<decltype(Q1::dim.time), decltype(Q2::dim.time)>,
+    std::ratio_add<decltype(Q1::dim.angle), decltype(Q2::dim.angle)>>;
+
+template <typename Q1, typename Q2>
+using Division = Quantity<std::ratio_subtract<decltype(Q1::dim.mass), decltype(Q2::dim.mass)>,
+    std::ratio_subtract<decltype(Q1::dim.length), decltype(Q2::dim.length)>,
+    std::ratio_subtract<decltype(Q1::dim.time), decltype(Q2::dim.time)>,
+    std::ratio_subtract<decltype(Q1::dim.angle), decltype(Q2::dim.angle)>>;
+
+#define QUANTITY_NEW(Name, base, Mass, Length, Time, Angle)                                            \
+    using Name = Quantity<std::ratio<Mass>, std::ratio<Length>, std::ratio<Time>, std::ratio<Angle>>; \
+    constexpr inline Name base = Name(1); \
+    constexpr inline Name operator""_##base(long double value) { \
+        return Name(static_cast<double>(value)); \
+    } \
+    constexpr inline Name operator""_##base(unsigned long long value) { \
+        return Name(static_cast<double>(value)); \
+    } \
+    constexpr inline Name from_##base(double value) { \
+        return Name(value); \
+    } \
+    constexpr inline double to_##base(Name quantity) { \
+        return quantity.raw(); \
+    } \
+    inline std::ostream& operator<<(std::ostream& os, const Name& quantity) { \
+        os << quantity.raw() << "_" << #base; \
+        return os; \
+    }
+
+#define QUANTITY_NEW_TAGGED(Name, base, Mass, Length, Time, Angle, Tag)                                            \
+    using Name = Quantity<std::ratio<Mass>, std::ratio<Length>, std::ratio<Time>, std::ratio<Angle>, std::ratio<Tag>>; \
+    constexpr inline Name base = Name(1); \
+    constexpr inline Name operator""_##base(long double value) { \
+        return Name(static_cast<double>(value)); \
+    } \
+    constexpr inline Name operator""_##base(unsigned long long value) { \
+        return Name(static_cast<double>(value)); \
+    } \
+    constexpr inline Name from_##base(double value) { \
+        return Name(value); \
+    } \
+    constexpr inline double to_##base(Name quantity) { \
+        return quantity.raw(); \
+    } \
+    inline std::ostream& operator<<(std::ostream& os, const Name& quantity) { \
+        os << quantity.raw() << "_" << #base; \
+        return os; \
+    }
+
+#define QUANTITY_LIT(Name, suffix, ratio) \
+    constexpr inline Name suffix = ratio; \
+    constexpr inline Name operator""_##suffix(long double value) { \
+        return Name(static_cast<double>(value) * ratio); \
+    } \
+    constexpr inline Name operator""_##suffix(unsigned long long value) { \
+        return Name(static_cast<double>(value) * ratio); \
+    } \
+    constexpr inline Name from_##suffix(double value) { \
+        return value * ratio; \
+    } \
+    constexpr inline double to_##suffix(Name quantity) { \
+        return quantity.convert(ratio); \
+    }
+
+QUANTITY_NEW(Number, num, 0, 0, 0, 0)
+
+
+// Aritmetic operators
+template <typename Q>
+constexpr inline Q operator+(const Q& lhs, const Q& rhs) {
+    return Q(lhs.raw() + rhs.raw());
+}
+template <typename Q>
+constexpr inline Q operator-(const Q& lhs, const Q& rhs) {
+    return Q(lhs.raw() - rhs.raw());
+}
+
+template <typename Q1, typename Q2>
+constexpr inline Multiplication<Q1, Q2>
+    operator*(const Q1& lhs, const Q2& rhs) {
+    return Multiplication<Q1, Q2>(lhs.raw() * rhs.raw());
+}
+
+template <typename Q, typename = std::enable_if_t<std::is_class<Q>::value>>
+constexpr inline Q operator*(const double& lhs, const Q& rhs) {
+    return Q(lhs * rhs.raw());
+}
+
+template <typename Q, typename = std::enable_if_t<std::is_class<Q>::value>>
+constexpr inline Q operator*(const Q& lhs, const double& rhs) {
+    return Q(lhs.raw() * rhs);
+}
+
+template <typename Q1, typename Q2>
+constexpr inline Division<Q1, Q2>
+    operator/(const Q1& lhs, const Q2& rhs) {
+    return Division<Q1, Q2>(lhs.raw() / rhs.raw());
+}
+
+template <typename Q>
+constexpr inline Quantity<std::ratio_subtract<Zero, decltype(Q::dim.mass)>,
+    std::ratio_subtract<Zero, decltype(Q::dim.length)>,
+    std::ratio_subtract<Zero, decltype(Q::dim.time)>,
+    std::ratio_subtract<Zero, decltype(Q::dim.angle)>>
+    operator/(const double& x, const Q& rhs) {
+    return Quantity<std::ratio_subtract<Zero, decltype(Q::dim.mass)>,
+        std::ratio_subtract<Zero, decltype(Q::dim.length)>,
+        std::ratio_subtract<Zero, decltype(Q::dim.time)>,
+        std::ratio_subtract<Zero, decltype(Q::dim.angle)>>(x / rhs.raw());
+}
+template <typename Q, typename = std::enable_if_t<std::is_class<Q>::value>>
+constexpr inline Q operator/(const Q& rhs, const double& x) {
+    return Q(rhs.raw() / x);
+}
+
+// Comparison operators
+template <typename Q>
+constexpr inline bool operator==(const Q& lhs, const Q& rhs) {
+    return (lhs.raw() == rhs.raw());
+}
+
+template <typename Q>
+constexpr inline bool operator!=(const Q& lhs, const Q& rhs) {
+    return (lhs.raw() != rhs.raw());
+}
+
+template <typename Q>
+constexpr inline bool operator<=(const Q& lhs, const Q& rhs) {
+    return (lhs.raw() <= rhs.raw());
+}
+template <typename Q>
+constexpr inline bool operator>=(const Q& lhs, const Q& rhs) {
+    return (lhs.raw() >= rhs.raw());
+}
+template <typename Q>
+constexpr inline bool operator<(const Q& lhs, const Q& rhs) {
+    return (lhs.raw() < rhs.raw());
+}
+template <typename Q>
+constexpr inline bool operator>(const Q& lhs, const Q& rhs) {
+    return (lhs.raw() > rhs.raw());
+}
+
+namespace units {
+    template <typename Q>
+    constexpr inline Q abs(const Q& lhs) {
+        return Q(std::abs(lhs.raw()));
+    }
+
+    template <typename R, typename Q>
+    constexpr inline Quantity<std::ratio_multiply<decltype(Q::dim.mass), R>,
+        std::ratio_multiply<decltype(Q::dim.length), R>,
+        std::ratio_multiply<decltype(Q::dim.time), R>,
+        std::ratio_multiply<decltype(Q::dim.angle), R>>
+        pow(const Q& lhs) {
+        return Quantity<std::ratio_multiply<decltype(Q::dim.mass), R>,
+            std::ratio_multiply<decltype(Q::dim.dlenth), R>,
+            std::ratio_multiply<decltype(Q::dim.time), R>,
+            std::ratio_multiply<decltype(Q::dim.angle), R>>(std::pow(lhs.raw(), double(R::num) / R::den));
+    }
+
+    template <int R, typename Q>
+    constexpr inline Quantity<std::ratio_multiply<decltype(Q::dim.mass), std::ratio<R>>,
+        std::ratio_multiply<decltype(Q::dim.length), std::ratio<R>>,
+        std::ratio_multiply<decltype(Q::dim.time), std::ratio<R>>,
+        std::ratio_multiply<decltype(Q::dim.angle), std::ratio<R>>>
+        pow(
+            const Quantity<decltype(Q::dim.mass), 
+            decltype(Q::dim.length), 
+            decltype(Q::dim.time), 
+            decltype(Q::dim.angle)>& lhs) {
+        return Quantity<std::ratio_multiply<decltype(Q::dim.mass), std::ratio<R>>,
+            std::ratio_multiply<decltype(Q::dim.length), std::ratio<R>>,
+            std::ratio_multiply<decltype(Q::dim.time), std::ratio<R>>,
+            std::ratio_multiply<decltype(Q::dim.angle), std::ratio<R>>>(std::pow(lhs.raw(), R));
+    }
+
+    template <int R, typename Q>
+    constexpr inline Quantity<std::ratio_divide<decltype(Q::dim.mass), std::ratio<R>>,
+        std::ratio_divide<decltype(Q::dim.length), std::ratio<R>>,
+        std::ratio_divide<decltype(Q::dim.time), std::ratio<R>>,
+        std::ratio_divide<decltype(Q::dim.angle), std::ratio<R>>>
+        root(
+            const Quantity<decltype(Q::dim.mass), 
+            decltype(Q::dim.length), 
+            decltype(Q::dim.time), 
+            decltype(Q::dim.angle)>& lhs) {
+        return Quantity<std::ratio_divide<decltype(Q::dim.mass), std::ratio<R>>,
+            std::ratio_divide<decltype(Q::dim.length), std::ratio<R>>,
+            std::ratio_divide<decltype(Q::dim.time), std::ratio<R>>,
+            std::ratio_divide<decltype(Q::dim.angle), std::ratio<R>>>(std::pow(lhs.raw(), 1.0 / R));
+    }
+
+    template <typename Q>
+    constexpr inline Quantity<std::ratio_divide<decltype(Q::dim.mass), std::ratio<2>>,
+        std::ratio_divide<decltype(Q::dim.length), std::ratio<2>>,
+        std::ratio_divide<decltype(Q::dim.time), std::ratio<2>>,
+        std::ratio_divide<decltype(Q::dim.angle), std::ratio<2>>>
+        sqrt(
+            const Quantity<decltype(Q::dim.mass), 
+            decltype(Q::dim.length), 
+            decltype(Q::dim.time), 
+            decltype(Q::dim.angle)>& rhs) {
+        return Quantity<std::ratio_divide<decltype(Q::dim.mass), std::ratio<2>>,
+            std::ratio_divide<decltype(Q::dim.length), std::ratio<2>>,
+            std::ratio_divide<decltype(Q::dim.time), std::ratio<2>>,
+            std::ratio_divide<decltype(Q::dim.angle), std::ratio<2>>>(std::sqrt(rhs.raw()));
+    }
+
+    template <typename Q>
+    constexpr inline Quantity<std::ratio_divide<decltype(Q::dim.mass), std::ratio<3>>,
+        std::ratio_divide<decltype(Q::dim.length), std::ratio<3>>,
+        std::ratio_divide<decltype(Q::dim.time), std::ratio<3>>,
+        std::ratio_divide<decltype(Q::dim.angle), std::ratio<3>>>
+        cbrt(
+            const Quantity<decltype(Q::dim.mass), 
+            decltype(Q::dim.length), decltype(Q::dim.time), 
+            decltype(Q::dim.angle)>& rhs) {
+        return Quantity<std::ratio_divide<decltype(Q::dim.mass), std::ratio<3>>,
+            std::ratio_divide<decltype(Q::dim.length), std::ratio<3>>,
+            std::ratio_divide<decltype(Q::dim.time), std::ratio<3>>,
+            std::ratio_divide<decltype(Q::dim.angle), std::ratio<3>>>(std::cbrt(rhs.raw()));
+    }
+
+    template <typename Q>
+    constexpr inline Quantity<std::ratio_multiply<decltype(Q::dim.mass), std::ratio<2>>,
+        std::ratio_multiply<decltype(Q::dim.length), std::ratio<2>>,
+        std::ratio_multiply<decltype(Q::dim.time), std::ratio<2>>,
+        std::ratio_multiply<decltype(Q::dim.angle), std::ratio<2>>>
+        square(
+            const Quantity<decltype(Q::dim.mass), 
+            decltype(Q::dim.length), decltype(Q::dim.time), 
+            decltype(Q::dim.angle)>& rhs) {
+        return Quantity<std::ratio_multiply<decltype(Q::dim.mass), std::ratio<2>>,
+            std::ratio_multiply<decltype(Q::dim.length), std::ratio<2>>,
+            std::ratio_multiply<decltype(Q::dim.time), std::ratio<2>>,
+            std::ratio_multiply<decltype(Q::dim.angle), std::ratio<2>>>(std::pow(rhs.raw(), 2));
+    }
+
+    template <typename Q>
+    constexpr inline Quantity<std::ratio_multiply<decltype(Q::dim.mass), std::ratio<3>>,
+        std::ratio_multiply<decltype(Q::dim.length), std::ratio<3>>,
+        std::ratio_multiply<decltype(Q::dim.time), std::ratio<3>>,
+        std::ratio_multiply<decltype(Q::dim.angle), std::ratio<3>>>
+        cube(
+            const Quantity<decltype(Q::dim.mass), 
+            decltype(Q::dim.length), 
+            decltype(Q::dim.time), 
+            decltype(Q::dim.angle)>& rhs) {
+        return Quantity<std::ratio_multiply<decltype(Q::dim.mass), std::ratio<3>>,
+            std::ratio_multiply<decltype(Q::dim.length), std::ratio<3>>,
+            std::ratio_multiply<decltype(Q::dim.time), std::ratio<3>>,
+            std::ratio_multiply<decltype(Q::dim.angle), std::ratio<3>>>(std::pow(rhs.raw(), 3));
+    }
+
+    template <typename Q>
+    constexpr inline Q hypot(const Q& lhs,
+        const Q& rhs) {
+        return Q(std::hypot(lhs.raw(), rhs.raw()));
+    }
+
+    template <typename Q>
+    constexpr inline Q mod(const Q& lhs,
+        const Q& rhs) {
+        return Q(std::fmod(lhs.raw(), rhs.raw()));
+    }
+
+    template <typename Q1, typename Q2>
+    constexpr inline Q1 copysign(const Q1& lhs,
+        const Q2& rhs) {
+        return Q1(std::copysign(lhs.raw(), rhs.raw()));
+    }
+
+    template <typename Q>
+    constexpr inline bool signbit(const Q& lhs) {
+        return std::signbit(lhs.raw());
+    }
+
+    template <typename Q>
+    constexpr inline Q clamp(const Q& lhs,
+        const Q& lo, Q& hi) {
+        return Q(std::clamp(lhs.raw(), lo.raw(), hi.raw()));
+    }
+
+    template <typename Q>
+    constexpr inline Q ceil(const Q& lhs,
+        const Q& rhs) {
+        return Q(std::ceil(lhs.raw() / rhs.raw()) * rhs.raw());
+    }
+
+    template <typename Q>
+    constexpr inline Q floor(const Q& lhs,
+        const Q& rhs) {
+        return Q(std::floor(lhs.raw() / rhs.raw()) * rhs.raw());
+    }
+
+    template <typename Q>
+    constexpr inline Q trunc(const Q& lhs,
+        const Q& rhs) {
+        return Q(std::trunc(lhs.raw() / rhs.raw()) * rhs.raw());
+    }
+
+    template <typename Q>
+    constexpr inline Q round(const Q& lhs,
+        const Q& rhs) {
+        return Q(std::round(lhs.raw() / rhs.raw()) * rhs.raw());
+    }
+
+    constexpr inline Number
+        sin(const Quantity<Zero, Zero, Zero, One>& rhs) {
+        return Number(std::sin(rhs.raw()));
+    }
+
+    constexpr inline Number
+        cos(const Quantity<Zero, Zero, Zero, One>& rhs) {
+        return Number(std::cos(rhs.raw()));
+    }
+
+    constexpr inline Number
+        tan(const Quantity<Zero, Zero, Zero, One>& rhs) {
+        return Number(std::tan(rhs.raw()));
+    }
+
+    constexpr inline Quantity<Zero, Zero, Zero, One>
+        asin(const Number& rhs) {
+        return Quantity<Zero, Zero, Zero, One>(
+            std::asin(rhs.raw()));
+    }
+
+    constexpr inline Quantity<Zero, Zero, Zero, One>
+        acos(const Number& rhs) {
+        return Quantity<Zero, Zero, Zero, One>(
+            std::acos(rhs.raw()));
+    }
+
+    constexpr inline Quantity<Zero, Zero, Zero, One>
+        atan(const Number& rhs) {
+        return Quantity<Zero, Zero, Zero, One>(
+            std::atan(rhs.raw()));
+    }
+
+    constexpr inline Number
+        sinh(const Quantity<Zero, Zero, Zero, One>& rhs) {
+        return Number(std::sinh(rhs.raw()));
+    }
+
+    constexpr inline Number
+        cosh(const Quantity<Zero, Zero, Zero, One>& rhs) {
+        return Number(std::cosh(rhs.raw()));
+    }
+
+    constexpr inline Number
+        tanh(const Quantity<Zero, Zero, Zero, One>& rhs) {
+        return Number(std::tanh(rhs.raw()));
+    }
+
+    constexpr inline Quantity<Zero, Zero, Zero, One>
+        asinh(const Number& rhs) {
+        return Quantity<Zero, Zero, Zero, One>(
+            std::asinh(rhs.raw()));
+    }
+
+    constexpr inline Quantity<Zero, Zero, Zero, One>
+        acosh(const Number& rhs) {
+        return Quantity<Zero, Zero, Zero, One>(
+            std::acosh(rhs.raw()));
+    }
+
+    constexpr inline Quantity<Zero, Zero, Zero, One>
+        atanh(const Number& rhs) {
+        return Quantity<Zero, Zero, Zero, One>(
+            std::atanh(rhs.raw()));
+    }
+
+    template <typename Q>
+    constexpr inline Quantity<Zero, Zero, Zero, One>
+        atan2(const Q& lhs, const Q& rhs) {
+        return Quantity<Zero, Zero, Zero, One>(
+            std::atan2(lhs.raw(), rhs.raw()));
+    }
+
+} // namespace units
+
+QUANTITY_NEW(Time, sec, 0, 0, 1, 0)
+QUANTITY_LIT(Time, ms, sec / 1000)
+QUANTITY_LIT(Time, min, sec * 60)
+QUANTITY_LIT(Time, hr, min * 60)
+QUANTITY_LIT(Time, day, hr * 24)
+
+QUANTITY_NEW(Length, m, 0, 1, 0, 0)
+QUANTITY_LIT(Length, mm, m / 1000)
+QUANTITY_LIT(Length, cm, m / 100)
+QUANTITY_LIT(Length, km, m * 1000)
+QUANTITY_LIT(Length, in, cm * 2.54)
+QUANTITY_LIT(Length, ft, in * 12)
+QUANTITY_LIT(Length, yd, ft * 3)
+QUANTITY_LIT(Length, mi, ft * 5280)
+QUANTITY_LIT(Length, tiles, 600 * mm)
+
+QUANTITY_NEW(Angle, rad, 0, 0, 0, 1)
+QUANTITY_LIT(Angle, deg, (M_PI / 180)* rad)
+QUANTITY_LIT(Angle, rot, 360 * deg)
+
+QUANTITY_NEW(LinearVelocity, mps, 0, 1, -1, 0)
+QUANTITY_LIT(LinearVelocity, cmps, cm / sec)
+QUANTITY_LIT(LinearVelocity, inps, in / sec)
+QUANTITY_LIT(LinearVelocity, miph, mi / hr)
+QUANTITY_LIT(LinearVelocity, kmph, km / hr)
+
+QUANTITY_NEW(AngularVelocity, radps, 0, 0, -1, 1)
+QUANTITY_LIT(AngularVelocity, degps, deg / sec)
+QUANTITY_LIT(AngularVelocity, rps, rot / sec)
+QUANTITY_LIT(AngularVelocity, rpm, rot / min)
+
+QUANTITY_NEW(LinearAcceleration, mps2, 0, 1, -2, 0)
+QUANTITY_LIT(LinearAcceleration, cmps2, cm / sec / sec)
+QUANTITY_LIT(LinearAcceleration, inps2, in / sec / sec)
+QUANTITY_LIT(LinearAcceleration, miph2, mi / hr / hr)
+QUANTITY_LIT(LinearAcceleration, kmph2, km / hr / hr)
+
+QUANTITY_NEW(AngularAcceleration, radps2, 0, 0, -2, 1)
+QUANTITY_LIT(AngularAcceleration, degps2, deg / sec /sec)
+QUANTITY_LIT(AngularAcceleration, rps2, rot / sec / sec)
+QUANTITY_LIT(AngularAcceleration, rpm2, rot / min / min)
+
+QUANTITY_NEW(LinearJerk, mps3, 0, 1, -3, 0)
+QUANTITY_LIT(LinearJerk, cmps3, cm / sec / sec / sec)
+QUANTITY_LIT(LinearJerk, inps3, in / sec / sec / sec)
+QUANTITY_LIT(LinearJerk, miph3, mi / hr / hr / hr)
+QUANTITY_LIT(LinearJerk, kmph3, km / hr / hr / hr)
+
+QUANTITY_NEW(AngularJerk, radps3, 0, 0, -3, 1)
+QUANTITY_LIT(AngularJerk, rps3, rot / sec / sec / sec)
+QUANTITY_LIT(AngularJerk, rpm3, rot / min / min / min)
+
+QUANTITY_NEW_TAGGED(Temperature, celcius, 0, 0, 0, 0, 0)
+
+QUANTITY_NEW_TAGGED(Voltage, volts, 0, 0, 0, 0, 1)
+QUANTITY_LIT(Voltage, mvolts, volts / 1000)
+
+template <typename Q>
+Quantity<
+    decltype(Q::dim.mass), 
+    decltype(Q::dim.angle), 
+    decltype(Q::dim.time), 
+    decltype(Q::dim.length)> 
+to_linear(
+    Quantity<decltype(Q::dim.mass), 
+    decltype(Q::dim.length), 
+    decltype(Q::dim.time), 
+    decltype(Q::dim.angle)> angular, 
+    Length diameter) {
+    return unit_cast<Quantity<decltype(Q::dim.mass), decltype(Q::dim.angle), decltype(Q::dim.time), decltype(Q::dim.length)>>(angular * (diameter / 2.0));
+}
+
+template <typename Q>
+Quantity<
+    decltype(Q::dim.mass), 
+    decltype(Q::dim.angle), 
+    decltype(Q::dim.time), 
+    decltype(Q::dim.length)> 
+to_angular(
+    Quantity<decltype(Q::dim.mass), 
+    decltype(Q::dim.length), 
+    decltype(Q::dim.time), 
+    decltype(Q::dim.angle)> linear, 
+    Length diameter) {
+    return unit_cast<Quantity<decltype(Q::dim.mass), decltype(Q::dim.angle), decltype(Q::dim.time), decltype(Q::dim.length)>>(linear / (diameter / 2.0));
+}
+
+constexpr Time FOREVER = Time(std::numeric_limits<double>::infinity());

--- a/src/lemlib/chassis/trackingWheel.cpp
+++ b/src/lemlib/chassis/trackingWheel.cpp
@@ -11,6 +11,7 @@
 
 #include <math.h>
 #include "lemlib/chassis/trackingWheel.hpp"
+#include "lemlib/units.hpp"
 #include "lemlib/util.hpp"
 #include "pros/llemu.hpp"
 
@@ -32,6 +33,21 @@ lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, float wheelDiame
 /**
  * @brief Create a new tracking wheel
  *
+ * @param encoder the optical shaft encoder to use
+ * @param wheelDiameter the diameter of the wheel
+ * @param distance distance between the tracking wheel and the center of rotation in inches
+ * @param gearRatio gear ratio of the tracking wheel, defaults to 1
+ */
+lemlib::TrackingWheel::TrackingWheel(pros::ADIEncoder* encoder, Length wheelDiameter, Length distance, float gearRatio) {
+    this->encoder = encoder;
+    this->diameter = to_in(wheelDiameter);
+    this->distance = to_in(distance);
+    this->gearRatio = gearRatio;
+}
+
+/**
+ * @brief Create a new tracking wheel
+ *
  * @param encoder the v5 rotation sensor to use
  * @param wheelDiameter the diameter of the wheel
  * @param distance distance between the tracking wheel and the center of rotation in inches
@@ -47,6 +63,22 @@ lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, float wheelDiamete
 /**
  * @brief Create a new tracking wheel
  *
+ * @param encoder the v5 rotation sensor to use
+ * @param wheelDiameter the diameter of the wheel
+ * @param distance distance between the tracking wheel and the center of rotation in inches
+ * @param gearRatio gear ratio of the tracking wheel, defaults to 1
+ */
+lemlib::TrackingWheel::TrackingWheel(pros::Rotation* encoder, Length wheelDiameter, Length distance, float gearRatio) {
+    this->rotation = encoder;
+    this->diameter = to_in(wheelDiameter);
+    this->distance = to_in(distance);
+    this->gearRatio = gearRatio;
+}
+
+
+/**
+ * @brief Create a new tracking wheel
+ *
  * @param motors the motor group to use
  * @param wheelDiameter the diameter of the wheel
  * @param distance half the track width of the drivetrain in inches
@@ -58,6 +90,22 @@ lemlib::TrackingWheel::TrackingWheel(pros::Motor_Group* motors, float wheelDiame
     this->diameter = wheelDiameter;
     this->distance = distance;
     this->rpm = rpm;
+}
+
+/**
+ * @brief Create a new tracking wheel
+ *
+ * @param motors the motor group to use
+ * @param wheelDiameter the diameter of the wheel
+ * @param distance half the track width of the drivetrain in inches
+ * @param rpm theoretical maximum rpm of the drivetrain wheels
+ */
+lemlib::TrackingWheel::TrackingWheel(pros::Motor_Group* motors, Length wheelDiameter, Length distance, AngularVelocity rpm) {
+    this->motors = motors;
+    this->motors->set_encoder_units(pros::E_MOTOR_ENCODER_ROTATIONS);
+    this->diameter = to_in(wheelDiameter);
+    this->distance = to_in(distance);
+    this->rpm = to_rpm(rpm);
 }
 
 /**

--- a/src/lemlib/pose.cpp
+++ b/src/lemlib/pose.cpp
@@ -9,6 +9,7 @@
  *
  */
 
+#include "units.hpp"
 #include <math.h>
 
 #define FMT_HEADER_ONLY
@@ -29,6 +30,12 @@ lemlib::Pose::Pose(float x, float y, float theta) {
     this->theta = theta;
 }
 
+lemlib::UnitPose::UnitPose(Length x, Length y, Angle theta) {
+    this->x = x;
+    this->y = y;
+    this->theta = theta;
+}
+
 /**
  * @brief Add a pose to this pose
  *
@@ -37,6 +44,10 @@ lemlib::Pose::Pose(float x, float y, float theta) {
  */
 lemlib::Pose lemlib::Pose::operator+(const lemlib::Pose& other) {
     return lemlib::Pose(this->x + other.x, this->y + other.y, this->theta);
+}
+
+lemlib::UnitPose lemlib::UnitPose::operator+(const lemlib::UnitPose& other) {
+    return lemlib::UnitPose(this->x + other.x, this->y + other.y, this->theta);
 }
 
 /**
@@ -49,6 +60,10 @@ lemlib::Pose lemlib::Pose::operator-(const lemlib::Pose& other) {
     return lemlib::Pose(this->x - other.x, this->y - other.y, this->theta);
 }
 
+lemlib::UnitPose lemlib::UnitPose::operator-(const lemlib::UnitPose& other) {
+    return lemlib::UnitPose(this->x - other.x, this->y - other.y, this->theta);
+}
+
 /**
  * @brief Multiply a pose by this pose
  *
@@ -56,6 +71,8 @@ lemlib::Pose lemlib::Pose::operator-(const lemlib::Pose& other) {
  * @return Pose
  */
 float lemlib::Pose::operator*(const lemlib::Pose& other) { return this->x * other.x + this->y * other.y; }
+
+Length lemlib::UnitPose::operator*(const lemlib::UnitPose& other) { return this->x * other.x.raw() + this->y * other.y.raw(); }
 
 /**
  * @brief Multiply a pose by a float
@@ -67,6 +84,10 @@ lemlib::Pose lemlib::Pose::operator*(const float& other) {
     return lemlib::Pose(this->x * other, this->y * other, this->theta);
 }
 
+lemlib::UnitPose lemlib::UnitPose::operator*(const float& other) {
+    return lemlib::UnitPose(this->x * other, this->y * other, this->theta);
+}
+
 /**
  * @brief Divide a pose by a float
  *
@@ -75,6 +96,10 @@ lemlib::Pose lemlib::Pose::operator*(const float& other) {
  */
 lemlib::Pose lemlib::Pose::operator/(const float& other) {
     return lemlib::Pose(this->x / other, this->y / other, this->theta);
+}
+
+lemlib::UnitPose lemlib::UnitPose::operator/(const float& other) {
+    return lemlib::UnitPose(this->x / other, this->y / other, this->theta);
 }
 
 /**
@@ -88,6 +113,10 @@ lemlib::Pose lemlib::Pose::lerp(lemlib::Pose other, float t) {
     return lemlib::Pose(this->x + (other.x - this->x) * t, this->y + (other.y - this->y) * t, this->theta);
 }
 
+lemlib::UnitPose lemlib::UnitPose::lerp(lemlib::UnitPose other, float t) {
+    return lemlib::UnitPose(this->x + (other.x - this->x) * t, this->y + (other.y - this->y) * t, this->theta);
+}
+
 /**
  * @brief Get the distance between two poses
  *
@@ -95,6 +124,7 @@ lemlib::Pose lemlib::Pose::lerp(lemlib::Pose other, float t) {
  * @return float
  */
 float lemlib::Pose::distance(lemlib::Pose other) { return std::hypot(this->x - other.x, this->y - other.y); }
+Length lemlib::UnitPose::distance(lemlib::UnitPose other) { return units::hypot(this->x - other.x, this->y - other.y); }
 
 /**
  * @brief Get the angle between two poses
@@ -103,6 +133,7 @@ float lemlib::Pose::distance(lemlib::Pose other) { return std::hypot(this->x - o
  * @return float in radians
  */
 float lemlib::Pose::angle(lemlib::Pose other) { return std::atan2(other.y - this->y, other.x - this->x); }
+Angle lemlib::UnitPose::angle(lemlib::UnitPose other) { return units::atan2(other.y - this->y, other.x - this->x); }
 
 /**
  * @brief Rotate a pose by an angle
@@ -113,6 +144,11 @@ float lemlib::Pose::angle(lemlib::Pose other) { return std::atan2(other.y - this
 lemlib::Pose lemlib::Pose::rotate(float angle) {
     return lemlib::Pose(this->x * std::cos(angle) - this->y * std::sin(angle),
                         this->x * std::sin(angle) + this->y * std::cos(angle), this->theta);
+}
+
+lemlib::UnitPose lemlib::UnitPose::rotate(Angle angle) {
+    return lemlib::UnitPose(this->x * units::cos(angle) - this->y * units::sin(angle),
+                        this->x * units::sin(angle) + this->y * units::cos(angle), this->theta);
 }
 
 std::string lemlib::format_as(const lemlib::Pose& pose) {

--- a/src/lemlib/timer.cpp
+++ b/src/lemlib/timer.cpp
@@ -10,6 +10,7 @@ using namespace lemlib;
  * makes the code more readable, and easier to develop.
  */
 Timer::Timer(uint32_t time) : period(time) { lastTime = pros::millis(); }
+Timer::Timer(Time time) : period(to_ms(time)) { lastTime = pros::millis(); }
 
 /**
  * Get the amount of time the timer is set to wait
@@ -58,6 +59,14 @@ bool Timer::isDone() {
  */
 void Timer::set(uint32_t time) {
     period = time; // set how long to wait
+    reset();
+}
+
+/**
+ * Set how long the timer should wait. Resets the timer.
+ */
+void Timer::set(Time time) {
+    period = to_ms(time); // set how long to wait
     reset();
 }
 


### PR DESCRIPTION
Added a coherent unit system based on SI, as well as some overloads and conversion functions making use of this system.

#### Summary
Adds a unit system based on SI, and some overloads for functions to allow taking the unit types. The system is coherent, and automatically converts between different units. Additionally, the macros for creating new units generate `to_unit` and `from_unit` conversion functions. Values of a unit can be created with the `_unit` suffix (eg. (90_deg).

#### Motivation
This addition allows users to specify explicitly which units they are using and will automatically convert between units for them, without needing to consciously worry about. This provides a smoother and more flexible interface to functions that originally needed flags specifying the correct unit (such as radians or degrees), as well as a more explicit way to call functions like turnTo, moveTo, and the Odometry constructors.

#### Test Plan
Compiles without warnings;
Difficult to test beyond compilation
