### PR TITLE
:sparkles: Implement gain scheduling

### DIFF
--- a/include/lemlib/pid.hpp
+++ b/include/lemlib/pid.hpp
@@ -15,39 +15,38 @@
 
 namespace lemlib {
 struct Gains {
-    float kF = 0;
-    float kA = 0;
-    float kP = 0;
-    float kI = 0;
-    float kD = 0;
+        float kF = 0;
+        float kA = 0;
+        float kP = 0;
+        float kI = 0;
+        float kD = 0;
 };
 
 /** @brief A function taking the target and the (target, Gains) elements adjacent to it, computing the resulting gains
-*/
+ */
 using Interpolator = std::function<Gains(float, std::pair<float, Gains>, std::pair<float, Gains>)>;
 
 /**
-* @brief A gain interpolator that selects the gains with the closest target
-*
-* @param target the target at which to interpolate
-* @param below the lower adjacent (target, Gains) value
-* @param above the higher adjacent (target, Gains) value
-*
-* @returns the interpolated gains
-*/
+ * @brief A gain interpolator that selects the gains with the closest target
+ *
+ * @param target the target at which to interpolate
+ * @param below the lower adjacent (target, Gains) value
+ * @param above the higher adjacent (target, Gains) value
+ *
+ * @returns the interpolated gains
+ */
 Gains interpolateNearest(float target, std::pair<float, Gains> below, std::pair<float, Gains> above);
 
 /**
-* @brief A gain interpolator that linearly interpolates gains
-*
-* @param target the target at which to interpolate
-* @param below the lower adjacent (target, Gains) value
-* @param above the higher adjacent (target, Gains) value
-*
-* @returns the interpolated gains
-*/
+ * @brief A gain interpolator that linearly interpolates gains
+ *
+ * @param target the target at which to interpolate
+ * @param below the lower adjacent (target, Gains) value
+ * @param above the higher adjacent (target, Gains) value
+ *
+ * @returns the interpolated gains
+ */
 Gains interpolateLinear(float, std::pair<float, Gains>, std::pair<float, Gains>);
-
 
 /**
  * @brief Feedforward, Acceleration, Proportional, Integral, Derivative PID controller
@@ -69,7 +68,7 @@ class FAPID {
          * @param name name of the FAPID. Used for logging
          */
         FAPID(float kF, float kA, float kP, float kI, float kD, std::string name);
-        
+
         /**
          * @brief Construct a new FAPID
          *
@@ -86,7 +85,7 @@ class FAPID {
          * @param name name of the FAPID. Used for logging
          */
         FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, std::string name);
-        
+
         /**
          * @brief Construct a new FAPID
          *
@@ -96,7 +95,7 @@ class FAPID {
          * @param name name of the FAPID. Used for logging
          */
         FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, Interpolator interpolator, std::string name);
-        
+
         /**
          * @brief Set gains
          *
@@ -189,7 +188,8 @@ class FAPID {
         // The gains the PID will use
         Gains currentGains;
 
-        // A function taking the target and the elements adjacent to the target in the (target, gain) set, computing the final gains
+        // A function taking the target and the elements adjacent to the target in the (target, gain) set, computing the
+        // final gains
         Interpolator gainInterpolator = interpolateNearest;
 
         float previousTarget = 0;
@@ -213,6 +213,5 @@ class FAPID {
         static pros::Task* logTask;
         static pros::Mutex logMutex;
 };
-
 
 } // namespace lemlib

--- a/include/lemlib/pid.hpp
+++ b/include/lemlib/pid.hpp
@@ -10,9 +10,45 @@
  */
 #pragma once
 #include <string>
