### PR TITLE
Add turnCurveGain for Differential

### DIFF
--- a/include/lemlib/chassis/differential.hpp
+++ b/include/lemlib/chassis/differential.hpp
@@ -272,7 +272,7 @@ class Differential : public Chassis {
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
          * of 0 disables the curve entirely.
          */
-        void tank(int left, int right, leftCurveGain = 0.0, rightCurveGain = 0.0,
+        void tank(int left, int right, float leftCurveGain = 0.0, float rightCurveGain = 0.0,
                   const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
 
         /**

--- a/include/lemlib/chassis/differential.hpp
+++ b/include/lemlib/chassis/differential.hpp
@@ -296,8 +296,8 @@ class Differential : public Chassis {
          * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
          * curve, refer to the `defaultDriveCurve` documentation.
          */
-        void curvature(int throttle, int turn, float cureGain = 0.0,
-                       const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
+        void curvature(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0,
+                    const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
     private:
         /**
          * @brief Chassis update function. Updates chassis motion and odometry

--- a/include/lemlib/chassis/differential.hpp
+++ b/include/lemlib/chassis/differential.hpp
@@ -272,7 +272,7 @@ class Differential : public Chassis {
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve. A value
          * of 0 disables the curve entirely.
          */
-        void tank(int left, int right, float curveGain = 0.0,
+        void tank(int left, int right, leftCurveGain = 0.0, rightCurveGain = 0.0,
                   const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
 
         /**
@@ -284,7 +284,7 @@ class Differential : public Chassis {
          * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
          * curve, refer to the `defaultDriveCurve` documentation.
          */
-        void arcade(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0,
+        void arcade(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0.0,
                     const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
         /**
          * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
@@ -296,7 +296,7 @@ class Differential : public Chassis {
          * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
          * curve, refer to the `defaultDriveCurve` documentation.
          */
-        void curvature(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0,
+        void curvature(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0.0,
                        const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
     private:
         /**

--- a/include/lemlib/chassis/differential.hpp
+++ b/include/lemlib/chassis/differential.hpp
@@ -284,8 +284,8 @@ class Differential : public Chassis {
          * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
          * curve, refer to the `defaultDriveCurve` documentation.
          */
-        void arcade(int throttle, int turn, float linearCurveGain = 0.0,
-                    float turnCurveGain = 0, const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
+        void arcade(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0,
+                  const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
         /**
          * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
          * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the

--- a/include/lemlib/chassis/differential.hpp
+++ b/include/lemlib/chassis/differential.hpp
@@ -284,9 +284,8 @@ class Differential : public Chassis {
          * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
          * curve, refer to the `defaultDriveCurve` documentation.
          */
-        void arcade(int throttle, int turn, float curveGain = 0.0,
-                    const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
-
+        void arcade(int throttle, int turn, float linearCurveGain = 0.0,
+                    float turnCurveGain = 0, const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
         /**
          * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
          * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the

--- a/include/lemlib/chassis/differential.hpp
+++ b/include/lemlib/chassis/differential.hpp
@@ -297,7 +297,7 @@ class Differential : public Chassis {
          * curve, refer to the `defaultDriveCurve` documentation.
          */
         void curvature(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0,
-                    const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
+                       const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
     private:
         /**
          * @brief Chassis update function. Updates chassis motion and odometry

--- a/include/lemlib/chassis/differential.hpp
+++ b/include/lemlib/chassis/differential.hpp
@@ -285,7 +285,7 @@ class Differential : public Chassis {
          * curve, refer to the `defaultDriveCurve` documentation.
          */
         void arcade(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0,
-                  const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
+                    const DriveCurveFunction_t& driveCurve = defaultDriveCurve);
         /**
          * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
          * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the

--- a/src/lemlib/chassis/differential.cpp
+++ b/src/lemlib/chassis/differential.cpp
@@ -270,7 +270,8 @@ void Differential::arcade(int throttle, int turn, float linearCurveGain, float t
  * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
  * curve, refer to the `defaultDriveCurve` documentation.
  */
-void Differential::tank(int left, int right, float leftCurveGain, float rightCurveGain, const DriveCurveFunction_t& driveCurve) {
+void Differential::tank(int left, int right, float leftCurveGain, float rightCurveGain,
+                        const DriveCurveFunction_t& driveCurve) {
     this->drivetrain->leftMotors->move(driveCurve(left, leftCurveGain));
     this->drivetrain->rightMotors->move(driveCurve(right, rightCurveGain));
 }

--- a/src/lemlib/chassis/differential.cpp
+++ b/src/lemlib/chassis/differential.cpp
@@ -270,8 +270,8 @@ void Differential::arcade(int throttle, int turn, float linearCurveGain, float t
  * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
  * curve, refer to the `defaultDriveCurve` documentation.
  */
-void Differential::tank(int left, int right, float curveGain, const DriveCurveFunction_t& driveCurve) {
-    this->drivetrain->leftMotors->move(driveCurve(left, curveGain));
-    this->drivetrain->rightMotors->move(driveCurve(right, curveGain));
+void Differential::tank(int left, int right, float leftCurveGain, float rightCurveGain, const DriveCurveFunction_t& driveCurve) {
+    this->drivetrain->leftMotors->move(driveCurve(left, leftCurveGain));
+    this->drivetrain->rightMotors->move(driveCurve(right, rightCurveGain));
 }
 }; // namespace lemlib

--- a/src/lemlib/chassis/differential.cpp
+++ b/src/lemlib/chassis/differential.cpp
@@ -251,11 +251,11 @@ void Differential::curvature(int throttle, int turn, float curveGain, const Driv
  * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
  * curve, refer to the `defaultDriveCurve` documentation.
  */
-void Differential::arcade(int throttle, int turn, float linearCurveGain, float turnCurveGain, const DriveCurveFunction_t& driveCurve) {
-    int leftPower = driveCurve(throttle + turn, curveGain);
-    int rightPower = driveCurve(throttle - turn, turnCurveGain);
-    this->drivetrain->leftMotors->move(leftPower);
-    this->drivetrain->rightMotors->move(rightPower);
+void Differential::arcade(int throttle, int turn, float linearCurveGain, float turnCurveGain,
+                          const DriveCurveFunction_t& driveCurve) {
+     int leftPower = driveCurve(throttle + turn, curveGain);
+     int rightPower = driveCurve(throttle - turn, turnCurveGain);
+     this->drivetrain->leftMotors->move(leftPower);
 }
 
 /**

--- a/src/lemlib/chassis/differential.cpp
+++ b/src/lemlib/chassis/differential.cpp
@@ -225,18 +225,21 @@ float defaultDriveCurve(float input, float scale) {
  * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
  * curve, refer to the `defaultDriveCurve` documentation.
  */
-void Differential::curvature(int throttle, int turn, float curveGain, const DriveCurveFunction_t& driveCurve) {
+void Differential::curvature(int throttle, int turn, float linearCurveGain, float turnCurveGain, const DriveCurveFunction_t& driveCurve) {
     // If we're not moving forwards change to arcade drive
     if (throttle == 0) {
-        this->arcade(throttle, turn, curveGain);
+        this->arcade(throttle, turn, linearCurveGain, turnCurveGain);
         return;
     }
 
-    float leftPower = throttle + (std::abs(throttle) * turn) / 127.0;
-    float rightPower = throttle - (std::abs(throttle) * turn) / 127.0;
+    float curvedThrottle = driveCurve(throttle, linearCurveGain);
+    float curvedTurn = driveCurve(turn, turnCurveGain);
+  
+    float leftPower = curvedThrottle + (std::abs(curvedThrottle) * curvedTurn) / 127.0;
+    float rightPower = curvedThrottle - (std::abs(curvedThrottle) * curvedTurn) / 127.0;
 
-    leftPower = driveCurve(leftPower, curveGain);
-    rightPower = driveCurve(rightPower, curveGain);
+    leftPower = driveCurve(leftPower, linearCurveGain);
+    rightPower = driveCurve(rightPower, turnCurveGain);
 
     this->drivetrain->leftMotors->move(leftPower);
     this->drivetrain->rightMotors->move(rightPower);

--- a/src/lemlib/chassis/differential.cpp
+++ b/src/lemlib/chassis/differential.cpp
@@ -225,7 +225,8 @@ float defaultDriveCurve(float input, float scale) {
  * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
  * curve, refer to the `defaultDriveCurve` documentation.
  */
-void Differential::curvature(int throttle, int turn, float linearCurveGain, float turnCurveGain, const DriveCurveFunction_t& driveCurve) {
+void Differential::curvature(int throttle, int turn, float linearCurveGain, float turnCurveGain,
+                             const DriveCurveFunction_t& driveCurve) {
     // If we're not moving forwards change to arcade drive
     if (throttle == 0) {
         this->arcade(throttle, turn, linearCurveGain, turnCurveGain);
@@ -234,7 +235,6 @@ void Differential::curvature(int throttle, int turn, float linearCurveGain, floa
 
     float curvedThrottle = driveCurve(throttle, linearCurveGain);
     float curvedTurn = driveCurve(turn, turnCurveGain);
-  
     float leftPower = curvedThrottle + (std::abs(curvedThrottle) * curvedTurn) / 127.0;
     float rightPower = curvedThrottle - (std::abs(curvedThrottle) * curvedTurn) / 127.0;
 

--- a/src/lemlib/chassis/differential.cpp
+++ b/src/lemlib/chassis/differential.cpp
@@ -251,9 +251,9 @@ void Differential::curvature(int throttle, int turn, float curveGain, const Driv
  * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
  * curve, refer to the `defaultDriveCurve` documentation.
  */
-void Differential::arcade(int throttle, int turn, float curveGain, const DriveCurveFunction_t& driveCurve) {
+void Differential::arcade(int throttle, int turn, float linearCurveGain, float turnCurveGain, const DriveCurveFunction_t& driveCurve) {
     int leftPower = driveCurve(throttle + turn, curveGain);
-    int rightPower = driveCurve(throttle - turn, curveGain);
+    int rightPower = driveCurve(throttle - turn, turnCurveGain);
     this->drivetrain->leftMotors->move(leftPower);
     this->drivetrain->rightMotors->move(rightPower);
 }

--- a/src/lemlib/chassis/differential.cpp
+++ b/src/lemlib/chassis/differential.cpp
@@ -253,7 +253,7 @@ void Differential::curvature(int throttle, int turn, float curveGain, const Driv
  */
 void Differential::arcade(int throttle, int turn, float linearCurveGain, float turnCurveGain,
                           const DriveCurveFunction_t& driveCurve) {
-    int leftPower = driveCurve(throttle + turn, curveGain);
+    int leftPower = driveCurve(throttle + turn, linearCurveGain);
     int rightPower = driveCurve(throttle - turn, turnCurveGain);
     this->drivetrain->leftMotors->move(leftPower);
 }

--- a/src/lemlib/chassis/differential.cpp
+++ b/src/lemlib/chassis/differential.cpp
@@ -253,9 +253,9 @@ void Differential::curvature(int throttle, int turn, float curveGain, const Driv
  */
 void Differential::arcade(int throttle, int turn, float linearCurveGain, float turnCurveGain,
                           const DriveCurveFunction_t& driveCurve) {
-     int leftPower = driveCurve(throttle + turn, curveGain);
-     int rightPower = driveCurve(throttle - turn, turnCurveGain);
-     this->drivetrain->leftMotors->move(leftPower);
+    int leftPower = driveCurve(throttle + turn, curveGain);
+    int rightPower = driveCurve(throttle - turn, turnCurveGain);
+    this->drivetrain->leftMotors->move(leftPower);
 }
 
 /**


### PR DESCRIPTION
#### Summary
Added curves to the turn input in arcade and curvature drives. This helps users customize their driving a little bit more and get better control over their turning in opcontrol.

#### Motivation
A lot of teams have their turning curve a little bit different from their linear speed curves.




<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 3b7a771f0b9e88fb1b7857fa6c70c10452074242 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7012494952)
- via manual download: [LemLib@0.5.0-rc1-c75ad38.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1076668955.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc1-c75ad38.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1076668955.zip;
pros c fetch LemLib@0.5.0-rc1-c75ad38.zip;
pros c apply LemLib@0.5.0-rc1-c75ad38;
rm LemLib@0.5.0-rc1-c75ad38.zip;
```