### PR TITLE
Drive Motor Velocity Controller Based on the move_velocity Function

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -269,6 +269,13 @@ class Chassis {
          */
         void turnAtSpeed(float speed, bool clockwise = true, bool radians = true);
         /**
+        * @brief Accelerate a motor group to a target speed (RPM) 
+        *
+        * @param motorGroup the target motor group
+        * @param speed speed to move at in RPM
+        */
+        void moveVelocity(pros::MotorGroup* motorGroup, float targetVelocity, int controllerChoice = 1);
+        /**
          * @brief Control the robot during the driver control period using the tank drive control scheme. In
          * this control scheme one joystick axis controls one half of the robot, and another joystick axis
          * controls another.

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -262,11 +262,11 @@ class Chassis {
          */
         void moveAtSpeed(float speed, bool forwards = true);
         /**
-        * @brief Move the chassis at a specific speed
-        *
-        * @param speed speed to move at in degree/s
-        * @param clockwise whether to move cw or ccw, true by default
-        */
+         * @brief Move the chassis at a specific speed
+         *
+         * @param speed speed to move at in degree/s
+         * @param clockwise whether to move cw or ccw, true by default
+         */
         void turnAtSpeed(float speed, bool clockwise = true, bool radians = true);
         /**
          * @brief Control the robot during the driver control period using the tank drive control scheme. In

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -255,6 +255,20 @@ class Chassis {
          */
         void follow(const asset& path, float lookahead, int timeout, bool forwards = true, bool async = true);
         /**
+         * @brief Move the chassis at a specific speed
+         *
+         * @param speed speed to move at in in/s
+         * @param forwards whether to move forwards or backwards
+         */
+        void moveAtSpeed(float speed, bool forwards = true);
+        /**
+        * @brief Move the chassis at a specific speed
+        *
+        * @param speed speed to move at in degree/s
+        * @param clockwise whether to move cw or ccw, true by default
+        */
+        void turnAtSpeed(float speed, bool clockwise = true, bool radians = true);
+        /**
          * @brief Control the robot during the driver control period using the tank drive control scheme. In
          * this control scheme one joystick axis controls one half of the robot, and another joystick axis
          * controls another.

--- a/include/lemlib/util.hpp
+++ b/include/lemlib/util.hpp
@@ -70,6 +70,14 @@ template <typename T> constexpr T sgn(T value) { return value < 0 ? -1 : 1; }
 float avg(std::vector<float> values);
 
 /**
+ * @brief Return the average of a vector of numbers
+ *
+ * @param values
+ * @return double
+ */
+double avg(std::vector<double> values);
+
+/**
  * @brief Exponential moving average
  *
  * @param current current measurement

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -540,7 +540,7 @@ void lemlib::Chassis::moveAtSpeed(float speed, bool forwards) {
  * @brief Turn the chassis at a specific speed
  * TODO: make a custom move_velocity (moveVelocity)
  *
- * @param speed speed to move at in rad/s or in/s
+ * @param speed speed to move at in rad/s or degrees/s
  * @param clockwise whether to move cw or ccw, true by default
  * @param radians if the speed is in rad/s, true by default
  */

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -504,7 +504,8 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, 
 }
 
 /**
- * @brief Move the chassis at a specific speed
+ * @brief Move the chassis at a specific speed 
+ * TODO: make a custom move_velocity (moveVelocity)
  *
  * @param speed speed to move at in in/s
  * @param forwards whether to move forwards or backwards, true by default
@@ -538,6 +539,7 @@ void lemlib::Chassis::moveAtSpeed(float speed, bool forwards) {
 
 /**
  * @brief Turn the chassis at a specific speed
+ * TODO: make a custom move_velocity (moveVelocity)
  *
  * @param speed speed to move at in rad/s or in/s
  * @param clockwise whether to move cw or ccw, true by default
@@ -587,3 +589,4 @@ void lemlib::Chassis::turnAtSpeed(float speed, bool clockwise, bool radians) {
         else drivetrain.leftMotors[i].move_velocity(-motorOutput);
     }
 }
+

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -502,3 +502,88 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, 
     // give the mutex back
     mutex.give();
 }
+
+/**
+ * @brief Move the chassis at a specific speed
+ *
+ * @param speed speed to move at in in/s
+ * @param forwards whether to move forwards or backwards, true by default
+ */
+void lemlib::Chassis::moveAtSpeed(float speed, bool forwards) { 
+    // find gearing 
+    std::vector<pros::motor_gearset_e_t> gearsets = drivetrain.leftMotors->get_gearing();
+    float maxRPM;
+    float motorOutput;
+
+    switch (gearsets[1]) {
+        case pros::E_MOTOR_GEARSET_36: maxRPM = 100; break;
+        case pros::E_MOTOR_GEARSET_18: maxRPM = 200; break;
+        case pros::E_MOTOR_GEARSET_06: maxRPM = 600; break;
+        default: maxRPM = 600; break;
+    }
+
+    // calculate the necessary RPM
+    motorOutput = speed * (maxRPM/drivetrain.rpm) * 60 * (1 / (M_PI * drivetrain.wheelDiameter));
+
+    // apply motorOutput
+    if (forwards) {
+        drivetrain.leftMotors->move_velocity(motorOutput);
+        drivetrain.rightMotors->move_velocity(motorOutput);
+    }
+    else {
+        drivetrain.leftMotors->move_velocity(-motorOutput);
+        drivetrain.rightMotors->move_velocity(-motorOutput);
+    }
+}
+
+/**
+ * @brief Turn the chassis at a specific speed
+ *
+ * @param speed speed to move at in rad/s or in/s
+ * @param clockwise whether to move cw or ccw, true by default
+ * @param radians if the speed is in rad/s, true by default
+ */
+void lemlib::Chassis::turnAtSpeed(float speed, bool clockwise, bool radians) { 
+    float maxRPM;
+    float motorOutput;
+
+    // left side motors loop
+    std::vector<pros::motor_gearset_e_t> gearsets = drivetrain.leftMotors->get_gearing();
+    for (int i = 0; i < drivetrain.leftMotors->size(); i++) {
+
+        switch (gearsets[i]) {
+            case pros::E_MOTOR_GEARSET_36: maxRPM = 100; break;
+            case pros::E_MOTOR_GEARSET_18: maxRPM = 200; break;
+            case pros::E_MOTOR_GEARSET_06: maxRPM = 600; break;
+            default: maxRPM = 600; break;
+        }
+
+        // calculate the necessary RPM
+        if (radians) motorOutput = speed * 1.0/2 * 60.0 * maxRPM / drivetrain.rpm;
+        else motorOutput = speed * 1.0/2 * 60.0 * maxRPM / drivetrain.rpm * 360;
+
+        // apply motorOutput
+        if (clockwise) drivetrain.leftMotors[i].move_velocity(motorOutput);
+        else drivetrain.leftMotors[i].move_velocity(-motorOutput);
+    }
+
+    // right side motors loop
+    gearsets = drivetrain.rightMotors->get_gearing();
+    for (int i = 0; i < drivetrain.rightMotors->size(); i++) {
+
+        switch (gearsets[i]) {
+            case pros::E_MOTOR_GEARSET_36: maxRPM = 100; break;
+            case pros::E_MOTOR_GEARSET_18: maxRPM = 200; break;
+            case pros::E_MOTOR_GEARSET_06: maxRPM = 600; break;
+            default: maxRPM = 600; break;
+        }
+
+        // calculate the necessary RPM
+        if (radians) motorOutput = speed * 1.0/2 * 60.0 * maxRPM / drivetrain.rpm;
+        else motorOutput = speed * 1.0/2 * 60.0 * maxRPM / drivetrain.rpm * 360;
+
+        // apply motorOutput
+        if (clockwise) drivetrain.leftMotors[i].move_velocity(motorOutput);
+        else drivetrain.leftMotors[i].move_velocity(-motorOutput);
+    }
+}

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -523,7 +523,7 @@ void lemlib::Chassis::moveAtSpeed(float speed, bool forwards) {
     }
 
     // calculate the necessary RPM
