### PR TITLE
feat: :sparkles: Motion Cancelation

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -280,7 +280,33 @@ class Chassis {
          * curve, refer to the `defaultDriveCurve` documentation.
          */
         void curvature(int throttle, int turn, float cureGain = 0.0);
+        /**
+         * @brief Cancels the currently running motion.
+         * If there is a queued motion, then that queued motion will run.
+         */
+        void cancelMotion();
+        /**
+         * @brief Cancels all motions, even those that are queued.
+         * After this, the chassis will not be in motion.
+         */
+        void cancelAllMotions();
+        /**
+         * @return whether a motion is currently running
+         */
+        bool isInMotion() const;
+    protected:
+        /**
+         * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue
+         */
+        void requestMotionStart();
+        /**
+         * @brief Dequeues this motion and permits queued task to run
+         */
+        void endMotion();
     private:
+        bool motionRunning = false;
+        bool motionQueued = false;
+
         pros::Mutex mutex;
         float distTravelled = 0;
 

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -177,7 +177,7 @@ void lemlib::Chassis::requestMotionStart() {
 
     // wait until this motion is at front of "queue"
     this->mutex.take(TIMEOUT_MAX);
-    
+
     // this->motionRunning should be true
     // and this->motionQueued should be false
     // indicating this motion is running
@@ -189,7 +189,7 @@ void lemlib::Chassis::endMotion() {
     this->motionQueued = false;
 
     // permit queued motion to run
-    this->mutex.give(); 
+    this->mutex.give();
 }
 
 void lemlib::Chassis::cancelMotion() {
@@ -203,9 +203,7 @@ void lemlib::Chassis::cancelAllMotions() {
     pros::delay(10); // give time for motion to stop
 }
 
-bool lemlib::Chassis::isInMotion() const {
-    return this->motionRunning;
-}
+bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
 
 /**
  * @brief Turn the chassis so it is facing the target point
@@ -447,7 +445,7 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
 void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
     this->requestMotionStart();
     // were all motions cancelled?
-    if(!this->motionRunning) return;
+    if (!this->motionRunning) return;
     // if the function is async, run it in a new task
     if (async) {
         pros::Task task([&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
@@ -475,7 +473,8 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, 
     const int compState = pros::competition::get_status();
 
     // main loop
-    while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close) && this->motionRunning) {
+    while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close) &&
+           this->motionRunning) {
         // update position
         const Pose pose = getPose(true, true);
 

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -475,7 +475,7 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, 
     const int compState = pros::competition::get_status();
 
     // main loop
-    while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close)) {
+    while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close) && this->motionRunning) {
         // update position
         const Pose pose = getPose(true, true);
 


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Allows users to cancel in-progress motions via two methods: 
- cancelMotion(): cancels currently running motion, permitting the queued motion (if there is one) to run.
- cancelAllMotions(): cancels all motions, even queued motions.

#### Motivation
<!-- Why are you making this pull request? -->
Motion chaining and greater control over motions

#### Test Plan
<!-- How did you test / plan to test this pull request? -->
You're gonna do it!

But if something does get messed up, then replace `this->requestMotionStart()` with the following and ping me w/ output:
```cpp
    printf("before: %s%s\n", this->motionRunning ? "R" : "", this->motionQueued ? "Q" : "");
    this->requestMotionStart();
    printf("after: %s%s\n", this->motionRunning ? "R" : "", this->motionQueued ? "Q" : "");
```

#### Additional Notes
<!-- Add any other information you think is relevant -->

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 4b6f00c274521dcde2f7270b2960aa1badb72e6b -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7296025266)
- via manual download: [LemLib@0.5.0-rc4+4b6f00.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1130416663.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc4+4b6f00.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1130416663.zip;
pros c fetch LemLib@0.5.0-rc4+4b6f00.zip;
pros c apply LemLib@0.5.0-rc4+4b6f00;
rm LemLib@0.5.0-rc4+4b6f00.zip;
```