+#include <set>
 #include "pros/rtos.hpp"
 
 namespace lemlib {
+struct Gains {
+    float kF = 0;
+    float kA = 0;
+    float kP = 0;
+    float kI = 0;
+    float kD = 0;
+};
+
+/** @brief A function taking the target and the (target, Gains) elements adjacent to it, computing the resulting gains
+*/
+using Interpolator = std::function<Gains(float, std::pair<float, Gains>, std::pair<float, Gains>)>;
+
+/**
+* @brief A gain interpolator that selects the gains with the closest target
+*
+* @param target the target at which to interpolate
+* @param below the lower adjacent (target, Gains) value
+* @param above the higher adjacent (target, Gains) value
+*
+* @returns the interpolated gains
+*/
+Gains interpolateNearest(float target, std::pair<float, Gains> below, std::pair<float, Gains> above);
+
+/**
+* @brief A gain interpolator that linearly interpolates gains
+*
+* @param target the target at which to interpolate
+* @param below the lower adjacent (target, Gains) value
+* @param above the higher adjacent (target, Gains) value
+*
+* @returns the interpolated gains
+*/
+Gains interpolateLinear(float, std::pair<float, Gains>, std::pair<float, Gains>);
+
+
 /**
  * @brief Feedforward, Acceleration, Proportional, Integral, Derivative PID controller
  *
@@ -33,6 +69,34 @@ class FAPID {
          * @param name name of the FAPID. Used for logging
          */
         FAPID(float kF, float kA, float kP, float kI, float kD, std::string name);
+        
+        /**
+         * @brief Construct a new FAPID
+         *
+         * @param gains the gains for the FAPID to use
+         * @param name name of the FAPID. Used for logging
+         */
+        FAPID(Gains gains, std::string name);
+
+        /**
+         * @brief Construct a new FAPID
+         *
+         * @param gains the default gains for the FAPID to use
+         * @param scheduled a set of (target, Gains) pairs to use for gain scheduling
+         * @param name name of the FAPID. Used for logging
+         */
+        FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, std::string name);
+        
+        /**
+         * @brief Construct a new FAPID
+         *
+         * @param gains the default gains for the FAPID to use
+         * @param scheduled a set of (target, Gains) pairs to use for gain scheduling
+         * @param interpolator the function to use when interpolating gains when scheduling
+         * @param name name of the FAPID. Used for logging
+         */
+        FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, Interpolator interpolator, std::string name);
+        
         /**
          * @brief Set gains
          *
@@ -43,6 +107,28 @@ class FAPID {
          * @param kD derivative gain, multiplied by change in error and added to output
          */
         void setGains(float kF, float kA, float kP, float kI, float kD);
+
+        /**
+         * @brief Set gains
+         *
+         * @param gains the new gains
+         */
+        void setGains(Gains gains);
+
+        /**
+         * @brief Set scheduled gains
+         *
+         * @param gains the new scheduled gains
+         */
+        void setScheduledGains(std::set<std::pair<float, Gains>> scheduled);
+
+        /**
+         * @brief Set gain interpolator
+         *
+         * @param gains the new gain interpolator
+         */
+        void setGainInterpolator(Interpolator interpolator);
+
         /**
          * @brief Set the exit conditions
          *
@@ -63,6 +149,7 @@ class FAPID {
          * @return float - output
          */
         float update(float target, float position, bool log = false);
+
         /**
          * @brief Reset the FAPID
          */
@@ -96,12 +183,16 @@ class FAPID {
          */
         static void init();
     private:
-        float kF;
-        float kA;
-        float kP;
-        float kI;
-        float kD;
+        // An ordered set of (target, Gains) pairs for gain scheduling
+        std::set<std::pair<float, Gains>> scheduledGains = {};
 
+        // The gains the PID will use
+        Gains currentGains;
+
+        // A function taking the target and the elements adjacent to the target in the (target, gain) set, computing the final gains
+        Interpolator gainInterpolator = interpolateNearest;
+
+        float previousTarget = 0;
         float largeError;
         float smallError;
         int largeTime = 0;
@@ -122,4 +213,6 @@ class FAPID {
         static pros::Task* logTask;
         static pros::Mutex logMutex;
 };
+
+
 } // namespace lemlib