-    motorOutput = speed * (maxRPM/drivetrain.rpm) * 60 * (1 / (M_PI * drivetrain.wheelDiameter));
+    motorOutput = speed * (maxRPM / drivetrain.rpm) * 60 * (1 / (M_PI * drivetrain.wheelDiameter));
 
     // apply motorOutput
     if (forwards) {
@@ -559,8 +559,8 @@ void lemlib::Chassis::turnAtSpeed(float speed, bool clockwise, bool radians) {
         }
 
         // calculate the necessary RPM
-        if (radians) motorOutput = speed * 1.0/2 * 60.0 * maxRPM / drivetrain.rpm;
-        else motorOutput = speed * 1.0/2 * 60.0 * maxRPM / drivetrain.rpm * 360;
+        if (radians) motorOutput = speed * (1.0/2) * 60 * (maxRPM / drivetrain.rpm);
+        else motorOutput = speed * (1.0/2) * 60.0 * (maxRPM / drivetrain.rpm) * 360;
 
         // apply motorOutput
         if (clockwise) drivetrain.leftMotors[i].move_velocity(motorOutput);
@@ -579,8 +579,8 @@ void lemlib::Chassis::turnAtSpeed(float speed, bool clockwise, bool radians) {
         }
 
         // calculate the necessary RPM
-        if (radians) motorOutput = speed * 1.0/2 * 60.0 * maxRPM / drivetrain.rpm;
-        else motorOutput = speed * 1.0/2 * 60.0 * maxRPM / drivetrain.rpm * 360;
+        if (radians) motorOutput = speed * (1.0/2) * 60 * (maxRPM / drivetrain.rpm);
+        else motorOutput = speed * (1.0/2) * 60.0 * (maxRPM / drivetrain.rpm) * 360;
 
         // apply motorOutput
         if (clockwise) drivetrain.leftMotors[i].move_velocity(motorOutput);

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -504,14 +504,14 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, 
 }
 
 /**
- * @brief Move the chassis at a specific speed 
+ * @brief Move the chassis at a specific speed
  * TODO: make a custom move_velocity (moveVelocity)
  *
  * @param speed speed to move at in in/s
  * @param forwards whether to move forwards or backwards, true by default
  */
