### PR TITLE
Fix data abort exception on imu calibration fail

### DIFF
--- a/src/lemlib/odom/differentialArc.cpp
+++ b/src/lemlib/odom/differentialArc.cpp
@@ -66,13 +66,25 @@ void DifferentialArc::calibrate(bool calibrateGyros) {
         pros::delay(10);
     }
 
+    // create new vector for gyros that calibrate
+    std::vector<std::shared_ptr<Gyro>> newGyros = {};
+
     // if a gyro failed to calibrate, output an error and erase the gyro
     for (auto it = gyros.begin(); it != gyros.end(); it++) {
         if (!(**it).isCalibrated()) {
-            infoSink()->warn("IMU on port {} failed to calibrate! Removing", (**it).getPort());
-            gyros.erase(it);
+            infoSink()->warn("IMU on port {} failed to calibrate! Removing...", (**it).getPort());
+            // original gyros.erase(it);
+            // doesnt work gyros.erase(std::next(gyros.begin(), std::distance(gyros.begin(), it)));
+        } else {
+            // if the gyro successfully calibrates, add it to the new vector
+            newGyros.push_back(*it);
         }
     }
+
+    // update the gyro vector
+    gyros = newGyros;
+
+    infoSink()->debug("Post-calibration Gyro vector size: {}", gyros.size());
 }
 
 /**

--- a/src/lemlib/odom/differentialArc.cpp
+++ b/src/lemlib/odom/differentialArc.cpp
@@ -56,8 +56,8 @@ void DifferentialArc::calibrate(bool calibrateGyros) {
     for (auto it = drivetrain.begin(); it != drivetrain.end(); it++) {
         if (it->reset()) {
             if (sgn(it->getOffset() == 1))
-                infoSink()->warn("Left drivetrain motor failed to calibrate!", it->getOffset());
-            else infoSink()->warn("Right drivetrain motor failed to calibrate!", it->getOffset());
+                infoSink()->warn("Left drivetrain motor failed to calibrate!");
+            else infoSink()->warn("Right drivetrain motor failed to calibrate!");
         } else newDrivetrain.push_back(*it);
     }
 

--- a/src/lemlib/odom/differentialArc.cpp
+++ b/src/lemlib/odom/differentialArc.cpp
@@ -1,4 +1,3 @@
-#include "lemlib/devices/trackingWheel.hpp"
 #include "lemlib/util.hpp"
 #include "lemlib/timer.hpp"
 #include "lemlib/logger/logger.hpp"
@@ -39,7 +38,6 @@ void DifferentialArc::calibrate(bool calibrateGyros) {
     for (auto it = verticals.begin(); it != verticals.end(); it++) {
         if (it->reset()) {
             infoSink()->warn("Vertical tracker at offset {} failed calibration!", it->getOffset());
-            verticals.erase(it);
         } else newVerticals.push_back(*it);
     }
 
@@ -47,7 +45,6 @@ void DifferentialArc::calibrate(bool calibrateGyros) {
     for (auto it = horizontals.begin(); it != horizontals.end(); it++) {
         if (it->reset()) {
             infoSink()->warn("Horizontal tracker at offset {} failed calibration!", it->getOffset());
-            horizontals.erase(it);
         } else newHorizontals.push_back(*it);
     }
 

--- a/src/lemlib/odom/differentialArc.cpp
+++ b/src/lemlib/odom/differentialArc.cpp
@@ -34,7 +34,6 @@ void DifferentialArc::calibrate(bool calibrateGyros) {
     std::vector<TrackingWheel> newHorizontals = {};
     std::vector<TrackingWheel> newDrivetrain = {};
     std::vector<std::shared_ptr<Gyro>> newGyros = {};
-    
 
     // calibrate vertical tracking wheels
     for (auto it = verticals.begin(); it != verticals.end(); it++) {
@@ -55,8 +54,7 @@ void DifferentialArc::calibrate(bool calibrateGyros) {
     // calibrate drivetrain motors
     for (auto it = drivetrain.begin(); it != drivetrain.end(); it++) {
         if (it->reset()) {
-            if (sgn(it->getOffset() == 1))
-                infoSink()->warn("Left drivetrain motor failed to calibrate!");
+            if (sgn(it->getOffset() == 1)) infoSink()->warn("Left drivetrain motor failed to calibrate!");
             else infoSink()->warn("Right drivetrain motor failed to calibrate!");
         } else newDrivetrain.push_back(*it);
     }


### PR DESCRIPTION
#### Summary
Creates a new vector for all successfully calibrated IMUs and updates the `gyro` vector to prevent a data race with `gyro.erase`.

#### Motivation
Liam asked me to fix this in the LemLib discord.

#### Test Plan
Has been tested with a brain and IMU, unplugged IMU during calibration and it does not throw data abort exception. After successful calibration, odometry appears to output correct heading value.

#### Additional Notes
None<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 79607cedfab0fec8b9f0f67ccc1cb4648a33fbf4 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/6922665957)
- via manual download: [LemLib@1.0.0-cb5e7cc.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1060069036.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@1.0.0-cb5e7cc.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1060069036.zip;
pros c fetch LemLib@1.0.0-cb5e7cc.zip;
pros c apply LemLib@1.0.0-cb5e7cc;
rm LemLib@1.0.0-cb5e7cc.zip;
```