### PR TITLE
Fix pr-comment again!

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,8 +1,6 @@
 name: Add Template to Pull Request 
 on:
-  workflow_run:
-    workflows: ['Build Template']
-    types: [completed]
+  workflow_call:
 jobs:
   pr_comment:
     # if Build Template was successful and ran on a branch that is currently the head in a pull request

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -21,7 +21,7 @@ jobs:
               const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});
                 
-              const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->`;
+              const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->\n`;
 
               body = old_body.split(marker)[0] + marker + body;
               await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
@@ -78,6 +78,8 @@ jobs:
             const template = artifacts[0];
 
             let body = `## Download the template for this pull request: \n\n`;
+            body += `> [!NOTE]  
+            > This is auto generated`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via Pros Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pr_comment:
     # if Build Template was successful and ran on a branch that is currently the head in a pull request
-    # if: github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.pull_requests.*.head.sha, github.event.workflow_run.head_sha)
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     permissions: 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -79,7 +79,7 @@ jobs:
 
             let body = `## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
-            > This is auto generated from [here](${{github.workflow_ref}})\n`;  
+            > This is auto generated from a workflow file\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via Pros Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -77,10 +77,10 @@ jobs:
             \`\`\``;
             
             core.info("Review thread message body:", body);
-            core.info(context.worflow_run);
-            console.log(context.worflow_run);
-            core.info(context.worflow_run.event);
-            console.log(context.worflow_run.event);
+            core.info(context.workflow_run);
+            console.log(context.workflow_run);
+            core.info(context.workflow_run.event);
+            console.log(context.workflow_run.event);
 
               await upsertComment(owner, repo, issue_number,
                 "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,15 +1,12 @@
 name: Add Template to Pull Request 
 on:
-  workflow_call:
-    inputs:
-      artifact_name:
-        description: "Name of the artifact that was produced"
-        required: true
-        type: string
+  workflow_run:
+    workflows: ['Build Template']
+    types: [completed]
 jobs:
   pr_comment:
     # if Build Template was successful and ran on a branch that is currently the head in a pull request
-    # if: github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.pull_requests.*.head.sha, github.event.workflow_run.head_sha)
+    if: github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.pull_requests.*.head.sha, github.event.workflow_run.head_sha)
     runs-on: ubuntu-latest
 
     permissions: 
@@ -21,65 +18,69 @@ jobs:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
-            console.log(context);
             async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
-            const {data: comments} = await github.rest.issues.listComments(
-              {owner, repo, issue_number});
-              
-            const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->\n`;
-            
-            body = old_body.split(marker)[0] + marker + body;
-            await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
-              owner: owner,
-              repo: repo,
-              pull_number: issue_number,
-              body: body,
-              headers: {
-                'X-GitHub-Api-Version': '2022-11-28'
-              }
-            }) 
+              const {data: comments} = await github.rest.issues.listComments(
+                {owner, repo, issue_number});
+                
+              const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->\n`;
+
+              body = old_body.split(marker)[0] + marker + body;
+              await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
+                owner: owner,
+                repo: repo,
+                pull_number: issue_number,
+                body: body,
+                headers: {
+                  'X-GitHub-Api-Version': '2022-11-28'
+                }
+              }) 
             }
-            
+
             const {owner, repo} = context.repo;
-            const run_id = context.runId;
-            
-            const pull_head_sha = context.payload.after;
-            const pull_user_id = context.payload.sender.id;
-            
-            
+            const run_id = ${{github.event.workflow_run.id}};
+
+            const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
+            const pull_user_id = ${{github.event.sender.id}};
+
+
             const {issue_number, old_body} = await (async () => {
-            const pulls = await github.rest.pulls.list({owner, repo});
-            for await (const {data} of github.paginate.iterator(pulls)) {
-              for (const pull of data) {
-                console.log(pull)
-                if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
-                  return {issue_number: pull.number, old_body: pull.body};
+              const pulls = await github.rest.pulls.list({owner, repo});
+              for await (const {data} of github.paginate.iterator(pulls)) {
+                for (const pull of data) {
+                  if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
+                    return {issue_number: pull.number, old_body: pull.body};
+                  }
                 }
               }
-            }
-            return {};
             })();
             if (issue_number) {
-            core.info(`Using pull request ${issue_number}`);
+              core.info(`Using pull request ${issue_number}`);
             } else {
-            return core.error(`No matching pull request found`);
+              return core.error(`No matching pull request found`);
             }
-            let templateName = "${{ inputs.artifact_name }}";
-            let templateLink = `https://nightly.link/${owner}/${repo}/actions/runs/${run_id}/${templateName}.zip`;
-            let body = ""
-            body += `## Download the template for this pull request: \n\n`;
-            body += `- via manual download: [${templateName}.zip](${templateLink})\n`;
-            body += "- via PROS Integrated Terminal: \n ```\n"
-            body += `curl -o ${templateName}.zip ${templateLink};\n`
-            body += `pros c fetch ${templateName}.zip;\n`
-            body += `pros c apply ${templateName};\n`
-            body += `rm ${templateName}.zip;\n`
-            body += "```\n";
-            body += "> [!NOTE] \n"
-            body += `> This is auto generated from [\`${context.workflow}\`](${ context.serverUrl }/${repo}/actions/runs/${run_id})\n`;  
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
+            if (!artifacts.length) {
+              return core.error(`No artifacts found`);
+            }
+            const template = artifacts[0];
+
+            let body = `## Download the template for this pull request: \n\n`;
+            body += `> [!NOTE]  
+            > This is auto generated from [\`${{ github.workflow }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
+            body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
+            body += `- via PROS Integrated Terminal: \n \`\`\`
+            curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;
+            pros c fetch ${template.name}.zip;
+            pros c apply ${template.name};
+            rm ${template.name}.zip;
+            \`\`\``;
             
             core.info(`Review thread message body: \n${body}`);
             
-            
-            await upsertComment(owner, repo, issue_number,
-              "nightly-link", old_body, body);
+            console.log(context.payload.workflow_run);
+            console.log(context.payload.workflow_run.pull_requests);
+
+              await upsertComment(owner, repo, issue_number,
+                "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -43,7 +43,7 @@ jobs:
             const {owner, repo} = context.repo;
             const run_id = context.runId;
             
-            const pull_head_sha = context.sha;
+            const pull_head_sha = context.payload.after;
             const pull_user_id = context.payload.sender.id;
             
             

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -57,6 +57,8 @@ jobs:
             } else {
             return core.error(`No matching pull request found`);
             }