--- a/include/lemlib/util.hpp
+++ b/include/lemlib/util.hpp
@@ -124,4 +124,17 @@ Waypoint closestWaypoint(const std::vector<Waypoint>& waypoints, const Pose& tar
  * multiple intersections, the first one will be returned
  */
 Pose circleLineIntersect(Pose p1, Pose p2, Pose center, float radius);
+
+/*
+ * @brief Linearly interpolate two points
+ *
+ * @param x the x value to interpolate
+ * @param x1 the x value of the lower adjacent coordinate
+ * @param y1 the y value of the lower adjacent coordinate
+ * @param x2 the x value of the upper adjacent coordinate
+ * @param y2 the y value of the upper adjacent coordinate
+ * @return the interpolated y value
+ */
+float linearInterp(float x, float x1, float y1, float x2, float y2);
+
 } // namespace lemlib

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -9,7 +9,10 @@
  *
  */
 
+#include <algorithm>
+#include <cmath>
 #include <iostream>
+#include <limits>
 #include <math.h>
 #include "lemlib/pid.hpp"
 #include "lemlib/util.hpp"
@@ -30,12 +33,48 @@ pros::Mutex FAPID::logMutex = pros::Mutex();
  * @param kD derivative gain, multiplied by change in error and added to output
  * @param name name of the FAPID. Used for logging
  */
-FAPID::FAPID(float kF, float kA, float kP, float kI, float kD, std::string name) {
-    this->kF = kF;
-    this->kA = kA;
-    this->kP = kP;
-    this->kI = kI;
-    this->kD = kD;
+lemlib::FAPID::FAPID(float kF, float kA, float kP, float kI, float kD, std::string name) {
+    auto gains = Gains {kF, kA, kP, kI, kD};
+    currentGains = gains;
+    this->name = name;
+}
+
+/**
+* @brief Construct a new FAPID
+*
+* @param gains the gains for the FAPID to use
+* @param name name of the FAPID. Used for logging
+*/
+lemlib::FAPID::FAPID(Gains gains, std::string name) {
+    currentGains = gains;
+    this->name = name;
+}
+
+/**
+* @brief Construct a new FAPID
+*
+* @param gains the default gains for the FAPID to use
+* @param scheduled a set of (target, Gains) pairs to use for gain scheduling
+* @param name name of the FAPID. Used for logging
+*/
+lemlib::FAPID::FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, std::string name) {
+    currentGains = gains;
+    scheduledGains = scheduled;
+    this->name = name;
+}
+
+/**
+* @brief Construct a new FAPID
+*
+* @param gains the default gains for the FAPID to use
+* @param scheduled a set of (target, Gains) pairs to use for gain scheduling
+* @param interpolator the function to use when interpolating gains when scheduling
+* @param name name of the FAPID. Used for logging
+*/
+lemlib::FAPID::FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, Interpolator interpolator, std::string name) {
+    currentGains = gains;
+    scheduledGains = scheduled;
+    gainInterpolator = interpolator;
     this->name = name;
 }
 
@@ -48,12 +87,36 @@ FAPID::FAPID(float kF, float kA, float kP, float kI, float kD, std::string name)
  * @param kI integral gain, multiplied by total error and added to output
  * @param kD derivative gain, multiplied by change in error and added to output
  */
