### PR TITLE
Update CONTRIBUTING.md with instructions for creating new files in `lemlib`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -146,6 +146,9 @@ You can apply the kernel to your project with the following commands
 - Apply the kernel: `pros c apply LemLib@a.b.c-d`
 - Remove the template: `pros c remove LemLib@a.b.c-d`
 
+If you are creating new files in the `lemlib` folder
+- Run `make clean quick -j`
+
 In order to contribute to LemLib, you will need to [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository and clone it to your local machine. You can then [commit](#commit-messages) your changes to your fork. Once you are done, you can [create a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the master branch. You can use the [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md) to structure your pull request.
 
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -147,7 +147,7 @@ You can apply the kernel to your project with the following commands
 - Remove the template: `pros c remove LemLib@a.b.c-d`
 
 If you are creating new files in the `lemlib` folder
-- Run `make clean quick -j`
+- Run: `make clean quick -j`
 
 In order to contribute to LemLib, you will need to [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository and clone it to your local machine. You can then [commit](#commit-messages) your changes to your fork. Once you are done, you can [create a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the master branch. You can use the [Pull Request Template](.github/PULL_REQUEST_TEMPLATE.md) to structure your pull request.
 


### PR DESCRIPTION
#### Summary
Add instructions in `CONTRIBUTING.md` to run `make clean quick -j` when creating a new file in the lemlib folder.

#### Motivation
When implementing LemLib-compatible PTO, I ran into issues with the `lemlib.a` file in the cold package not recognizing the new files. Andrew provided me with the `make clean quick -j` command which allowed the project to compile properly with the new files.

#### Test Plan
N/A (it's text in a markdown file)

#### Additional Notes
<!-- Add any other information you think is relevant -->

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 65fbf756652fca4c739ee059c2bf52c3f2e19083 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7292675406)
- via manual download: [LemLib@0.5.0-rc2+65fbf7.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1129753966.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc2+65fbf7.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1129753966.zip;
pros c fetch LemLib@0.5.0-rc2+65fbf7.zip;
pros c apply LemLib@0.5.0-rc2+65fbf7;
rm LemLib@0.5.0-rc2+65fbf7.zip;
```