+
+            console.log("run metadata:", {owner, repo, run_id})
             
             const artifacts = await github.paginate(
             github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -62,13 +62,13 @@ jobs:
             } else {
             return core.error(`No matching pull request found`);
             }
-            let templateName = context.payload.inputs.template_name;
+            let templateName = ${{ inputs.templateName }};
             let templateLink = `https://nightly.link/${owner}/${repo}/actions/runs/${run_id}/${templateName}.zip`;
             let body = ""
             body += `## Download the template for this pull request: \n\n`;
-            body += `- via manual download: [${templateName}.zip](${templateLink}.zip)\n`;
+            body += `- via manual download: [${templateName}.zip](${templateLink})\n`;
             body += "- via PROS Integrated Terminal: \n ```\n"
-            body += `curl -o ${templateName}.zip ${templateLink}.zip;\n`
+            body += `curl -o ${templateName}.zip ${templateLink};\n`
             body += `pros c fetch ${templateName}.zip;\n`
             body += `pros c apply ${templateName};\n`
             body += `rm ${templateName}.zip;\n`

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -67,7 +67,7 @@ jobs:
 
             let body = `## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
-            > This is auto generated from a workflow file\n`;  
+            > This is auto generated from [${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via PROS Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -18,6 +18,7 @@ jobs:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
+            console.log(context);
             async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
               const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -33,19 +33,6 @@ jobs:
                   'X-GitHub-Api-Version': '2022-11-28'
                 }
               }) 
-              // const existing = comments.filter((c) => c.body.includes(marker));
-              // if (existing.length > 0) {
-              //   const last = existing[existing.length - 1];
-              //   core.info(`Updating comment ${last.id}`);
-              //   await github.rest.issues.updateComment({
-              //     owner, repo,
-              //     body,
-              //     comment_id: last.id,
-              //   });
-              // } else {
-              //   core.info(`Creating a comment in issue / PR #${issue_number}`);
-              //   await github.rest.issues.createComment({issue_number, body, owner, repo});
-              // }
             }
 
             const {owner, repo} = context.repo;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -18,9 +18,6 @@ jobs:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
-            console.log(context);
-            console.log(context.payload.workflow_run);
-            console.log(context.payload.workflow_run.pull_requests);
             async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
               const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});
@@ -86,9 +83,6 @@ jobs:
             
             core.info(`Review thread message body: \n${body}`);
             
-            console.log(context.payload.workflow_run);
-            console.log(context.payload.workflow_run.pull_requests);
-            
-              await upsertComment(owner, repo, issue_number,
-                "nightly-link", old_body, body);
+            await upsertComment(owner, repo, issue_number,
+              "nightly-link", old_body, body);
           

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -17,26 +17,39 @@ jobs:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
+            const octokit = new Octokit({
+              auth: '${{ secrets.GITHUB_TOKEN }}'
+            })
+            
             async function upsertComment(owner, repo, issue_number, purpose, body) {
               const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});
+              
+              const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->`;
 
-              const marker = `<!-- bot: ${purpose} -->`;
-              body = marker + "\n" + body;
-
-              const existing = comments.filter((c) => c.body.includes(marker));
-              if (existing.length > 0) {
-                const last = existing[existing.length - 1];
-                core.info(`Updating comment ${last.id}`);
-                await github.rest.issues.updateComment({
-                  owner, repo,
-                  body,
-                  comment_id: last.id,
-                });
-              } else {
-                core.info(`Creating a comment in issue / PR #${issue_number}`);
-                await github.rest.issues.createComment({issue_number, body, owner, repo});
-              }
+              body = body.split(marker)[0] + marker + body;
+              await octokit.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
+                owner: owner,
+                repo: repo,
+                pull_number: issue_number,
+                body: body,
+                headers: {
+                  'X-GitHub-Api-Version': '2022-11-28'
+                }
+              }) 
+              # const existing = comments.filter((c) => c.body.includes(marker));
+              # if (existing.length > 0) {
+              #   const last = existing[existing.length - 1];
+              #   core.info(`Updating comment ${last.id}`);
+              #   await github.rest.issues.updateComment({
+              #     owner, repo,
+              #     body,
+              #     comment_id: last.id,
+              #   });
+              # } else {
+              #   core.info(`Creating a comment in issue / PR #${issue_number}`);
+              #   await github.rest.issues.createComment({issue_number, body, owner, repo});
+              # }
             }
 
             const {owner, repo} = context.repo;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -7,7 +7,7 @@ jobs:
   pr_comment:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    #test
+
     permissions: 
       pull-requests: write
     

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,6 +1,11 @@
 name: Add Template to Pull Request 
 on:
   workflow_call:
+    inputs:
+      artifact_name:
+        description: "Name of the artifact that was produced"
+        required: true
+        type: string
 jobs:
   pr_comment:
     # if Build Template was successful and ran on a branch that is currently the head in a pull request
@@ -57,26 +62,19 @@ jobs:
             } else {
             return core.error(`No matching pull request found`);
             }
