### PR TITLE
Added setBrakeMode for chassis

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -261,7 +261,7 @@ class Chassis {
          * @param async whether the function should be run asynchronously. true by default
          */
 
-         /**
+        /**
          * @brief Sets the brake mode of the drivetrain motors
          *
          * @param mode Mode to set the drivetrain motors to

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -261,12 +261,12 @@ class Chassis {
          * @param async whether the function should be run asynchronously. true by default
          */
 
-        void setBrakeMode(pros::motor_brake_mode_e mode);
-        /**
+         /**
          * @brief Sets the brake mode of the drivetrain motors
          *
          * @param mode Mode to set the drivetrain motors to
          */
+        void setBrakeMode(pros::motor_brake_mode_e mode);
 
         void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
         /**

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -212,6 +212,14 @@ class Chassis {
          * @param maxSpeed the maximum speed the robot can turn at. Default is 127
          * @param async whether the function should be run asynchronously. true by default
          */
+
+        void setBrakeMode(pros::motor_brake_mode_e mode);
+        /**
+         * @brief Sets the brake mode of the drivetrain motors
+         *
+         * @param mode Mode to set the drivetrain motors to
+         */
+
         void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
         /**
          * @brief Move the chassis towards the target pose

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -209,7 +209,7 @@ void lemlib::Chassis::waitUntilDone() {
  * @brief Sets the brake mode of the drivetrain motors
  *
  */
-void lemlib::Chassis::setBrakeMode(pros::motor_brake_mode_e mode) {\
+void lemlib::Chassis::setBrakeMode(pros::motor_brake_mode_e mode) {
     mutex.take(TIMEOUT_MAX);
     drivetrain.leftMotors->set_brake_modes(mode);
     drivetrain.rightMotors->set_brake_modes(mode);

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -173,10 +173,8 @@ void lemlib::Chassis::waitUntilDone() {
  *
  */
 void lemlib::Chassis::setBrakeMode(pros::motor_brake_mode_e mode) {
-    mutex.take(TIMEOUT_MAX);
     drivetrain.leftMotors->set_brake_modes(mode);
     drivetrain.rightMotors->set_brake_modes(mode);
-    mutex.give();
 }
 
 /**

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -206,6 +206,17 @@ void lemlib::Chassis::waitUntilDone() {
 }
 
 /**
+ * @brief Sets the brake mode of the drivetrain motors
+ *
+ */
+void lemlib::Chassis::setBrakeMode(pros::motor_brake_mode_e mode) {\
+    mutex.take(TIMEOUT_MAX);
+    drivetrain.leftMotors->set_brake_modes(mode);
+    drivetrain.rightMotors->set_brake_modes(mode);
+    mutex.give();
+}
+
+/**
  * @brief Turn the chassis so it is facing the target point
  *
  * The PID logging id is "angularPID"


### PR DESCRIPTION
#### Summary
In EZ-Template, there's a feature to switch all the drive motor's brake modes. This is used for switching from hold for autonomous to coast in user control.

#### Motivation
This saves 1 line.

#### Test Plan
Tested on robot, switch occurred perfectly. RC1

#### Additional Notes
N/A

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 121bacf29a7b2fd9af395d1b246c703a05d2fe57 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7205705021)
- via manual download: [LemLib@0.5.0-rc3+121bac.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1113965097.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc3+121bac.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1113965097.zip;
pros c fetch LemLib@0.5.0-rc3+121bac.zip;
pros c apply LemLib@0.5.0-rc3+121bac;
rm LemLib@0.5.0-rc3+121bac.zip;
```