-void lemlib::Chassis::moveAtSpeed(float speed, bool forwards) { 
-    // find gearing 
+void lemlib::Chassis::moveAtSpeed(float speed, bool forwards) {
+    // find gearing
     std::vector<pros::motor_gearset_e_t> gearsets = drivetrain.leftMotors->get_gearing();
     float maxRPM;
     float motorOutput;
@@ -530,8 +530,7 @@ void lemlib::Chassis::moveAtSpeed(float speed, bool forwards) {
     if (forwards) {
         drivetrain.leftMotors->move_velocity(motorOutput);
         drivetrain.rightMotors->move_velocity(motorOutput);
-    }
-    else {
+    } else {
         drivetrain.leftMotors->move_velocity(-motorOutput);
         drivetrain.rightMotors->move_velocity(-motorOutput);
     }
@@ -545,14 +544,13 @@ void lemlib::Chassis::moveAtSpeed(float speed, bool forwards) {
  * @param clockwise whether to move cw or ccw, true by default
  * @param radians if the speed is in rad/s, true by default
  */
-void lemlib::Chassis::turnAtSpeed(float speed, bool clockwise, bool radians) { 
+void lemlib::Chassis::turnAtSpeed(float speed, bool clockwise, bool radians) {
     float maxRPM;
     float motorOutput;
 
     // left side motors loop
     std::vector<pros::motor_gearset_e_t> gearsets = drivetrain.leftMotors->get_gearing();
     for (int i = 0; i < drivetrain.leftMotors->size(); i++) {
-
         switch (gearsets[i]) {
             case pros::E_MOTOR_GEARSET_36: maxRPM = 100; break;
             case pros::E_MOTOR_GEARSET_18: maxRPM = 200; break;
@@ -561,8 +559,8 @@ void lemlib::Chassis::turnAtSpeed(float speed, bool clockwise, bool radians) {
         }
 
         // calculate the necessary RPM
-        if (radians) motorOutput = speed * (1.0/2) * 60 * (maxRPM / drivetrain.rpm);
-        else motorOutput = speed * (1.0/2) * 60.0 * (maxRPM / drivetrain.rpm) * 360;
+        if (radians) motorOutput = speed * (1.0 / 2) * 60 * (maxRPM / drivetrain.rpm);
+        else motorOutput = speed * (1.0 / 2) * 60.0 * (maxRPM / drivetrain.rpm) * 360;
 
         // apply motorOutput
         if (clockwise) drivetrain.leftMotors[i].move_velocity(motorOutput);
@@ -572,7 +570,6 @@ void lemlib::Chassis::turnAtSpeed(float speed, bool clockwise, bool radians) {
     // right side motors loop
     gearsets = drivetrain.rightMotors->get_gearing();
     for (int i = 0; i < drivetrain.rightMotors->size(); i++) {
-
         switch (gearsets[i]) {
             case pros::E_MOTOR_GEARSET_36: maxRPM = 100; break;
             case pros::E_MOTOR_GEARSET_18: maxRPM = 200; break;
@@ -581,12 +578,11 @@ void lemlib::Chassis::turnAtSpeed(float speed, bool clockwise, bool radians) {
         }
 
         // calculate the necessary RPM
-        if (radians) motorOutput = speed * (1.0/2) * 60 * (maxRPM / drivetrain.rpm);
-        else motorOutput = speed * (1.0/2) * 60.0 * (maxRPM / drivetrain.rpm) * 360;
+        if (radians) motorOutput = speed * (1.0 / 2) * 60 * (maxRPM / drivetrain.rpm);
+        else motorOutput = speed * (1.0 / 2) * 60.0 * (maxRPM / drivetrain.rpm) * 360;
 
         // apply motorOutput
         if (clockwise) drivetrain.leftMotors[i].move_velocity(motorOutput);
         else drivetrain.leftMotors[i].move_velocity(-motorOutput);
     }
 }
-

--- a/src/lemlib/util.cpp
+++ b/src/lemlib/util.cpp
@@ -54,6 +54,18 @@ float lemlib::avg(std::vector<float> values) {
 }
 
 /**
+ * @brief Return the average of a vector of numbers
+ *
+ * @param values
+ * @return double
+ */
+double lemlib::avg(std::vector<double> values) {
+    double sum = 0;
+    for (double value : values) { sum += value; }
+    return (float) sum / values.size();
+}
+
+/**
  * @brief Exponential moving average
  *
  * @param current current measurement

--- a/src/lemlib/util.cpp
+++ b/src/lemlib/util.cpp
@@ -57,7 +57,7 @@ float lemlib::avg(std::vector<float> values) {
  * @brief Return the average of a vector of numbers
  *
  * @param values
- * @return double
+ * @return casted float
  */
 double lemlib::avg(std::vector<double> values) {
     double sum = 0;

--- a/src/lemlib/util.cpp
+++ b/src/lemlib/util.cpp
@@ -62,7 +62,7 @@ float lemlib::avg(std::vector<float> values) {
 double lemlib::avg(std::vector<double> values) {
     double sum = 0;
     for (double value : values) { sum += value; }
-    return (float) sum / values.size();
+    return (float)sum / values.size();
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include "lemlib/api.hpp"
 #include "lemlib/logger/stdout.hpp"
 #include "pros/misc.h"
+#include "pros/rtos.h"
 
 // controller
 pros::Controller controller(pros::E_CONTROLLER_MASTER);
@@ -152,6 +153,19 @@ void opcontrol() {
         int rightX = controller.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_X);
         // move the chassis with curvature drive
         chassis.curvature(leftY, rightX);
+
+        // testing moveAtSpeed and turnAtSpeed
+        if (controller.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_A)) {
+            chassis.moveAtSpeed(10);
+            pros::c::delay(1000);
+            chassis.moveAtSpeed(0);
+        }
+        if (controller.get_digital_new_press(pros::E_CONTROLLER_DIGITAL_B)) {
+            chassis.turnAtSpeed(2);
+            pros::c::delay(1000);
+            chassis.moveAtSpeed(0);
+        }
+
         // delay to save resources
         pros::delay(10);
     }


### PR DESCRIPTION
#### Summary
Creates functions to set the chassis to move in in/s or turn in rad/s using chassis information and move_velocity() function.

#### Motivation
Make the move options more versatile for motors.

#### Test Plan
Run on own robot or have someone else run it. Set motors to speeds that coincide with nice angles at 1 second, 2 seconds, etc. 

#### Additional Notes
Temporary fix/starting point for a proper solution once velocity controllers are implemented. Needs to be reworked to use move voltage and have some sort of feedback loop like a PID or TBH controller in place of the built-in move_velocity function.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: c658638d6a2248f9139f071f72a08aaef6fd3ae7 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/6964698941)
- via manual download: [LemLib@0.5.0-rc1+c65863.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1068361745.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc1+c65863.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1068361745.zip;
pros c fetch LemLib@0.5.0-rc1+c65863.zip;
pros c apply LemLib@0.5.0-rc1+c65863;
rm LemLib@0.5.0-rc1+c65863.zip;
```