-
-            console.log("run metadata:", {owner, repo, run_id})
-            
-            const artifacts = await github.paginate(
-            github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
-            if (!artifacts.length) {
-            return core.error(`No artifacts found`);
-            }
-            const template = artifacts[0];
-            
-            let body = `## Download the template for this pull request: \n\n`;
-            body += `> [!NOTE]  
-            > This is auto generated from [\`${context.workflow}\`](${ context.serverUrl }/${repo}/actions/runs/${run_id})\n`;  
-            body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
-            body += `- via PROS Integrated Terminal: \n \`\`\`
-            curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;
-            pros c fetch ${template.name}.zip;
-            pros c apply ${template.name};
-            rm ${template.name}.zip;
-            \`\`\``;
+            let templateName = context.payload.inputs.template_name;
+            let templateLink = `https://nightly.link/${owner}/${repo}/actions/runs/${run_id}/${templateName}.zip`;
+            let body = ""
+            body += `## Download the template for this pull request: \n\n`;
+            body += `- via manual download: [${templateName}.zip](${templateLink}.zip)\n`;
+            body += "- via PROS Integrated Terminal: \n ```\n"
+            body += `curl -o ${templateName}.zip ${templateLink}.zip;\n`
+            body += `pros c fetch ${templateName}.zip;\n`
+            body += `pros c apply ${templateName};\n`
+            body += `rm ${templateName}.zip;\n`
+            body += "```";
+            body += "> [!NOTE] \n"
+            body += `> This is auto generated from [\`${context.workflow}\`](${ context.serverUrl }/${repo}/actions/runs/${run_id})\n`;  
             
             core.info(`Review thread message body: \n${body}`);
             

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -22,7 +22,7 @@ jobs:
               {owner, repo, issue_number});
               
             const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->\n`;
-
+            
             body = old_body.split(marker)[0] + marker + body;
             await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
               owner: owner,
@@ -34,14 +34,14 @@ jobs:
               }
             }) 
             }
-
+            
             const {owner, repo} = context.repo;
-            const run_id = context.run_id;
-
+            const run_id = context.runId;
+            
             const pull_head_sha = context.sha;
             const pull_user_id = context.payload.sender.id;
-
-
+            
+            
             const {issue_number, old_body} = await (async () => {
             const pulls = await github.rest.pulls.list({owner, repo});
             for await (const {data} of github.paginate.iterator(pulls)) {
@@ -57,17 +57,17 @@ jobs:
             } else {
             return core.error(`No matching pull request found`);
             }
-
+            
             const artifacts = await github.paginate(
             github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
             if (!artifacts.length) {
             return core.error(`No artifacts found`);
             }
             const template = artifacts[0];
-          
+            
             let body = `## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
-            > This is auto generated from [\`${context.workflow}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
+            > This is auto generated from [\`${context.workflow}\`](${ context.serverUrl }/${repo}/actions/runs/${run_id})\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via PROS Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;
@@ -75,9 +75,9 @@ jobs:
             pros c apply ${template.name};
             rm ${template.name}.zip;
             \`\`\``;
-          
+            
             core.info(`Review thread message body: \n${body}`);
-
-
+            
+            
             await upsertComment(owner, repo, issue_number,
               "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -7,7 +7,7 @@ jobs:
   pr_comment:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    
+    #test
     permissions: 
       pull-requests: write
     

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,3 +1,5 @@
+# test
+
 name: Comment on pull request 
 on:
   workflow_run:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -62,7 +62,7 @@ jobs:
             const artifacts = await github.paginate(
               github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
             if (!artifacts.length) {
-              return core.error(`No artifacts found`);
+              return core.error(`No artifacts found, perhaps Build Template was skipped`);
             }
             const template = artifacts[0];
 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,4 +1,3 @@
-# quick test
 name: Comment on pull request 
 on:
   workflow_run:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -62,7 +62,7 @@ jobs:
             } else {
             return core.error(`No matching pull request found`);
             }
-            let templateName = ${{ inputs.templateName }};
+            let templateName = ${{ inputs.artifact_name }};
             let templateLink = `https://nightly.link/${owner}/${repo}/actions/runs/${run_id}/${templateName}.zip`;
             let body = ""
             body += `## Download the template for this pull request: \n\n`;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -5,7 +5,8 @@ on:
     types: [completed]
 jobs:
   pr_comment:
-    # if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    # if Build Template was successful and ran on a branch that is currently the head in a pull request
+    if: github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.pull_requests.*.head.sha, github.event.workflow_run.head_sha)
     runs-on: ubuntu-latest
 
     permissions: 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -79,7 +79,7 @@ jobs:
 
             let body = `## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
-            > This is auto generated`;  
+            > This is auto generated from [here](${{github.action_path}})`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via Pros Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -62,7 +62,7 @@ jobs:
             } else {
             return core.error(`No matching pull request found`);
             }
-            let templateName = ${{ inputs.artifact_name }};
+            let templateName = "${{ inputs.artifact_name }}";
             let templateLink = `https://nightly.link/${owner}/${repo}/actions/runs/${run_id}/${templateName}.zip`;
             let body = ""
             body += `## Download the template for this pull request: \n\n`;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -5,7 +5,7 @@ on:
     types: [completed]
 jobs:
   pr_comment:
-    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    # if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     permissions: 
@@ -76,12 +76,9 @@ jobs:
             rm ${template.name}.zip;
             \`\`\``;
             
-            core.info("Review thread message body:", body);
-            core.info(context);
-            console.log(context);
-            core.info(context.payload.workflow_run);
+            core.info(`Review thread message body: \n${body}`);
+            
             console.log(context.payload.workflow_run);
-            core.info(context.payload.workflow_run.event);
             console.log(context.payload.workflow_run.event);
 
               await upsertComment(owner, repo, issue_number,

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,3 +1,4 @@
+# quick test
 name: Comment on pull request 
 on:
   workflow_run:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -19,6 +19,8 @@ jobs:
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
             console.log(context);
+            console.log(context.workflow_run);
+            console.log(context.workflow_run.pull_requests);
             async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
               const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -4,7 +4,7 @@ on:
 jobs:
   pr_comment:
     # if Build Template was successful and ran on a branch that is currently the head in a pull request
-    if: github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.pull_requests.*.head.sha, github.event.workflow_run.head_sha)
+    # if: github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.pull_requests.*.head.sha, github.event.workflow_run.head_sha)
     runs-on: ubuntu-latest
 
     permissions: 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -67,7 +67,7 @@ jobs:
 
             let body = `## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
-            > This is auto generated from [${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
+            > This is auto generated from [`${{ github.workflow }}`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}}\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via PROS Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pr_comment:
     # if Build Template was successful and ran on a branch that is currently the head in a pull request
-    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     permissions: 
@@ -26,7 +26,7 @@ jobs:
                 {owner, repo, issue_number});
                 
               const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->\n`;
-
+            
               body = old_body.split(marker)[0] + marker + body;
               await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
                 owner: owner,
@@ -38,14 +38,14 @@ jobs:
                 }
               }) 
             }
-
+            
             const {owner, repo} = context.repo;
             const run_id = ${{github.event.workflow_run.id}};
-
+            
             const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
             const pull_user_id = ${{github.event.sender.id}};
-
-
+            
+            /** @type {{old_body: string}} */
             const {issue_number, old_body} = await (async () => {
               const pulls = await github.rest.pulls.list({owner, repo});
               for await (const {data} of github.paginate.iterator(pulls)) {
@@ -55,21 +55,25 @@ jobs:
                   }
                 }
               }
