### PR TITLE
Fix Documention Mistakes

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -154,9 +154,9 @@ In order to contribute to LemLib, you will need to [fork](https://help.github.co
 You can improve the documentation by:
 - Editing the [README](../README.md)
 - Adding/Editing comments in the source code
-- Editing the [Doxygen configuration file](Doxyfile)
-- Changing the [Header HTML file](docs/doxygen-awesome/header.html) and the [Footer HTML file](docs/doxygen-awesome/footer.html)
-- Adding/Editing [Tutorials](docs/tutorials)
+- Editing the [Doxygen configuration file](../docs/Doxyfile)
+- Changing the [Header HTML file](../docs/doxygen-awesome/header.html) and the [Footer HTML file](docs/doxygen-awesome/footer.html)
+- Adding/Editing [Tutorials](../docs/tutorials)
 - Opening an [Issue](https://github.com/LemLib/LemLib/issues) to suggest a change or to report a bug
 
 Changes should be requested via a [Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the LemLib repository. You can use the [Pull Request Template](PULL_REQUEST_TEMPLATE.md) to structure your pull request. Additionally, you should verify that the documentation builds correctly on your machine. You can do so by running `doxygen` in the root directory of the project. The documentation will be generated in the `docs` folder. You can then open the `index.html` file in your browser to view the documentation.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -145,21 +145,21 @@ You can apply the kernel to your project with the following commands
 - Apply the kernel: `pros c apply LemLib@a.b.c-d`
 - Remove the template: `pros c remove LemLib@a.b.c-d`
 
-In order to contribute to LemLib, you will need to [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository and clone it to your local machine. You can then [commit](#commit-messages) your changes to your fork. Once you are done, you can [create a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the master branch. You can use the [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md) to structure your pull request.
+In order to contribute to LemLib, you will need to [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository and clone it to your local machine. You can then [commit](#commit-messages) your changes to your fork. Once you are done, you can [create a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the master branch. You can use the [Pull Request Template](PULL_REQUEST_TEMPLATE.md) to structure your pull request.
 
 
 ### Improving The Documentation
 > We use [Doxygen](http://www.doxygen.nl/) to generate the documentation. The documentation is hosted on [GitHub Pages](https://pages.github.com/). The documentation is generated automatically by Github Actions.
 
 You can improve the documentation by:
-- Editing the [README](README.md)
+- Editing the [README](../README.md)
 - Adding/Editing comments in the source code
 - Editing the [Doxygen configuration file](Doxyfile)
 - Changing the [Header HTML file](docs/doxygen-awesome/header.html) and the [Footer HTML file](docs/doxygen-awesome/footer.html)
 - Adding/Editing [Tutorials](docs/tutorials)
 - Opening an [Issue](https://github.com/LemLib/LemLib/issues) to suggest a change or to report a bug
 
-Changes should be requested via a [Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the LemLib repository. You can use the [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md) to structure your pull request. Additionally, you should verify that the documentation builds correctly on your machine. You can do so by running `doxygen` in the root directory of the project. The documentation will be generated in the `docs` folder. You can then open the `index.html` file in your browser to view the documentation.
+Changes should be requested via a [Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the LemLib repository. You can use the [Pull Request Template](PULL_REQUEST_TEMPLATE.md) to structure your pull request. Additionally, you should verify that the documentation builds correctly on your machine. You can do so by running `doxygen` in the root directory of the project. The documentation will be generated in the `docs` folder. You can then open the `index.html` file in your browser to view the documentation.
 
 
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -155,7 +155,7 @@ You can improve the documentation by:
 - Editing the [README](../README.md)
 - Adding/Editing comments in the source code
 - Editing the [Doxygen configuration file](../docs/Doxyfile)
-- Changing the [Header HTML file](../docs/doxygen-awesome/header.html) and the [Footer HTML file](docs/doxygen-awesome/footer.html)
+- Changing the [Header HTML file](../docs/doxygen-awesome/header.html) and the [Footer HTML file](../docs/doxygen-awesome/footer.html)
 - Adding/Editing [Tutorials](../docs/tutorials)
 - Opening an [Issue](https://github.com/LemLib/LemLib/issues) to suggest a change or to report a bug
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Welcome to LemLib! This open-source PROS template aims to introduce common algor
 
 The creation of this template was inspired by [EZ-Template](https://github.com/EZ-Robotics/EZ-Template) and [OkapiLib](https://github.com/OkapiLib/OkapiLib). We aim to develop a library that strikes a balance between ease-of-use, akin to that of EZ-Template, and comprehensive functionality, similar to that of OkapiLib.
 
-> Want a place to chat with the devs and other users? Join our [discord server](https://discord.gg/pCHr7XZUTj).
+> Want a place to chat with the devs and other users? Join our [Discord server](https://discord.gg/pCHr7XZUTj).
 
 ## License
 This project is licensed under the MIT license. Check [LICENSE](https://github.com/LemLib/LemLib/blob/master/LICENSE) for more details.
@@ -21,23 +21,23 @@ This project is licensed under the MIT license. Check [LICENSE](https://github.c
 - Generic PID class
 - Odometry
 - Odom turn to face point
-- [Boomerang controller](https://www.desmos.com/calculator/sptjw5szex)
+- [Boomerang controller](https://www.desmos.com/calculator/sptjw5szex) (Beta)
 - Pure Pursuit
 - [Path Generator](https://github.com/LemLib/Path-Gen) support
 
 ## Example Project
-You can find a fully annotated example project [here](https://github.com/LemLib/LemLib/blob/master/src/main.cpp)
+You can find a fully annotated example project [here](https://github.com/LemLib/LemLib/blob/master/src/main.cpp).
 
 ## Tutorials
-The tutorials provide a detailed walkthrough through all the features of LemLib. It covers everything from installation to pure pursuit.
+The tutorials provide a detailed walkthrough through all the features of LemLib. It covers everything from installation to Pure Pursuit.
  - 1: [Getting Started](https://lemlib.github.io/LemLib/md_docs_tutorials_1_getting_started.html)
  - 2: [Setting up the Chassis](https://lemlib.github.io/LemLib/md_docs_tutorials_2_setting_up_the_chassis.html)
- - 3: [Driver Control](https://lemlib.github.io/LemLib/md_docs_tutorials_3_driver_control.html)
+ - 3: [Driver Control](https://lemlib.github.io/LemLib/md_docs_tutorials_3_driver_control.html) (Beta)
  - 4: [Tuning and Moving](https://lemlib.github.io/LemLib/md_docs_tutorials_4_auto_and_tuning.html)
  - 5: [Pure Pursuit](https://lemlib.github.io/LemLib/md_docs_tutorials_5_pure_pursuit.html)
 
 ## FAQ
-_**1. Help! why is my controller vibrating?**_
+_**1. Help! Why is my controller vibrating?**_
 Your inertial sensor calibration failed.
 Check if its connected to the right port and try again.
 
@@ -55,7 +55,7 @@ The one exception to this would be if you have 2 parallel tracking wheels which 
 
 _**5. Do I need an SD card?**_
 Only if you use Pure Pursuit `chassis.follow()`.
-This will change in the next major release however. In fact you could try it right now in our latest beta
+This will change in the next major release however. In fact you could try it right now in our latest beta.
 
 _**6. What are the units?**_
 The units are inches and degrees.
@@ -63,16 +63,16 @@ In a future release, Qunits will be used so you can use whatever units you like.
 
 _**7. Is LemLib VRC legal?**_
 Yes.
-Per the recf student-centred policy, in the context of third-party libraries
+Per the RECF student-centred policy, in the context of third-party libraries.
 > Students should be able to understand and explain the code used on their robots
 
-In other words, you need to know how LemLib works. You don't need to know the details like all the math, just more or less how the algorithm works. If you want to learn more about LemLib, you can look through the documentation and ask questions on our Discord server
+In other words, you need to know how LemLib works. You don't need to know the details like all the math, just more or less how the algorithm works. If you want to learn more about LemLib, you can look through the documentation and ask questions on our Discord server.
 
 ## Documentation
-Check out the [Doxygen documentation](https://lemlib.github.io/LemLib/index.html)
+Check out the [Doxygen documentation](https://lemlib.github.io/LemLib/index.html).
 
 ## Contributing
-Want to contribute? Please read [CONTRIBUTING.md](https://github.com/LemLib/LemLib/blob/master/.github/CONTRIBUTING.md) and join our [discord server](https://discord.gg/pCHr7XZUTj)
+Want to contribute? Please read [CONTRIBUTING.md](https://github.com/LemLib/LemLib/blob/master/.github/CONTRIBUTING.md) and join our [Discord server](https://discord.gg/pCHr7XZUTj).
 
 ## Code of Conduct
 See the [Code of Conduct](https://github.com/LemLib/LemLib/blob/master/.github/CODE_OF_CONDUCT.md) on how to behave like an adult.

--- a/docs/tutorials/1_getting_started.md
+++ b/docs/tutorials/1_getting_started.md
@@ -8,12 +8,12 @@ Welcome to LemLib! This tutorial will walk you through the basics of LemLib and 
 
 LemLib is a [PROS](https://pros.cs.purdue.edu) template, so you can use it with any text editor. However, we recommend using Visual Studio Code, as it has the best support for PROS.
 
-To install visual studio code, go to [https://code.visualstudio.com](https://code.visualstudio.com) and download the installer for your operating system
+To install Visual Studio Code, go to [https://code.visualstudio.com](https://code.visualstudio.com) and download the installer for your operating system.
 
 <img src="./assets/1_getting_started/download-visual-studio-code.png"  width="800">
 
 <br>
-Once you have installed it, open it and install the PROS extension. You can do this by clicking typing `Ctrl+Shift+X` (`⌘+Shift+X` on Mac), searching for "pros", and clicking the install button.
+Once you have installed it, open it and install the PROS extension. You can do this by clicking typing `Ctrl+Shift+X` (`⌘+Shift+X` on Mac), searching for "PROS", and clicking the install button.
 <br>
 <img src="./assets/1_getting_started/install-pros.png" height=500 style="display: block;margin-left: auto;margin-right: auto;">
 <br>
@@ -25,12 +25,12 @@ Now we can install LemLib!
 
 ## Installation
 
-In visual studio code, press the pros button on the sidebar and click `Open Integrated Terminal`.
+In Visual Studio Code, press the PROS button on the sidebar and click `Open Integrated Terminal`.
 
 <br>
 <img src="./assets/1_getting_started/integrated_terminal.png" height=800 style="display: block;margin-left: auto;margin-right: auto;">
 
-Then copy/paste the following into the terminal, and hit enter
+Then copy and paste the following into the terminal, and hit enter.
 ```bash
 curl -o LemLib@0.5.0.zip <placeholder_link>;
 pros c fetch LemLib@0.5.0.zip;

--- a/docs/tutorials/2_setting_up_the_chassis.md
+++ b/docs/tutorials/2_setting_up_the_chassis.md
@@ -19,7 +19,7 @@ pros::Motor right_front_motor(3, pros::E_MOTOR_GEARSET_36, true); // port 3, red
 pros::Motor right_back_motor(4, pros::E_MOTOR_GEARSET_36, true); // port 4, red gearbox, reversed
 ```
 
-Now we need to group the left side and right side motors so we can pass it to LemLib. To do this, we can use the `pros::MotorGroup` class. Here is an example:
+Now we need to group the left side and right side motors so that we can pass it to LemLib. To do this, we can use the `pros::MotorGroup` class. Here is an example:
 ```cpp
 pros::MotorGroup left_side_motors({left_front_motor, left_back_motor});
 pros::MotorGroup right_side_motors({right_front_motor, right_back_motor});
@@ -29,7 +29,7 @@ Now that we have the motors set up, we need to tell LemLib about the track width
 
 <img src="./assets/2_setting_up_the_chassis/track_width.png" height=400 style="display: block;margin-left: auto;margin-right: auto;">
 
-We also need to tell LemLib the diameter of the wheels. LemLib has wheel presets you can use for this (e.g `lemlib::Omniwheel::NEW_4` for the new 4 inch wheels) After that, we need to tell LemLib the rpm of the wheels. If your drivetrain is not geared, then the rpm of the wheels is the same as the rpm of the motor cartridge. If it is geared, refer to [this spreadsheet](https://docs.google.com/spreadsheets/d/1RSoLv3tnpiCgFyHb0QayxK-42r9MgVRD_4QQmeFM618/edit#gid=0) to find the rpm of the wheels. And finally, we need to tell the robot how fast it can go around corners. If you have traction wheels, you can start at 8+, but if you don't have traction wheels, start at 2. We will tune this later.
+We also need to tell LemLib the diameter of the wheels. LemLib has wheel presets you can use for this (e.g `lemlib::Omniwheel::NEW_4` for the new 4 inch wheels) After that, we need to tell LemLib the rpm of the wheels. If your drivetrain is not geared, then the rpm of the wheels is the same as the rpm of the motor cartridge. If it is geared, refer to [this spreadsheet](https://docs.google.com/spreadsheets/d/1RSoLv3tnpiCgFyHb0QayxK-42r9MgVRD_4QQmeFM618/edit#gid=0) to find the rpm of the wheels. And finally, we need to tell the robot how fast it can go around corners. If you have at least two traction wheels, you can start at 8, but if you don't have traction wheels, start at 2. We will tune this later.
 
 Now that we have all the information we need, we can create a `lemlib::Drivetrain_t` struct to pass to LemLib. Below is an example:
 ```cpp
@@ -112,7 +112,7 @@ You don't need all these sensors though. Even if you don't have any, you can sti
 
 ## PIDs
 
-Lemlib uses 2 PIDs to control the motion of the robot (except for pure pursuit). Every chassis will have different constants however, so you will need to tune them. More about that in the next tutorial. For now, just copy and paste the following code into your `main.cpp` file:
+Lemlib uses 2 PIDs to control the motion of the robot (except for pure pursuit). Every chassis will have different constants however, so you will need to tune them. More about that in the third tutorial. For now, just copy and paste the following code into your `main.cpp` file:
 ```cpp
 // forward/backward PID
 lemlib::ControllerSettings linearController(10, // proportional gain (kP)

--- a/docs/tutorials/3_driver_control.md
+++ b/docs/tutorials/3_driver_control.md
@@ -1,7 +1,7 @@
 # 03 - Driver Control
 
 ## Introduction
-In this tutorial, we will be learning how to drive the robot.
+In this tutorial, we will be learning how to program the drivetrain to allow for controller joystick inputs.
 
 ## The controller
 The controller has 2 joysticks. A `left` one and a `right` one. Each joystick has 2 axes, an `x` axis and a `y` axis. We will be using these axes to control the drivetrain.
@@ -29,7 +29,7 @@ void opcontrol() {
 ```
 
 ## Arcade Drive
-Arcade drive is the most popular form of controlling the robot. In arcade control, we give the robot a forwards/backwards speed and a turning speed. Below are 2 examples: single stick arcade and double stick arcade
+Arcade drive is the most popular form of controlling the robot. In arcade control, we give the robot a forwards/backwards speed and a turning speed. Below are 2 examples: single stick arcade and double stick arcade.
 
 #### Single Stick Arcade
 ```cpp
@@ -124,7 +124,7 @@ Instead of the regular linear relationship between controller input and drivetra
 
 <img src="./assets/3_driver_control/curve.jpg" height=400 style="display: block;margin-left: auto;margin-right: auto;">
 
-Here is a [desmos graph](https://www.desmos.com/calculator/fuouoahwvc) which shows this relationship. You can tune `t` to make it as curvy as you like. Once you have this t value, we can input it into the drive functions:
+Here is a [Desmos graph](https://www.desmos.com/calculator/fuouoahwvc) which shows this relationship. You can tune `t` to make it as steep as you like. Once we have this t value, we can input it into the drive functions:
 
 ```cpp
 pros::Controller controller();

--- a/docs/tutorials/4_auto_and_tuning.md
+++ b/docs/tutorials/4_auto_and_tuning.md
@@ -4,7 +4,7 @@
 In this tutorial, we will be learning how to tune the PIDs, move the robot autonomously, and use odometry.
 
 ## Odometry
-As mentioned in the previous tutorial, LemLib uses odometry to track the position of the robot. However, we need to calibrate it at the start of each match. To do this, we need to call the `chassis.calibrate()` function in `initialize()` Below is an example of how to do this:
+As mentioned in the previous tutorial, LemLib uses odometry to track the position of the robot. However, we need to calibrate it at the start of each match. To do this, we need to call the `lemlib::Chassis::calibrate()` function in `initialize()` Below is an example of how to do this:
 ```cpp
 void initialize() {
     chassis.calibrate();
@@ -14,7 +14,7 @@ Note that the chassis should be stationary when you call this function. It will 
 
 
 
-Pretty simple, right? Now, we can use the `chassis.getPose()` function to get the current position of the robot. It returns a `lemlib::Pose` object, which contains the x, y, and heading. The code below uses the `chassis.getPose()` function to print the current position of the robot to the brain screen:
+Pretty simple, right? Now, we can use the `lemlib::Chassis::getPose()` function to get the current position of the robot. It returns a `lemlib::Pose` object, which contains the x, y, and heading. The code below uses the `lemlib::Chassis::getPose()` function to constantly print the current position of the robot to the brain screen:
 ```cpp
 void initialize() {
     pros::lcd::initialize(); // initialize brain screen
@@ -33,20 +33,20 @@ void initialize() {
 }
 ```
 
-We can also set the position of the robot using the `chassis.setPose()` function. Below is an example of how to do this:
+We can also set the position of the robot using the `lemlib::Chassis::setPose()` function. Below is an example of how to do this:
 ```cpp
 void autonomous() {
-    // this is where the robot start in auto
+    // this is where the robot start in auton
     // X: 5.2, Y: 10.333, Heading: 87
     chassis.setPose(5.2, 10.333, 87);
 }
 ```
-It is highly recommended you set the starting position of the robot for each autonomous. Otherwise you won't be able to take advantage of the visualization in the path generator
+It is highly recommended you set the starting position of the robot for each autonomous. Otherwise you won't be able to take advantage of the visualization in the path generator.
 
-## Moving with turnTo and moveToPose
-LemLib has 3 functions for moving the to. We will be covering the first 2 in this tutorial, and the third in the next tutorial.
+## Moving with turnTo, moveToPoint, and moveToPose
+LemLib has 4 functions for moving the robot. We will be covering the first 3 in this tutorial, and the forth in the next tutorial.
 
-The first function is `chassis.turnTo()`. This function turns the robot so that it is facing the specified (x, y) point. It takes between 3 and 5 arguments. It uses the PID gains specified in the lateralController struct. Below is an example of how to use it:
+The first function is `lemlib::Chassis::turnTo()`. This function turns the robot so that it is facing the specified (x, y) point. It takes between 3 and 5 arguments. It uses the PID gains specified in the lateralController struct. Below is an example of how to use it:
 ```cpp
 void autonomous() {
     // turn to the point (53, 53) with a timeout of 1000 ms
@@ -61,7 +61,17 @@ void autonomous() {
 
 As you can see, using this function is very easy. The first 2 parameters are the X and Y location the robot should be facing. The third parameter is the timeout, which is the maximum time the robot can spend turning before giving up. The fourth parameter is whether the back of the robot should face the point (true) or the front of the robot should face the point (false). It defaults to false if not specified. The fifth parameter is the maximum speed the robot can turn at. If you don't specify a value for this parameter, the robot will turn at full speed.
 
-The second function is `chassis.moveToPose()`. This function moves the robot to the specified (x, y) point with a target heading in degrees. It uses the PID gains specified in the lateralController and angularController struct. Below is an example of how to use it:
+The second function is `lemlib::Chassis::moveToPoint`. This function moves the robot to the specified (x, y) point. It takes 3 or 4 arguments. It uses the PID gains specified in the lateralController and angularController struct. Below is an example of how to use it:
+```cpp
+void autonomous() {
+    chassis.moveTo(53, 53, 1000); // move to the point (53, 53) with a timeout of 1000 ms
+    chassis.moveTo(10, 0, 1000, 50); // move to the point (10, 0) with a timeout of 1000 ms, and a maximum speed of 50
+}
+```
+
+This function is similar to the `lemlib::Chassis::turnTo()` function. The first 2 parameters are the X and Y location the robot should move towards. The third parameter is the timeout, which is the maximum time the robot can spend turning before giving up. The fourth parameter is the maximum speed the robot can move at. If you don't specify a value for this parameter, the robot will move at full speed.
+
+The third function is `lemlib::Chassis::moveToPose()`. This function moves the robot to the specified (x, y) point with the addition of a target heading in degrees. It uses the PID gains specified in the lateralController and angularController struct. Below is an example of how to use it:
 ```cpp
 void autonomous() {
     // move to the point (53, 53) at heading 90 with a timeout of 1000 ms
@@ -72,10 +82,10 @@ void autonomous() {
 }
 ```
 
-This function is very similar to the `chassis.turnTo()` function. The first 3 parameters are the x, y, and heading the robot should move to. The fourth parameter is the timeout, which is the maximum time the robot can spend turning before giving up. The fifth parameter is whether the robot should move backwards or forwards. The fifth parameter is the maximum speed the robot can move at. Only the first 4 parameters are required.
+This function is very similar to the `lemlib::Chassis::moveToPoint()` function. The first 3 parameters are the x, y, and heading the robot should move to. The fourth parameter is the timeout, which is the maximum time the robot can spend turning before giving up. The fifth parameter is whether the robot should move backwards or forwards. The fifth parameter is the maximum speed the robot can move at. Only the first 4 parameters are required.
 
 ## Understanding asynchronous movements
-By default all movements in lemlib run asynchronously. Put plainly, it runs in its own task. While the system is robust, it takes a little getting used to. Let's look at some examples:
+By default all movements in LemLib run asynchronously. Put plainly, it runs in its own task. While the system is robust, it takes a little getting used to. Let's look at some examples:
 
 ```c++
 pros::millis(); // returns 0000
@@ -105,9 +115,10 @@ pros::millis(); // outputs 1000
 
 > _**IMPORTANT NOTE**_
 <br>
-> `chassis::waitUntil` and `chassis.waitUntilDone` work for all movements. The only difference is when you are using `chassis.turnTo`, where instead of inches the units are in degrees.
 
-This system will take a bit of getting used to, but it is very powerful. If you need additional examples, check out the [example project](https://github.com/LemLib/LemLib/blob/master/src/main.cpp), open a [discussion](https://github.com/LemLib/LemLib/discussions/new?category=q-a), or open a ticket in our [discord server](https://discord.gg/pCHr7XZUTj)
+> `lemlib::Chassis::waitUntil` and `lemlib::Chassis::waitUntilDone` work for all movements. The only difference is when you are using `chassis.turnTo`, where instead of inches the units are in degrees.
+
+This system will take a bit of getting used to, but it is very powerful. If you need additional examples, check out the [example project](https://github.com/LemLib/LemLib/blob/master/src/main.cpp), open a [discussion](https://github.com/LemLib/LemLib/discussions/new?category=q-a), or open a ticket in our [Discord server](https://discord.gg/pCHr7XZUTj).
 
 
 ## Tuning the PIDs
@@ -129,11 +140,11 @@ lemlib::ChassisController_t lateralController {
 
 The first 2 parameters are the kP and kD gains. These are the ones we will be focusing on for now. When we tune them, we want kP as high as possible with minimal oscillation (the robot moving backwards/forwards repeatedly at the end). Here is the method we will be using to tune these gains:
 
-1. Move the robot 10 inches forward using the `chassis.moveToPose()` function
-2. increase kP until the robot starts oscillating
-3. increase kD until the oscillation stops
-4. record kP and kD values
-5. repeat steps 2-4 until you can't stop the oscillation. At this point, use the last kP and kD values you recorded.
+1. Move the robot 10 inches forward using the `lemlib::Chassis::moveToPose()` function.
+2. Increase kP until the robot starts oscillating.
+3. Increase kD until the oscillation stops.
+4. Record kP and kD values.
+5. Repeat steps 2-4 until you can't stop the oscillation. At this point, use the last kP and kD values you recorded.
 
 After this, you need to tune the slew rate. This controls the maximum acceleration of the chassis in order to prevent tipping. To tune it, simply increase it until the robot starts tipping too much. Higher values make the robot accelerate faster, and slower values make the robot accelerate slower. 
 
@@ -156,11 +167,11 @@ lemlib::ChassisController_t angularController {
 
 Here is the algorithm we will be using to tune these gains:
 
-1. Turn the robot to face (30, 0) using the `chassis.turnTo()` function with the robot starting at (0, 0)
-2. increase kP until the robot starts oscillating
-3. increase kD until the oscillation stops
-4. record kP and kD values
-5. repeat steps 2-4 until you can't stop the oscillation. At this point, use the last kP and kD values you recorded.
+1. Turn the robot to face (30, 0) using the `chassis.turnTo()` function with the robot starting at (0, 0).
+2. Increase kP until the robot starts oscillating.
+3. Increase kD until the oscillation stops.
+4. Record kP and kD values.
+5. Repeat steps 2-4 until you can't stop the oscillation. At this point, use the last kP and kD values you recorded.
 
 ## Optional - Tuning Timeouts
 
@@ -175,14 +186,14 @@ Advanced users may wish to alter these values to decrease the time it takes to e
 
 ## Using the Path Generator for Coordinates
 
-You may be wondering how we know what coordinate the robot start at, and what the location is of a specific thing (e.g a goal). Thankfully, it is very easy. You can use [this software](https://lemlib.github.io/Path-Gen/). Just hover your mouse over a location on the field, and you will see the coordinates of the mouse on the field. Refer to the image below:
+You may be wondering how we know what coordinate the robot start at, and what the location is of a specific object (e.g a goal). Thankfully, it is very easy. You can use [this software](https://lemlib.github.io/Path-Gen/). Just hover your mouse over a location on the field, and you will see the coordinates of the mouse on the field. Refer to the image below:
 
 <img src="./assets/4_auto_and_tuning/path_coords.png">
 
-You can use these coordinates to set the starting position of the robot, and use them with the `chassis.turnTo()` and `chassis.moveToPose()` functions.`
+You can use these coordinates to set the starting position of the robot, and use them with the `lemlib::Chassis::turnTo()`,`lemlib::Chassis::moveToPoint()` and `lemlib::Chassis::moveToPose()` functions.
 Note that the origin of the field is in the middle, and the field coordinates are measured in inches. **0 degrees is facing up, and increases clockwise**.
 
-Thats it! You now know how to move the robot around the field using the `chassis.turnTo()` and `chassis.moveToPose()` functions. In the next tutorial, we will be covering how to use the Path Generator to create a path for the robot to follow.
+Thats it! You now know how to move the robot around the field using the `lemlib::Chassis::turnTo()`,`lemlib::Chassis::moveToPoint()` and `lemlib::Chassis::moveToPose()` functions. In the next tutorial, we will be covering how to use the Path Generator to create a path for the robot to follow.
 
 
 [Previous Tutorial](3_driver_control.md) <br>

--- a/docs/tutorials/5_pure_pursuit.md
+++ b/docs/tutorials/5_pure_pursuit.md
@@ -14,26 +14,26 @@ Tuning Pure Pursuit is very simple. If you want the robot to follow the path mor
 
 ## Creating Paths
 
-You can use [path.jerryio.com](https://path.jerryio.com) to generate paths for the autonomous
+You can use [path.jerryio.com](https://path.jerryio.com) to generate paths for the autonomous.
 
 Using the Path Generator is simple:
- - Select the LemLib format (top right)
- - Left Click Drag to move existing waypoints (big purple circles)
- - Left Click to add a waypoint
- - Right Click to remove a waypoint
+ - Select the LemLib format (top right).
+ - Left click drag to move existing waypoints (big purple circles).
+ - Left click to add a waypoint.
+ - Right click to remove a waypoint.
 
 Another feature of the path.jerryio is the ability to make the robot go faster or slower at certain points. The planner will automatically slow down the robot around sharp corners and decelerate as it approaches the end of the path. You can view the velocity of the path at each waypoint on the speed graph at the bottom of the page. See the video below:
 
 <img src="./assets/5_pure_pursuit/custom_speed.gif" height=400 style="display: block;margin-left: auto;margin-right: auto;">
 <br>
 
-For further information on the path.jerryio, check out its [user guide](https://github.com/Jerrylum/path.jerryio/wiki)
+For further information on the path.jerryio, check out its [user guide](https://github.com/Jerrylum/path.jerryio/wiki).
 
 ## Files
 
-path.jerryio saves paths as .txt files. You can upload this file to your robot, and reupload it again to path.jerryio for further modification later on.
+Path.jerryio saves paths as .txt files. You can upload this file to your robot, and reupload it again to path.jerryio for further modification later on.
 
-To upload the path, all you need to do is save the .txt file to the `static` folder in your project. To do this, click `ctrl + s` on windows, or `⌘ + s` on mac, then browse to the `static` folder and select it. Now if you hit save, it will automatically save to the file in your `static` folder.
+To upload the path, all you need to do is save the .txt file to the `static` folder in your project. To do this, click `Ctrl + S` on Windows, or `⌘ + S` on Mac, then browse to the `static` folder and select it. Now if you hit save, it will automatically save to the file in your `static` folder.
 
 Almost there! Now we just need to tell the robot to follow the path. We can do this through the `lemlib::Chassis::follow` function. Below is an example of how to use it:
 ```cpp
@@ -55,10 +55,11 @@ In the above example, the robot reads the path in "example.txt", has a timeout o
 
 > _**IMPORTANT NOTE**_
 <br>
+
 > The position of the robot when it starts following the path is critical. It does not need to be very close, but it is easy to accidentally make the robot start at the end of the path than at the start of the path. You can identify the end of the path with the checkered flag at the end of the path. If you do make this mistake, it will seem that the robot is barely moving, not moving where its supposed to, or even not moving at all. 
 
 ## Conclusion
-Thats it for the tutorials! I hope they were helpful. If you have any questions, feel free to ask me on Discord (sizzlinseal). You can also open issues and pull requests on the repos.
+That's it for the tutorials! I hope they were helpful. If you have any questions, feel free to ask me on Discord (sizzlinseal). You can also open issues and pull requests on the repos.
  - [LemLib](https://github.com/LemLib/LemLib)
  - [path.jerryio](https://path.jerryio.com/)
 


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->

This commit fixes capitalization and punctuation errors. It also fixes the wrong link in contributing.md. Also uses `lemlib::Chassis::` instead of `chassis.` as it used to be a mix of the two and inconsistent.

#### Motivation
<!-- Why are you making this pull request? -->

No more capitalization mistakes for my OCD.

#### Test Plan
<!-- How did you test / plan to test this pull request? -->

No changes to the code part of LemLib, tested all the fixed links and the documentation looks normal in GitHub.

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 0e8fcfdde7d3d54f4c0f1071b209561b213bc8de -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7152081568)
- via manual download: [LemLib@0.5.0-rc2+0e8fcf.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1103666721.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc2+0e8fcf.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1103666721.zip;
pros c fetch LemLib@0.5.0-rc2+0e8fcf.zip;
pros c apply LemLib@0.5.0-rc2+0e8fcf;
rm LemLib@0.5.0-rc2+0e8fcf.zip;
```