-void FAPID::setGains(float kF, float kA, float kP, float kI, float kD) {
-    this->kF = kF;
-    this->kA = kA;
-    this->kP = kP;
-    this->kI = kI;
-    this->kD = kD;
+void lemlib::FAPID::setGains(float kF, float kA, float kP, float kI, float kD) {
+    auto gains = Gains {kF, kA, kP, kI, kD};
+    currentGains = gains;
+}
+
+/**
+* @brief Set gains
+*
+* @param gains the new gains
+*/
+void lemlib::FAPID::setGains(Gains gains) {
+    currentGains = gains;
+}
+
+/**
+* @brief Set scheduled gains
+*
+* @param gains the new scheduled gains
+*/
+void lemlib::FAPID::setScheduledGains(std::set<std::pair<float, Gains>> scheduled) {
+    scheduledGains = scheduled;
+}
+
+/**
+* @brief Set gain interpolator
+*
+* @param gains the new gain interpolator
+*/
+void lemlib::FAPID::setGainInterpolator(Interpolator interpolator) {
+    gainInterpolator = interpolator;
 }
 
 /**
@@ -74,6 +137,50 @@ void FAPID::setExit(float largeError, float smallError, int largeTime, int small
 }
 
 /**
+* @brief A gain interpolator that selects the gains with the closest target
+*
+* @param target the target at which to interpolate
+* @param below the lower adjacent (target, Gains) value
+* @param above the higher adjacent (target, Gains) value
+*
+* @returns the interpolated gains
+*/
+lemlib::Gains interpolateNearest(float target, std::pair<float, Gains> below, std::pair<float, Gains> above) {
+    if(std::abs(target - below.first) < std::abs(target - above.first)) {
+        return below.second;
+    } else {
+        return above.second;
+    }
+}
+
+/**
+* @brief A gain interpolator that linearly interpolates gains
+*
+* @param target the target at which to interpolate
+* @param below the lower adjacent (target, Gains) value
+* @param above the higher adjacent (target, Gains) value
+*
+* @returns the interpolated gains
+*/
+lemlib::Gains interpolateLinear(float target, std::pair<float, Gains> below, std::pair<float, Gains> above) {
+    auto nearest = lemlib::interpolateNearest(target, below, above);
+    auto [x1, y1] = below;
+    auto [x2, y2] = above;
+
+    // Should kF and kA be interpolated? 
+    // It seems that feedforward constants should remain the same
+
+    auto kF = nearest.kF;
+    auto kA = nearest.kA;
+
+    auto kP = lemlib::linearInterp(target, x1, y1.kP, x2, y2.kP);
+    auto kI = lemlib::linearInterp(target, x1, y1.kI, x2, y2.kI);
+    auto kD = lemlib::linearInterp(target, x1, y1.kD, x2, y2.kD);
+    
+    return Gains{ kF, kA, kP, kI, kD };
+}
+
+/**
  * @brief Update the FAPID
  *
  * @param target the target value
@@ -82,10 +189,26 @@ void FAPID::setExit(float largeError, float smallError, int largeTime, int small
  * PIDs could slow down the program.
  * @return float - output
  */
-float FAPID::update(float target, float position, bool log) {
+float lemlib::FAPID::update(float target, float position, bool log) {
+    // Check if we have scheduled gains, and if we have a different target
+    if (!scheduledGains.empty() && previousTarget != target) {
+        auto upper = std::upper_bound(
+            scheduledGains.begin(), 
+            scheduledGains.end(), 
+            target, 
+            [](auto value, auto entry ) { return value < entry.first; });
+        
+        // Nearest scheduled gains above and below (or equal) the target
+        auto above = *upper;
+        auto below = upper == scheduledGains.begin() ? *upper : *(--upper);
+        currentGains = gainInterpolator(target, below, above);
+    }
+
     // check most recent input if logging is enabled
     // this does not run by default because the mutexes could slow down the program
     // calculate output
+
+    auto [kF, kA, kP, kI, kD] = currentGains;
     float error = target - position;
     float deltaError = error - prevError;
     float output = kF * target + kP * error + kI * totalError + kD * deltaError;
@@ -174,32 +297,32 @@ void FAPID::log() {
             if (input == "reset()") {
                 reset();
             } else if (input == "kF") {
-                std::cout << kF << std::endl;
+                std::cout << currentGains.kF << std::endl;
             } else if (input == "kA") {
-                std::cout << kA << std::endl;
+                std::cout << currentGains.kA << std::endl;
             } else if (input == "kP") {
-                std::cout << kP << std::endl;
+                std::cout << currentGains.kP << std::endl;
             } else if (input == "kI") {
-                std::cout << kI << std::endl;
+                std::cout << currentGains.kI << std::endl;
             } else if (input == "kD") {
-                std::cout << kD << std::endl;
+                std::cout << currentGains.kD << std::endl;
             } else if (input == "totalError") {
                 std::cout << totalError << std::endl;
             } else if (input.find("kF_") == 0) {
                 input.erase(0, 3);
-                kF = std::stof(input);
+                currentGains.kF = std::stof(input);
             } else if (input.find("kA_") == 0) {
                 input.erase(0, 3);
-                kA = std::stof(input);
+                currentGains.kA = std::stof(input);
             } else if (input.find("kP_") == 0) {
                 input.erase(0, 3);
-                kP = std::stof(input);
+                currentGains.kP = std::stof(input);
             } else if (input.find("kI_") == 0) {
                 input.erase(0, 3);
-                kI = std::stof(input);
+                currentGains.kI = std::stof(input);
             } else if (input.find("kD_") == 0) {
                 input.erase(0, 3);
-                kD = std::stof(input);
+                currentGains.kD = std::stof(input);
             }
             // clear the input
             input = "";

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -34,8 +34,7 @@ pros::Mutex FAPID::logMutex = pros::Mutex();
  * @param name name of the FAPID. Used for logging
  */
 lemlib::FAPID::FAPID(float kF, float kA, float kP, float kI, float kD, std::string name) {
-    auto gains = Gains {kF, kA, kP, kI, kD};
-    currentGains = gains;
+    currentGains = Gains {kF, kA, kP, kI, kD};
     this->name = name;
 }
 

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -40,23 +40,23 @@ lemlib::FAPID::FAPID(float kF, float kA, float kP, float kI, float kD, std::stri
 }
 
 /**
-* @brief Construct a new FAPID
-*
-* @param gains the gains for the FAPID to use
-* @param name name of the FAPID. Used for logging
-*/
+ * @brief Construct a new FAPID
+ *
+ * @param gains the gains for the FAPID to use
+ * @param name name of the FAPID. Used for logging
+ */
 lemlib::FAPID::FAPID(Gains gains, std::string name) {
     currentGains = gains;
     this->name = name;
 }
 
 /**
-* @brief Construct a new FAPID
-*
-* @param gains the default gains for the FAPID to use
-* @param scheduled a set of (target, Gains) pairs to use for gain scheduling
-* @param name name of the FAPID. Used for logging
-*/
+ * @brief Construct a new FAPID
+ *
+ * @param gains the default gains for the FAPID to use
+ * @param scheduled a set of (target, Gains) pairs to use for gain scheduling
+ * @param name name of the FAPID. Used for logging
+ */
 lemlib::FAPID::FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, std::string name) {
     currentGains = gains;
     scheduledGains = scheduled;
@@ -64,14 +64,15 @@ lemlib::FAPID::FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, s
 }
 
 /**
-* @brief Construct a new FAPID
-*
-* @param gains the default gains for the FAPID to use
-* @param scheduled a set of (target, Gains) pairs to use for gain scheduling
-* @param interpolator the function to use when interpolating gains when scheduling
-* @param name name of the FAPID. Used for logging
-*/
-lemlib::FAPID::FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, Interpolator interpolator, std::string name) {
+ * @brief Construct a new FAPID
+ *
+ * @param gains the default gains for the FAPID to use
+ * @param scheduled a set of (target, Gains) pairs to use for gain scheduling
+ * @param interpolator the function to use when interpolating gains when scheduling
+ * @param name name of the FAPID. Used for logging
+ */
+lemlib::FAPID::FAPID(Gains gains, std::set<std::pair<float, Gains>> scheduled, Interpolator interpolator,
+                     std::string name) {
     currentGains = gains;
     scheduledGains = scheduled;
     gainInterpolator = interpolator;
@@ -93,31 +94,25 @@ void lemlib::FAPID::setGains(float kF, float kA, float kP, float kI, float kD) {
 }
 
 /**
-* @brief Set gains
-*
-* @param gains the new gains
-*/
-void lemlib::FAPID::setGains(Gains gains) {
-    currentGains = gains;
-}
+ * @brief Set gains
+ *
+ * @param gains the new gains
+ */
+void lemlib::FAPID::setGains(Gains gains) { currentGains = gains; }
 
 /**
-* @brief Set scheduled gains
-*
-* @param gains the new scheduled gains
-*/
-void lemlib::FAPID::setScheduledGains(std::set<std::pair<float, Gains>> scheduled) {
-    scheduledGains = scheduled;
-}
+ * @brief Set scheduled gains
+ *
+ * @param gains the new scheduled gains
+ */
+void lemlib::FAPID::setScheduledGains(std::set<std::pair<float, Gains>> scheduled) { scheduledGains = scheduled; }
 
 /**
-* @brief Set gain interpolator
-*
-* @param gains the new gain interpolator
-*/
-void lemlib::FAPID::setGainInterpolator(Interpolator interpolator) {
-    gainInterpolator = interpolator;
-}
+ * @brief Set gain interpolator
+ *
+ * @param gains the new gain interpolator
+ */
+void lemlib::FAPID::setGainInterpolator(Interpolator interpolator) { gainInterpolator = interpolator; }
 
 /**
  * @brief Set the exit conditions
@@ -137,16 +132,16 @@ void FAPID::setExit(float largeError, float smallError, int largeTime, int small
 }
 
 /**
-* @brief A gain interpolator that selects the gains with the closest target
-*
-* @param target the target at which to interpolate
-* @param below the lower adjacent (target, Gains) value
-* @param above the higher adjacent (target, Gains) value
-*
-* @returns the interpolated gains
-*/
+ * @brief A gain interpolator that selects the gains with the closest target
+ *
+ * @param target the target at which to interpolate
+ * @param below the lower adjacent (target, Gains) value
+ * @param above the higher adjacent (target, Gains) value
+ *
+ * @returns the interpolated gains
+ */
 lemlib::Gains interpolateNearest(float target, std::pair<float, Gains> below, std::pair<float, Gains> above) {
-    if(std::abs(target - below.first) < std::abs(target - above.first)) {
+    if (std::abs(target - below.first) < std::abs(target - above.first)) {
         return below.second;
     } else {
         return above.second;
@@ -154,20 +149,20 @@ lemlib::Gains interpolateNearest(float target, std::pair<float, Gains> below, st
 }
 
 /**
-* @brief A gain interpolator that linearly interpolates gains
-*
-* @param target the target at which to interpolate
-* @param below the lower adjacent (target, Gains) value
-* @param above the higher adjacent (target, Gains) value
-*
-* @returns the interpolated gains
-*/
+ * @brief A gain interpolator that linearly interpolates gains
+ *
+ * @param target the target at which to interpolate
+ * @param below the lower adjacent (target, Gains) value
+ * @param above the higher adjacent (target, Gains) value
+ *
+ * @returns the interpolated gains
+ */
 lemlib::Gains interpolateLinear(float target, std::pair<float, Gains> below, std::pair<float, Gains> above) {
     auto nearest = lemlib::interpolateNearest(target, below, above);
     auto [x1, y1] = below;
     auto [x2, y2] = above;
 
-    // Should kF and kA be interpolated? 
+    // Should kF and kA be interpolated?
     // It seems that feedforward constants should remain the same
 
     auto kF = nearest.kF;
@@ -176,8 +171,8 @@ lemlib::Gains interpolateLinear(float target, std::pair<float, Gains> below, std
     auto kP = lemlib::linearInterp(target, x1, y1.kP, x2, y2.kP);
     auto kI = lemlib::linearInterp(target, x1, y1.kI, x2, y2.kI);
     auto kD = lemlib::linearInterp(target, x1, y1.kD, x2, y2.kD);
-    
-    return Gains{ kF, kA, kP, kI, kD };
+
+    return Gains {kF, kA, kP, kI, kD};
 }
 
 /**
@@ -192,12 +187,9 @@ lemlib::Gains interpolateLinear(float target, std::pair<float, Gains> below, std
 float lemlib::FAPID::update(float target, float position, bool log) {
     // Check if we have scheduled gains, and if we have a different target
     if (!scheduledGains.empty() && previousTarget != target) {
-        auto upper = std::upper_bound(
-            scheduledGains.begin(), 
-            scheduledGains.end(), 
-            target, 
-            [](auto value, auto entry ) { return value < entry.first; });
-        
+        auto upper = std::upper_bound(scheduledGains.begin(), scheduledGains.end(), target,
+                                      [](auto value, auto entry) { return value < entry.first; });
+
         // Nearest scheduled gains above and below (or equal) the target
         auto above = *upper;
         auto below = upper == scheduledGains.begin() ? *upper : *(--upper);

--- a/src/lemlib/util.cpp
+++ b/src/lemlib/util.cpp
@@ -195,12 +195,9 @@ Pose circleLineIntersect(Pose p1, Pose p2, Pose center, float radius) {
  * @return the interpolated y value
  */
 float linearInterp(float x, float x1, float y1, float x2, float y2) {
-    if (x2 - x1 == 0) {
-        return y1;
-    }
+    if (x2 - x1 == 0) { return y1; }
 
     return y1 + (x - x1) * ((y2 - y1) / (x2 - x1));
 }
 
 }; // namespace lemlib
-

--- a/src/lemlib/util.cpp
+++ b/src/lemlib/util.cpp
@@ -183,4 +183,24 @@ Pose circleLineIntersect(Pose p1, Pose p2, Pose center, float radius) {
     // no intersection found
     return center;
 }
+
+/*
+ * @brief Linearly interpolate two points
+ *
+ * @param x the x value to interpolate
+ * @param x1 the x value of the lower adjacent coordinate
+ * @param y1 the y value of the lower adjacent coordinate
+ * @param x2 the x value of the upper adjacent coordinate
+ * @param y2 the y value of the upper adjacent coordinate
+ * @return the interpolated y value
+ */
+float linearInterp(float x, float x1, float y1, float x2, float y2) {
+    if (x2 - x1 == 0) {
+        return y1;
+    }
+
+    return y1 + (x - x1) * ((y2 - y1) / (x2 - x1));
+}
+
 }; // namespace lemlib
+

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -43,3 +43,18 @@ TEST(UtilsTest, ema) {
     float output = lemlib::ema(127, 0, 0.5);
     EXPECT_FLOAT_EQ(output, 63.5);
 }
+
+TEST(UtilsTest, linearInterp) {
+    float output = lemlib::linearInterp(5, 0, 0, 10, 10);
+    EXPECT_FLOAT_EQ(output, 5);
+}
+
+TEST(UtilsTest, linearInterp) {
+    float output = lemlib::linearInterp(5, 0, 0, 10, 20);
+    EXPECT_FLOAT_EQ(output, 10);
+}
+
+TEST(UtilsTest, linearInterp) {
+    float output = lemlib::linearInterp(0, 1, 1, 1, 1);
+    EXPECT_FLOAT_EQ(output, 1);
+}

--- a/test/util.cpp
+++ b/test/util.cpp
@@ -44,17 +44,17 @@ TEST(UtilsTest, ema) {
     EXPECT_FLOAT_EQ(output, 63.5);
 }
 
-TEST(UtilsTest, linearInterp) {
+TEST(UtilsTest, linearInterp1) {
     float output = lemlib::linearInterp(5, 0, 0, 10, 10);
     EXPECT_FLOAT_EQ(output, 5);
 }
 
-TEST(UtilsTest, linearInterp) {
+TEST(UtilsTest, linearInterp2) {
     float output = lemlib::linearInterp(5, 0, 0, 10, 20);
     EXPECT_FLOAT_EQ(output, 10);
 }
 
-TEST(UtilsTest, linearInterp) {
+TEST(UtilsTest, linearInterpDivBy0) {
     float output = lemlib::linearInterp(0, 1, 1, 1, 1);
     EXPECT_FLOAT_EQ(output, 1);
 }


### PR DESCRIPTION
Implement gain scheduling, and a way to easily modify interpolation behavior by taking a user-specified function. Implements #46 

#### Summary
Provides a way to set the gains based on the target/set-point of the PID, as well as ways to interpolate between these gains. Constants do not change during movement.

#### Motivation
This was a requested feature in #46. Because of the non-linear nature of robots, it can be difficult to find PID constants that are effective across the whole robots range of motion. Gain scheduling allows for an easy an automatic way to adjust constants based on the set-point, and gain more consistent performance.

#### Test Plan
It compiles without any warnings, but there are no unit tests as of now.

#### Additional Notes
<!-- Add any other information you think is relevant -->
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: e09eedf54ab13fc0c85fdff4ab7247d5408f2c8e -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/6997385034)
- via manual download: [LemLib@0.5.0-rc1-cb78624.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1073853218.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc1-cb78624.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1073853218.zip;
pros c fetch LemLib@0.5.0-rc1-cb78624.zip;
pros c apply LemLib@0.5.0-rc1-cb78624;
rm LemLib@0.5.0-rc1-cb78624.zip;
```