-            })();
+            })();            
             if (issue_number) {
               core.info(`Using pull request ${issue_number}`);
             } else {
               return core.error(`No matching pull request found`);
             }
-
+            
+            let old_sha = /\<\!-- commit-sha: (?<sha>[a-z0-9]+) --\>/i.exec(old_body).groups?.sha
+            if (old_sha != undefined && pull_head_sha == old_sha) return core.error("Comment is already up-to-date!")
+            
             const artifacts = await github.paginate(
               github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
             if (!artifacts.length) {
               return core.error(`No artifacts found, perhaps Build Template was skipped`);
             }
             const template = artifacts[0];
-
-            let body = `## Download the template for this pull request: \n\n`;
+            
+            let body = `<!-- commit-sha: ${pull_head_sha} -->\n`;
+            body +=`## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
             > This is auto generated from [\`${{ github.workflow }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
@@ -84,6 +88,7 @@ jobs:
             
             console.log(context.payload.workflow_run);
             console.log(context.payload.workflow_run.pull_requests);
-
+            
               await upsertComment(owner, repo, issue_number,
                 "nightly-link", old_body, body);
+          

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -38,9 +38,23 @@ jobs:
             const {owner, repo} = context.repo;
             const run_id = ${{github.event.workflow_run.id}};
 
-            const pull_requests = ${{ toJSON(github.event.workflow_run.pull_requests) }};
-            if (!pull_requests.length) {
-              return core.error("This workflow doesn't match any pull requests!");
+            const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
+            const pull_user_id = ${{github.event.sender.id}};
+
+            const issue_number = await (async () => {
+              const pulls = await github.pulls.list({owner, repo});
+              for await (const {data} of github.paginate.iterator(pulls)) {
+                for (const pull of data) {
+                  if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
+                    return pull.number;
+                  }
+                }
+              }
+            })();
+            if (issue_number) {
+              core.info(`Using pull request ${issue_number}`);
+            } else {
+              return core.error(`No matching pull request found`);
             }
 
             const artifacts = await github.paginate(
@@ -61,7 +75,5 @@ jobs:
             
             core.info("Review thread message body:", body);
 
-            for (const pr of pull_requests) {
-              await upsertComment(owner, repo, pr.number,
+              await upsertComment(owner, repo, issue_number,
                 "nightly-link", body);
-            }

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -42,7 +42,7 @@ jobs:
             const pull_user_id = ${{github.event.sender.id}};
 
             const issue_number = await (async () => {
-              const pulls = await github.pulls.list({owner, repo});
+              const pulls = await github.rest.pulls.list({owner, repo});
               for await (const {data} of github.paginate.iterator(pulls)) {
                 for (const pull of data) {
                   if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pr_comment:
     # if Build Template was successful and ran on a branch that is currently the head in a pull request
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
 
     permissions: 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -8,6 +8,10 @@ jobs:
   pr_comment:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    
+    permissions: 
+      pull-requests: write
+    
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -12,6 +12,9 @@ jobs:
       pull-requests: write
     
     steps:
+      - name: Print event context
+        run: echo ${{ github.event.workflow_run }}
+
       - uses: actions/github-script@v6
         with:
           # This snippet is public-domain, taken from

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,3 +1,4 @@
+# test #3
 name: Comment on pull request 
 on:
   workflow_run:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -19,8 +19,8 @@ jobs:
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
             console.log(context);
-            console.log(context.workflow_run);
-            console.log(context.workflow_run.pull_requests);
+            console.log(context.payload.workflow_run);
+            console.log(context.payload.workflow_run.pull_requests);
             async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
               const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -37,19 +37,19 @@ jobs:
                   'X-GitHub-Api-Version': '2022-11-28'
                 }
               }) 
-              # const existing = comments.filter((c) => c.body.includes(marker));
-              # if (existing.length > 0) {
-              #   const last = existing[existing.length - 1];
-              #   core.info(`Updating comment ${last.id}`);
-              #   await github.rest.issues.updateComment({
-              #     owner, repo,
-              #     body,
-              #     comment_id: last.id,
-              #   });
-              # } else {
-              #   core.info(`Creating a comment in issue / PR #${issue_number}`);
-              #   await github.rest.issues.createComment({issue_number, body, owner, repo});
-              # }
+              // const existing = comments.filter((c) => c.body.includes(marker));
+              // if (existing.length > 0) {
+              //   const last = existing[existing.length - 1];
+              //   core.info(`Updating comment ${last.id}`);
+              //   await github.rest.issues.updateComment({
+              //     owner, repo,
+              //     body,
+              //     comment_id: last.id,
+              //   });
+              // } else {
+              //   core.info(`Creating a comment in issue / PR #${issue_number}`);
+              //   await github.rest.issues.createComment({issue_number, body, owner, repo});
+              // }
             }
 
             const {owner, repo} = context.repo;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,5 +1,3 @@
-# test
-
 name: Comment on pull request 
 on:
   workflow_run:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -69,7 +69,7 @@ jobs:
             body += `> [!NOTE]  
             > This is auto generated from a workflow file\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
-            body += `- via Pros Integrated Terminal: \n \`\`\`
+            body += `- via PROS Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;
             pros c fetch ${template.name}.zip;
             pros c apply ${template.name};

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,4 +1,4 @@
-name: Comment on pull request 
+name: Add Template to Pull Request 
 on:
   workflow_run:
     workflows: ['Build Template']

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -17,69 +17,67 @@ jobs:
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
             console.log(context);
-          # async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
-          #   const {data: comments} = await github.rest.issues.listComments(
-          #     {owner, repo, issue_number});
+            async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
+            const {data: comments} = await github.rest.issues.listComments(
+              {owner, repo, issue_number});
               
