### PR TITLE
Remove IMU errno calibration check

### DIFF
--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -106,8 +106,7 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
     if (sensors.imu != nullptr && calibrateIMU) {
         int attempt = 1;
         // calibrate inertial, and if calibration fails, then repeat 5 times or until successful
-        while (sensors.imu->reset(true) != 1 && (errno == PROS_ERR || errno == ENODEV || errno == ENXIO) &&
-               attempt < 5) {
+        while (sensors.imu->reset(true) != 1 && attempt < 5) {
             pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, "---");
             pros::delay(10);
             attempt++;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -105,6 +105,7 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
     // calibrate the IMU if it exists and the user doesn't specify otherwise
     if (sensors.imu != nullptr && calibrateIMU) {
         int attempt = 1;
+      
         // calibrate inertial, and if calibration fails, then repeat 5 times or until successful
         while (sensors.imu->reset(true) != 1 && attempt < 5) {
             pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, "---");

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -105,7 +105,6 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
     // calibrate the IMU if it exists and the user doesn't specify otherwise
     if (sensors.imu != nullptr && calibrateIMU) {
         int attempt = 1;
-      
         // calibrate inertial, and if calibration fails, then repeat 5 times or until successful
         while (sensors.imu->reset(true) != 1 && attempt < 5) {
             pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, "---");


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Makes it such that the imu will calibrate until it has attempted to 5 times, or until `imu.reset()` returns true.
#### Motivation
<!-- Why are you making this pull request? -->
@BattleCh1cken had a problem, where if the port is incorrect, the imu still ends up being used. This set `errno` to `EADDRINUSE`, which means `Address already in use`.
#### Test Plan
<!-- How did you test / plan to test this pull request? -->

#### Additional Notes
<!-- Add any other information you think is relevant -->

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: fc3ccc0067560b62352337f1b3e33be67ea7a460 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7000061300)
- via manual download: [LemLib@0.5.0-rc1+fc3ccc.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1074185346.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc1+fc3ccc.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1074185346.zip;
pros c fetch LemLib@0.5.0-rc1+fc3ccc.zip;
pros c apply LemLib@0.5.0-rc1+fc3ccc;
rm LemLib@0.5.0-rc1+fc3ccc.zip;
```