-          #   const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->\n`;
+            const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->\n`;
 
-          #   body = old_body.split(marker)[0] + marker + body;
-          #   await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
-          #     owner: owner,
-          #     repo: repo,
-          #     pull_number: issue_number,
-          #     body: body,
-          #     headers: {
-          #       'X-GitHub-Api-Version': '2022-11-28'
-          #     }
-          #   }) 
-          # }
+            body = old_body.split(marker)[0] + marker + body;
+            await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
+              owner: owner,
+              repo: repo,
+              pull_number: issue_number,
+              body: body,
+              headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
+            }) 
+            }
 
-          # const {owner, repo} = context.repo;
-          # const run_id = ${{github.event.workflow_run.id}};
+            const {owner, repo} = context.repo;
+            const run_id = context.run_id;
 
-          # const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
-          # const pull_user_id = ${{github.event.sender.id}};
+            const pull_head_sha = context.sha;
+            const pull_user_id = context.payload.sender.id;
 
 
-          # const {issue_number, old_body} = await (async () => {
-          #   const pulls = await github.rest.pulls.list({owner, repo});
-          #   for await (const {data} of github.paginate.iterator(pulls)) {
-          #     for (const pull of data) {
-          #       if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
-          #         return {issue_number: pull.number, old_body: pull.body};
-          #       }
-          #     }
-          #   }
-          # })();
-          # if (issue_number) {
-          #   core.info(`Using pull request ${issue_number}`);
-          # } else {
-          #   return core.error(`No matching pull request found`);
-          # }
+            const {issue_number, old_body} = await (async () => {
+            const pulls = await github.rest.pulls.list({owner, repo});
+            for await (const {data} of github.paginate.iterator(pulls)) {
+              for (const pull of data) {
+                if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
+                  return {issue_number: pull.number, old_body: pull.body};
+                }
+              }
+            }
+            })();
+            if (issue_number) {
+            core.info(`Using pull request ${issue_number}`);
+            } else {
+            return core.error(`No matching pull request found`);
+            }
 
-          # const artifacts = await github.paginate(
-          #   github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
-          # if (!artifacts.length) {
-          #   return core.error(`No artifacts found`);
-          # }
-          # const template = artifacts[0];
-
-          # let body = `## Download the template for this pull request: \n\n`;
-          # body += `> [!NOTE]  
-          # > This is auto generated from [\`${{ github.workflow }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
-          # body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
-          # body += `- via PROS Integrated Terminal: \n \`\`\`
-          # curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;
-          # pros c fetch ${template.name}.zip;
-          # pros c apply ${template.name};
-          # rm ${template.name}.zip;
-          # \`\`\``;
+            const artifacts = await github.paginate(
+            github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
+            if (!artifacts.length) {
+            return core.error(`No artifacts found`);
+            }
+            const template = artifacts[0];
           
-          # core.info(`Review thread message body: \n${body}`);
+            let body = `## Download the template for this pull request: \n\n`;
+            body += `> [!NOTE]  
+            > This is auto generated from [\`${context.workflow}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
+            body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
+            body += `- via PROS Integrated Terminal: \n \`\`\`
+            curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;
+            pros c fetch ${template.name}.zip;
+            pros c apply ${template.name};
+            rm ${template.name}.zip;
+            \`\`\``;
           
-          # console.log(context.payload.workflow_run);
-          # console.log(context.payload.workflow_run.pull_requests);
+            core.info(`Review thread message body: \n${body}`);
 
-          #   await upsertComment(owner, repo, issue_number,
-          #     "nightly-link", old_body, body);
+
+            await upsertComment(owner, repo, issue_number,
+              "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -51,11 +51,13 @@ jobs:
             const pulls = await github.rest.pulls.list({owner, repo});
             for await (const {data} of github.paginate.iterator(pulls)) {
               for (const pull of data) {
+                console.log(pull)
                 if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
                   return {issue_number: pull.number, old_body: pull.body};
                 }
               }
             }
+            return {};
             })();
             if (issue_number) {
             core.info(`Using pull request ${issue_number}`);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -24,7 +24,7 @@ jobs:
               const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->`;
 
               body = body.split(marker)[0] + marker + body;
-              await github.rest.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
+              await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
                 owner: owner,
                 repo: repo,
                 pull_number: issue_number,

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -79,7 +79,7 @@ jobs:
 
             let body = `## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
-            > This is auto generated from [here](${{github.action_path}})`;  
+            > This is auto generated from [here](${{github.action_path}})\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via Pros Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   pr_comment:
     # if Build Template was successful and ran on a branch that is currently the head in a pull request
-    if: github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.pull_requests.*.head.sha, github.event.workflow_run.head_sha)
+    # if: github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.pull_requests.*.head.sha, github.event.workflow_run.head_sha)
     runs-on: ubuntu-latest
 
     permissions: 

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -77,12 +77,10 @@ jobs:
             \`\`\``;
             
             core.info("Review thread message body:", body);
-            core.info(${{github.event.workflow_run}});
-            console.log(${{github.event.workflow_run}});
-            core.info(context);
-            console.log(context);
-            core.info(github);
-            console.log(github);
+            core.info(context.worflow_run);
+            console.log(context.worflow_run);
+            core.info(context.worflow_run.event);
+            console.log(context.worflow_run.event);
 
               await upsertComment(owner, repo, issue_number,
                 "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -79,7 +79,7 @@ jobs:
             core.info(`Review thread message body: \n${body}`);
             
             console.log(context.payload.workflow_run);
-            console.log(context.payload.workflow_run.event);
+            console.log(context.payload.workflow_run.pull_requests);
 
               await upsertComment(owner, repo, issue_number,
                 "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -12,9 +12,6 @@ jobs:
       pull-requests: write
     
     steps:
-      - name: Print event context
-        run: echo ${{ github.event.workflow_run }}
-
       - uses: actions/github-script@v6
         with:
           # This snippet is public-domain, taken from
@@ -80,6 +77,12 @@ jobs:
             \`\`\``;
             
             core.info("Review thread message body:", body);
+            core.info(${{github.event.workflow_run}});
+            console.log(${{github.event.workflow_run}});
+            core.info(context);
+            console.log(context);
+            core.info(github);
+            console.log(github);
 
               await upsertComment(owner, repo, issue_number,
                 "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -17,12 +17,11 @@ jobs:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
-            async function upsertComment(owner, repo, issue_number, purpose, body) {
+            async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
               const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});
                 
               const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->`;
-              const old_body = ${{github.event.pull_request.body}}
 
               body = old_body.split(marker)[0] + marker + body;
               await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
@@ -55,12 +54,12 @@ jobs:
             const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
             const pull_user_id = ${{github.event.sender.id}};
 
-            const issue_number = await (async () => {
+            const {issue_number, old_body} = await (async () => {
               const pulls = await github.rest.pulls.list({owner, repo});
               for await (const {data} of github.paginate.iterator(pulls)) {
                 for (const pull of data) {
                   if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
-                    return pull.number;
+                    return {issue_number: pull.number, old_body: pull.body};
                   }
                 }
               }
@@ -90,4 +89,4 @@ jobs:
             core.info("Review thread message body:", body);
 
               await upsertComment(owner, repo, issue_number,
-                "nightly-link", body);
+                "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -18,69 +18,70 @@ jobs:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
-            async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
-              const {data: comments} = await github.rest.issues.listComments(
-                {owner, repo, issue_number});
-                
-              const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->\n`;
+            console.log(context);
+          # async function upsertComment(owner, repo, issue_number, purpose,old_body, body) {
+          #   const {data: comments} = await github.rest.issues.listComments(
+          #     {owner, repo, issue_number});
+              
+          #   const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->\n`;
 
-              body = old_body.split(marker)[0] + marker + body;
-              await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
-                owner: owner,
-                repo: repo,
-                pull_number: issue_number,
-                body: body,
-                headers: {
-                  'X-GitHub-Api-Version': '2022-11-28'
-                }
-              }) 
-            }
+          #   body = old_body.split(marker)[0] + marker + body;
+          #   await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
+          #     owner: owner,
+          #     repo: repo,
+          #     pull_number: issue_number,
+          #     body: body,
+          #     headers: {
+          #       'X-GitHub-Api-Version': '2022-11-28'
+          #     }
+          #   }) 
+          # }
 
-            const {owner, repo} = context.repo;
-            const run_id = ${{github.event.workflow_run.id}};
+          # const {owner, repo} = context.repo;
+          # const run_id = ${{github.event.workflow_run.id}};
 
-            const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
-            const pull_user_id = ${{github.event.sender.id}};
+          # const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
+          # const pull_user_id = ${{github.event.sender.id}};
 
 
-            const {issue_number, old_body} = await (async () => {
-              const pulls = await github.rest.pulls.list({owner, repo});
-              for await (const {data} of github.paginate.iterator(pulls)) {
-                for (const pull of data) {
-                  if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
-                    return {issue_number: pull.number, old_body: pull.body};
-                  }
-                }
-              }
-            })();
-            if (issue_number) {
-              core.info(`Using pull request ${issue_number}`);
-            } else {
-              return core.error(`No matching pull request found`);
-            }
+          # const {issue_number, old_body} = await (async () => {
+          #   const pulls = await github.rest.pulls.list({owner, repo});
+          #   for await (const {data} of github.paginate.iterator(pulls)) {
+          #     for (const pull of data) {
+          #       if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
+          #         return {issue_number: pull.number, old_body: pull.body};
+          #       }
+          #     }
+          #   }
+          # })();
+          # if (issue_number) {
+          #   core.info(`Using pull request ${issue_number}`);
+          # } else {
+          #   return core.error(`No matching pull request found`);
+          # }
 
-            const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
-            if (!artifacts.length) {
-              return core.error(`No artifacts found`);
-            }
-            const template = artifacts[0];
+          # const artifacts = await github.paginate(
+          #   github.rest.actions.listWorkflowRunArtifacts, {owner, repo, run_id});
+          # if (!artifacts.length) {
+          #   return core.error(`No artifacts found`);
+          # }
+          # const template = artifacts[0];
 
-            let body = `## Download the template for this pull request: \n\n`;
-            body += `> [!NOTE]  
-            > This is auto generated from [\`${{ github.workflow }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
-            body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
-            body += `- via PROS Integrated Terminal: \n \`\`\`
-            curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;
-            pros c fetch ${template.name}.zip;
-            pros c apply ${template.name};
-            rm ${template.name}.zip;
-            \`\`\``;
-            
-            core.info(`Review thread message body: \n${body}`);
-            
-            console.log(context.payload.workflow_run);
-            console.log(context.payload.workflow_run.pull_requests);
+          # let body = `## Download the template for this pull request: \n\n`;
+          # body += `> [!NOTE]  
+          # > This is auto generated from [\`${{ github.workflow }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
+          # body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
+          # body += `- via PROS Integrated Terminal: \n \`\`\`
+          # curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;
+          # pros c fetch ${template.name}.zip;
+          # pros c apply ${template.name};
+          # rm ${template.name}.zip;
+          # \`\`\``;
+          
+          # core.info(`Review thread message body: \n${body}`);
+          
+          # console.log(context.payload.workflow_run);
+          # console.log(context.payload.workflow_run.pull_requests);
 
-              await upsertComment(owner, repo, issue_number,
-                "nightly-link", old_body, body);
+          #   await upsertComment(owner, repo, issue_number,
+          #     "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,4 +1,3 @@
-#test
 name: Comment on pull request 
 on:
   workflow_run:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -67,7 +67,7 @@ jobs:
 
             let body = `## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
-            > This is auto generated from [`${{ github.workflow }}`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}}\n`;  
+            > This is auto generated from [`${{ github.workflow }}`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via PROS Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -67,7 +67,7 @@ jobs:
 
             let body = `## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
-            > This is auto generated from [`${{ github.workflow }}`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
+            > This is auto generated from [\`${{ github.workflow }}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via PROS Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -72,7 +72,7 @@ jobs:
             body += `pros c fetch ${templateName}.zip;\n`
             body += `pros c apply ${templateName};\n`
             body += `rm ${templateName}.zip;\n`
-            body += "```";
+            body += "```\n";
             body += "> [!NOTE] \n"
             body += `> This is auto generated from [\`${context.workflow}\`](${ context.serverUrl }/${repo}/actions/runs/${run_id})\n`;  
             

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -62,7 +62,7 @@ jobs:
               return core.error(`No matching pull request found`);
             }
             
-            let old_sha = /\<\!-- commit-sha: (?<sha>[a-z0-9]+) --\>/i.exec(old_body).groups?.sha
+            let old_sha = /\<\!-- commit-sha: (?<sha>[a-z0-9]+) --\>/i.exec(old_body)?.groups?.sha
             if (old_sha != undefined && pull_head_sha == old_sha) return core.error("Comment is already up-to-date!")
             
             const artifacts = await github.paginate(

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,4 +1,3 @@
-# test #3
 name: Comment on pull request 
 on:
   workflow_run:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,3 +1,4 @@
+#test
 name: Comment on pull request 
 on:
   workflow_run:

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -17,10 +17,6 @@ jobs:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
           script: |
-            const octokit = new Octokit({
-              auth: '${{ secrets.GITHUB_TOKEN }}'
-            })
-            
             async function upsertComment(owner, repo, issue_number, purpose, body) {
               const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});
@@ -28,7 +24,7 @@ jobs:
               const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->`;
 
               body = body.split(marker)[0] + marker + body;
-              await octokit.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
+              await github.rest.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
                 owner: owner,
                 repo: repo,
                 pull_number: issue_number,

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -79,7 +79,7 @@ jobs:
 
             let body = `## Download the template for this pull request: \n\n`;
             body += `> [!NOTE]  
-            > This is auto generated from [here](${{github.action_path}})\n`;  
+            > This is auto generated from [here](${{github.workflow_ref}})\n`;  
             body += `- via manual download: [${template.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip)\n`;
             body += `- via Pros Integrated Terminal: \n \`\`\`
             curl -o ${template.name}.zip https://nightly.link/${owner}/${repo}/actions/artifacts/${template.id}.zip;

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -77,10 +77,12 @@ jobs:
             \`\`\``;
             
             core.info("Review thread message body:", body);
-            core.info(context.workflow_run);
-            console.log(context.workflow_run);
-            core.info(context.workflow_run.event);
-            console.log(context.workflow_run.event);
+            core.info(context);
+            console.log(context);
+            core.info(context.payload.workflow_run);
+            console.log(context.payload.workflow_run);
+            core.info(context.payload.workflow_run.event);
+            console.log(context.payload.workflow_run.event);
 
               await upsertComment(owner, repo, issue_number,
                 "nightly-link", old_body, body);

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -20,10 +20,11 @@ jobs:
             async function upsertComment(owner, repo, issue_number, purpose, body) {
               const {data: comments} = await github.rest.issues.listComments(
                 {owner, repo, issue_number});
-              
+                
               const marker = `<!-- DO NOT REMOVE!! -->\n<!-- bot: ${purpose} -->`;
+              const old_body = ${{github.event.pull_request.body}}
 
-              body = body.split(marker)[0] + marker + body;
+              body = old_body.split(marker)[0] + marker + body;
               await github.request('PATCH /repos/{owner}/{repo}/pulls/{pull_number}', {
                 owner: owner,
                 repo: repo,

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -100,9 +100,4 @@ jobs:
           retention-days: 89
   comment-on-pr:
     needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2.3.4
-      - name: Run pr-comment
-        uses: ./.github/workflows/pr-comment.yml
+    uses: ./.github/workflows/pr-comment.yml

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -104,7 +104,7 @@ jobs:
           name: ${{steps.get-template-name.outputs.name}}
           path: 'template/*'
           retention-days: 89
-  comment-on-pr:
+  pr-comment:
     needs: build
     uses: ./.github/workflows/pr-comment.yml
     with: 

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -1,3 +1,4 @@
+#test
 name: Build Template
 
 on:

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -35,6 +35,8 @@ jobs:
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
+    outputs:
+      template-name: ${{ steps.get-template-name.outputs.name }}
     steps:
       - name: Get short SHA
         uses: benjlevesque/short-sha@v2.2
@@ -85,18 +87,25 @@ jobs:
 
       - name: Create template folder
         run: mkdir template
-
+      
+      - name: Get template name
+        id: get-template-name
+        run: |
+          echo "name=LemLib@${{ steps.get-version.outputs.version }}-c${{ env.SHA }}" >> "$GITHUB_OUTPUT"
+      
       - name: Unzip Template
         uses: montudor/action-zip@v1.0.0
         with:
-          args: unzip "LemLib@${{ steps.get-version.outputs.version }}-c${{ env.SHA }}.zip" -d template
+          args: unzip "${{steps.get-template-name.outputs.name}}.zip" -d template
   
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: LemLib@${{ steps.get-version.outputs.version }}-c${{ env.SHA }}
+          name: ${{steps.get-template-name.outputs.name}}
           path: 'template/*'
           retention-days: 89
   comment-on-pr:
     needs: build
     uses: ./.github/workflows/pr-comment.yml
+    with: 
+      artifact_name: ${{ needs.build.outputs.template-name}}

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -10,30 +10,30 @@ on:
   workflow_dispatch:
 
 jobs:
-  skip-check:
-    # Minimum permissions required by skip-duplicate-actions
-    permissions:
-      actions: write
-      contents: read
+  # skip-check:
+  #   # Minimum permissions required by skip-duplicate-actions
+  #   permissions:
+  #     actions: write
+  #     contents: read
 
-    # continue-on-error: true # Uncomment once integration is finished
-    runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v5
-        with:
-          # All of these options are optional, so you can remove them if you are happy with the defaults
-          concurrent_skipping: 'same_content_newer'
-          cancel_others: 'true'
-          paths: '["src/**", "include/**", "firmware/**", ".github/workflows/pros-build.yml", "**/*.mk", "**/project.pros", "**/Makefile"]'
-          do_not_skip: '["workflow_dispatch", "schedule"]'
+  #   # continue-on-error: true # Uncomment once integration is finished
+  #   runs-on: ubuntu-latest
+  #   # Map a step output to a job output
+  #   outputs:
+  #     should_skip: ${{ steps.skip_check.outputs.should_skip }}
+  #   steps:
+  #     - id: skip_check
+  #       uses: fkirc/skip-duplicate-actions@v5
+  #       with:
+  #         # All of these options are optional, so you can remove them if you are happy with the defaults
+  #         concurrent_skipping: 'same_content_newer'
+  #         cancel_others: 'true'
+  #         paths: '["src/**", "include/**", "firmware/**", ".github/workflows/pros-build.yml", "**/*.mk", "**/project.pros", "**/Makefile"]'
+  #         do_not_skip: '["workflow_dispatch", "schedule"]'
 
   build:
-    needs: skip-check
-    if: needs.skip-check.outputs.should_skip != 'true'
+    # needs: skip-check
+    # if: needs.skip-check.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Get short SHA

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    
     steps:
       - name: Get short SHA
         uses: benjlevesque/short-sha@v2.2

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -1,3 +1,4 @@
+#test
 name: Build Template
 
 on:
@@ -28,15 +29,13 @@ jobs:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
           cancel_others: 'true'
-          # paths: '["src/**", "include/**", "firmware/**", ".github/workflows/pros-build.yml", "**/*.mk", "**/project.pros", "**/Makefile"]'
+          paths: '["src/**", "include/**", "firmware/**", ".github/workflows/pros-build.yml", "**/*.mk", "**/project.pros", "**/Makefile"]'
           do_not_skip: '["workflow_dispatch", "schedule"]'
 
   build:
     needs: skip-check
     if: needs.skip-check.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
-    outputs:
-      template-name: ${{ steps.get-template-name.outputs.name }}
     steps:
       - name: Get short SHA
         uses: benjlevesque/short-sha@v2.2
@@ -87,27 +86,15 @@ jobs:
 
       - name: Create template folder
         run: mkdir template
-      
-      - name: Get template name
-        id: get-template-name
-        run: |
-          echo "name=LemLib@${{ steps.get-version.outputs.version }}-c${{ env.SHA }}" >> "$GITHUB_OUTPUT"
-      
+
       - name: Unzip Template
         uses: montudor/action-zip@v1.0.0
         with:
-          args: unzip "${{steps.get-template-name.outputs.name}}.zip" -d template
+          args: unzip "LemLib@${{ steps.get-version.outputs.version }}-c${{ env.SHA }}.zip" -d template
   
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: ${{steps.get-template-name.outputs.name}}
+          name: LemLib@${{ steps.get-version.outputs.version }}-c${{ env.SHA }}
           path: 'template/*'
           retention-days: 89
-  pr-comment:
-    needs: build
-    permissions: 
-      pull-requests: write
-    uses: ./.github/workflows/pr-comment.yml@master
-    with: 
-      artifact_name: ${{ needs.build.outputs.template-name}}

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           # All of these options are optional, so you can remove them if you are happy with the defaults
           concurrent_skipping: 'same_content_newer'
-          skip_after_successful_duplicate: 'true'
           cancel_others: 'true'
           paths: '["src/**", "include/**", "firmware/**", ".github/workflows/pros-build.yml", "**/*.mk", "**/project.pros", "**/Makefile"]'
           do_not_skip: '["workflow_dispatch", "schedule"]'

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -29,7 +29,7 @@ jobs:
           concurrent_skipping: 'same_content_newer'
           skip_after_successful_duplicate: 'true'
           cancel_others: 'true'
-          paths: '["src/**", "include/**", "firmware/**", ".github/workflows/pros-build.yml", "**/*.mk", "**/project.pros", "**/Makefile"]'
+          # paths: '["src/**", "include/**", "firmware/**", ".github/workflows/pros-build.yml", "**/*.mk", "**/project.pros", "**/Makefile"]'
           do_not_skip: '["workflow_dispatch", "schedule"]'
 
   build:

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -108,6 +108,6 @@ jobs:
     needs: build
     permissions: 
       pull-requests: write
-    uses: ./.github/workflows/pr-comment.yml
+    uses: ./.github/workflows/pr-comment.yml@master
     with: 
       artifact_name: ${{ needs.build.outputs.template-name}}

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -106,6 +106,8 @@ jobs:
           retention-days: 89
   pr-comment:
     needs: build
+    permissions: 
+      pull-requests: write
     uses: ./.github/workflows/pr-comment.yml
     with: 
       artifact_name: ${{ needs.build.outputs.template-name}}

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -10,30 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  # skip-check:
-  #   # Minimum permissions required by skip-duplicate-actions
-  #   permissions:
-  #     actions: write
-  #     contents: read
-
-  #   # continue-on-error: true # Uncomment once integration is finished
-  #   runs-on: ubuntu-latest
-  #   # Map a step output to a job output
-  #   outputs:
-  #     should_skip: ${{ steps.skip_check.outputs.should_skip }}
-  #   steps:
-  #     - id: skip_check
-  #       uses: fkirc/skip-duplicate-actions@v5
-  #       with:
-  #         # All of these options are optional, so you can remove them if you are happy with the defaults
-  #         concurrent_skipping: 'same_content_newer'
-  #         cancel_others: 'true'
-  #         paths: '["src/**", "include/**", "firmware/**", ".github/workflows/pros-build.yml", "**/*.mk", "**/project.pros", "**/Makefile"]'
-  #         do_not_skip: '["workflow_dispatch", "schedule"]'
-
   build:
-    # needs: skip-check
-    # if: needs.skip-check.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Get short SHA

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -102,5 +102,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
       - name: Run pr-comment
         uses: ./.github/workflows/pr-comment.yml

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -9,9 +9,32 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  skip-check:
+    # Minimum permissions required by skip-duplicate-actions
+    permissions:
+      actions: write
+      contents: read
+
+    # continue-on-error: true # Uncomment once integration is finished
     runs-on: ubuntu-latest
-    
+    # Map a step output to a job output
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v5
+        with:
+          # All of these options are optional, so you can remove them if you are happy with the defaults
+          concurrent_skipping: 'same_content_newer'
+          skip_after_successful_duplicate: 'true'
+          cancel_others: 'true'
+          paths: '["src/**", "include/**", "firmware/**", ".github/workflows/pros-build.yml", "**/*.mk", "**/project.pros", "**/Makefile"]'
+          do_not_skip: '["workflow_dispatch", "schedule"]'
+
+  build:
+    needs: skip-check
+    if: needs.skip-check.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
     steps:
       - name: Get short SHA
         uses: benjlevesque/short-sha@v2.2

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -1,4 +1,3 @@
-#test
 name: Build Template
 
 on:

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -98,3 +98,9 @@ jobs:
           name: LemLib@${{ steps.get-version.outputs.version }}-c${{ env.SHA }}
           path: 'template/*'
           retention-days: 89
+  comment-on-pr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run pr-comment
+        uses: ./.github/workflows/pr-comment.yml


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Triggered by both push and pull request, but checks whether the pr comment is up to date before editing the comment

#### Motivation
<!-- Why are you making this pull request? -->
Before, pr-comment was only triggered by pull_request events, which isn't triggered when the pr can't be automatically merged

#### Test Plan
<!-- How did you test / plan to test this pull request? -->
please work 🤞

But actually, I tested by making a pr from my second fork into my first fork and testing that it worked
#### Additional Notes
<!-- Add any other information you think is relevant -->

# SQUASH AND MERGE
# SQUASH AND MERGE
# SQUASH AND MERGE
# SQUASH AND MERGE<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/6792596500)
- via manual download: [LemLib@1.0.0-c3e6c35.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1035404898.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@1.0.0-c3e6c35.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1035404898.zip;
pros c fetch LemLib@1.0.0-c3e6c35.zip;
pros c apply LemLib@1.0.0-c3e6c35;
rm LemLib@1.0.0-c3e6c35.zip;
```