### PR TITLE
Chore: Add README, LICENSE, and VERSION to template zip

### DIFF
--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -104,7 +104,7 @@ jobs:
         run: echo "\n## [Github link](${{github.server_url}}/${{github.repository}})" >> template/include/lemlib/README.md
 
       - name: Fix relative Github links in README.md
-        run: perl -i -pe 's@(?<=[^/])(docs/assets/.*?)(?=[")])@${{github.server_url}}/${{github.repository}}/blob/master/$1?raw=true@g' include/lemlib/README.md
+        run: perl -i -pe 's@(?<=[^/])(docs/assets/.*?)(?=[")])@${{github.server_url}}/${{github.repository}}/blob/master/$1?raw=true@g' template/include/lemlib/README.md
 
       - name: Unzip Template
         uses: montudor/action-zip@v1.0.0

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -92,22 +92,22 @@ jobs:
       - name: Create template folder
         run: mkdir template
 
-      - name: Unzip Template
-        uses: montudor/action-zip@v1.0.0
-        with:
-          args: unzip "${{steps.template-name.outputs.name}}.zip" -d template
-
       - name: test
         run: ls -l
       - name: test2
         run: whoami
-
+        
       - name: Copy LICENSE and README.md into template
-        run: cp {LICENSE,README.md} template/include/lemlib/
-
+        run: cp {LICENSE,README.md} template/include/lemlib/  
+        
       - name: Append GitHub link to README.md
         run: echo "${{github.server_url}}/${{github.repository}}">> template/include/lemlib/README.md
-
+        
+      - name: Unzip Template
+        uses: montudor/action-zip@v1.0.0
+        with:
+          args: unzip "${{steps.template-name.outputs.name}}.zip" -d template
+        
       - name: Create VERSION file
         run: echo $POSTFIX > template/include/lemlib/VERSION
         env:

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -2,9 +2,9 @@ name: Build Template
 
 on:
   push:
-    branches: "*"
+    branches: "**"
   pull_request:
-    branches: "*"
+    branches: "**"
 
   workflow_dispatch:
 

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -2,16 +2,16 @@ name: Build Template
 
 on:
   push:
-    branches: '*'
+    branches: "*"
   pull_request:
-    branches: '*'
+    branches: "*"
 
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Get short SHA
         id: short-sha
@@ -29,33 +29,33 @@ jobs:
           SHA: ${{ github.event.after }} # this isn't present for pr opened events
           ACTION: ${{github.event.action}}
           PR_NUM: ${{github.event.number}}
-      
+
       - name: Set short SHA
         run: echo $SHA
         env:
           SHA: ${{ steps.short-sha.outputs.sha }}
-    
+
       - name: Install ARM Toolchain
         uses: fiam/arm-none-eabi-gcc@v1
         with:
-          release: '10-2020-q4'
+          release: "10-2020-q4"
 
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-  
+
       - name: PIP Installer
         uses: BSFishy/pip-action@v1
         with:
           packages: pros-cli
-  
-      - name: Testing PROS Install 
+
+      - name: Testing PROS Install
         run: pros --version
 
       - name: Checkout
         uses: actions/checkout@v2.3.4
-      
+
       - name: Get version number
         id: version
         run: |
@@ -64,7 +64,7 @@ jobs:
 
       - name: Get Template Postfix
         id: template-postfix
-        run: | 
+        run: |
           echo postfix="$VER+$SHA" >> "$GITHUB_OUTPUT"
         env:
           SHA: ${{ steps.short-sha.outputs.sha }}
@@ -72,18 +72,18 @@ jobs:
 
       - name: Get Template Name
         id: template-name
-        run: | 
+        run: |
           echo name=$TEMPLATE_NAME@$POSTFIX >> "$GITHUB_OUTPUT"
         env:
           POSTFIX: ${{ steps.template-postfix.outputs.postfix }}
           TEMPLATE_NAME: ${{ github.event.repository.name }}
-      
+
       - name: Update version in Makefile
         run: sed -i "s/^VERSION:=.*\$/VERSION:=$POSTFIX/" Makefile
         env:
           POSTFIX: ${{ steps.template-postfix.outputs.postfix }}
 
-      - name: Build PROS Project  
+      - name: Build PROS Project
         run: make clean quick -j
 
       - name: Create LemLib template
@@ -96,10 +96,18 @@ jobs:
         uses: montudor/action-zip@v1.0.0
         with:
           args: unzip "${{steps.template-name.outputs.name}}.zip" -d template
-  
+
+      - name: Copy LICENSE and README.md into template
+        run: cp {LICENSE,README.md} template/include/lemlib/
+
+      - name: Create VERSION file
+        run: echo $POSTFIX > template/include/lemlib/VERSION
+        env:
+          POSTFIX: ${{ steps.template-postfix.outputs.postfix }}
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
           name: ${{ steps.template-name.outputs.name }}
-          path: 'template/*'
+          path: "template/*"
           retention-days: 89

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -101,7 +101,7 @@ jobs:
         run: cp {LICENSE,README.md} template/include/lemlib/  
         
       - name: Append GitHub link to README.md
-        run: echo "${{github.server_url}}/${{github.repository}}">> template/include/lemlib/README.md
+        run: echo "\n## [Github link](${{github.server_url}}/${{github.repository}})" >> template/include/lemlib/README.md
 
       - name: Unzip Template
         uses: montudor/action-zip@v1.0.0

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -90,7 +90,7 @@ jobs:
         run: pros make template
 
       - name: Create template folder
-        run: mkdir template
+        run: mkdir -p template/include/lemlib/
 
       - name: test
         run: ls -l
@@ -102,7 +102,7 @@ jobs:
         
       - name: Append GitHub link to README.md
         run: echo "${{github.server_url}}/${{github.repository}}">> template/include/lemlib/README.md
-        
+
       - name: Unzip Template
         uses: montudor/action-zip@v1.0.0
         with:

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -96,9 +96,11 @@ jobs:
         uses: montudor/action-zip@v1.0.0
         with:
           args: unzip "${{steps.template-name.outputs.name}}.zip" -d template
-          
+
       - name: test
         run: ls -l
+      - name: test2
+        run: whoami
 
       - name: Copy LICENSE and README.md into template
         run: cp {LICENSE,README.md} template/include/lemlib/

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -100,6 +100,9 @@ jobs:
       - name: Copy LICENSE and README.md into template
         run: cp {LICENSE,README.md} template/include/lemlib/
 
+      - name: Append GitHub link to README.md
+        run: echo "${{github.server_url}}/${{github.repository}}">> template/include/lemlib/README.md
+
       - name: Create VERSION file
         run: echo $POSTFIX > template/include/lemlib/VERSION
         env:

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -96,6 +96,9 @@ jobs:
         uses: montudor/action-zip@v1.0.0
         with:
           args: unzip "${{steps.template-name.outputs.name}}.zip" -d template
+          
+      - name: test
+        run: ls -l
 
       - name: Copy LICENSE and README.md into template
         run: cp {LICENSE,README.md} template/include/lemlib/

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -91,11 +91,6 @@ jobs:
 
       - name: Create template folder
         run: mkdir -p template/include/lemlib/
-
-      - name: test
-        run: ls -l
-      - name: test2
-        run: whoami
         
       - name: Copy LICENSE and README.md into template
         run: cp {LICENSE,README.md} template/include/lemlib/  

--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Append GitHub link to README.md
         run: echo "\n## [Github link](${{github.server_url}}/${{github.repository}})" >> template/include/lemlib/README.md
 
+      - name: Fix relative Github links in README.md
+        run: perl -i -pe 's@(?<=[^/])(docs/assets/.*?)(?=[")])@${{github.server_url}}/${{github.repository}}/blob/master/$1?raw=true@g' include/lemlib/README.md
+
       - name: Unzip Template
         uses: montudor/action-zip@v1.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(f
 # whatever files you want here. This line is configured to add all header files
 # that are in the the include directory get exported
 
-TEMPLATE_FILES=$(INCDIR)/lemlib/*.hpp $(INCDIR)/lemlib/logger/*.hpp $(INCDIR)/lemlib/chassis/*.hpp $(INCDIR)/fmt/*.h $(FWDIR)/asset.mk $(ROOT)/static/example.txt
+TEMPLATE_FILES=$(INCDIR)/lemlib/*.hpp $(INCDIR)/lemlib/logger/*.hpp $(INCDIR)/lemlib/chassis/*.hpp $(INCDIR)/fmt/*.h $(FWDIR)/asset.mk $(ROOT)/static/example.txt $(INCDIR)/lemlib/LICENSE $(INCDIR)/lemlib/README.md $(INCDIR)/lemlib/VERSION
 
 .DEFAULT_GOAL=quick
 

--- a/include/lemlib/api.hpp
+++ b/include/lemlib/api.hpp
@@ -1,13 +1,3 @@
-/**
- * @file include/lemlib/api.hpp
- * @author LemLib Team
- * @brief LemLib API header file. Include this in your source files to use the library.
- * @version 0.4.5
- * @date 2023-01-27
- *
- * @copyright Copyright (c) 2023
- *
- */
 #pragma once
 
 #include "lemlib/util.hpp"

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -1,13 +1,3 @@
-/**
- * @file include/lemlib/chassis/chassis.hpp
- * @author LemLib Team
- * @brief Chassis class declarations
- * @version 0.4.5
- * @date 2023-01-23
- *
- * @copyright Copyright (c) 2023
- *
- */
 
 #pragma once
 

--- a/include/lemlib/chassis/odom.hpp
+++ b/include/lemlib/chassis/odom.hpp
@@ -1,14 +1,3 @@
-/**
- * @file include/lemlib/chassis/odom.hpp
- * @author LemLib Team
- * @brief This is the header file for the odom.cpp file. Its not meant to be used directly, only through the chassis
- * class
- * @version 0.4.5
- * @date 2023-01-23
- *
- * @copyright Copyright (c) 2023
- *
- */
 
 #pragma once
 

--- a/include/lemlib/chassis/trackingWheel.hpp
+++ b/include/lemlib/chassis/trackingWheel.hpp
@@ -1,13 +1,3 @@
-/**
- * @file include/lemlib/chassis/trackingWheel.hpp
- * @author LemLib Team
- * @brief tracking wheel class declarations
- * @version 0.4.5
- * @date 2023-01-23
- *
- * @copyright Copyright (c) 2023
- *
- */
 
 #pragma once
 

--- a/include/lemlib/pose.hpp
+++ b/include/lemlib/pose.hpp
@@ -1,13 +1,3 @@
-/**
- * @file include/lemlib/pose.hpp
- * @author LemLib Team
- * @brief Pose class declarations
- * @version 0.4.5
- * @date 2023-01-23
- *
- * @copyright Copyright (c) 2023
- *
- */
 #pragma once
 
 #include <string>

--- a/include/lemlib/util.hpp
+++ b/include/lemlib/util.hpp
@@ -1,13 +1,3 @@
-/**
- * @file include/lemlib/util.hpp
- * @author LemLib Team
- * @brief Utility functions declarations
- * @version 0.4.5
- * @date 2023-01-15
- *
- * @copyright Copyright (c) 2023
- *
- */
 
 #pragma once
 

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -1,13 +1,3 @@
-/**
- * @file src/lemlib/chassis/chassis.cpp
- * @author LemLib Team
- * @brief definitions for the chassis class
- * @version 0.4.5
- * @date 2023-01-27
- *
- * @copyright Copyright (c) 2023
- *
- */
 #include <algorithm>
 #include <math.h>
 #include "pros/motors.hpp"

--- a/src/lemlib/chassis/odom.cpp
+++ b/src/lemlib/chassis/odom.cpp
@@ -1,13 +1,3 @@
-/**
- * @file src/lemlib/chassis/odom.cpp
- * @author LemLib Team
- * @brief Odometry source file. Contains odometry functions and global variables
- * @version 0.4.5
- * @date 2023-01-27
- *
- * @copyright Copyright (c) 2023
- *
- */
 
 // The implementation below is mostly based off of
 // the document written by 5225A (Pilons)

--- a/src/lemlib/chassis/pursuit.cpp
+++ b/src/lemlib/chassis/pursuit.cpp
@@ -1,12 +1,3 @@
-/**
- * @file src/lemlib/chassis/pursuit.cpp
- * @author LemLib Team
- * @brief Pure Pursuit implementation
- * @version 0.4.5
- * @date 2023-02-09
- * @copyright Copyright (c) 2023
- *
- */
 
 // The implementation below is mostly based off of
 // the document written by Dawgma

--- a/src/lemlib/chassis/trackingWheel.cpp
+++ b/src/lemlib/chassis/trackingWheel.cpp
@@ -1,13 +1,3 @@
-/**
- * @file src/lemlib/chassis/trackingWheel.cpp
- * @author LemLib Team
- * @brief tracking wheel class definitions
- * @version 0.4.5
- * @date 2023-01-23
- *
- * @copyright Copyright (c) 2023
- *
- */
 
 #include <math.h>
 #include "lemlib/chassis/trackingWheel.hpp"

--- a/src/lemlib/pose.cpp
+++ b/src/lemlib/pose.cpp
@@ -1,13 +1,3 @@
-/**
- * @file src/lemlib/pose.cpp
- * @author LemLib Team
- * @brief Source file containing the implementation of the Pose class
- * @version 0.4.5
- * @date 2023-01-23
- *
- * @copyright Copyright (c) 2023
- *
- */
 
 #define FMT_HEADER_ONLY
 #include "fmt/core.h"

--- a/src/lemlib/util.cpp
+++ b/src/lemlib/util.cpp
@@ -1,13 +1,3 @@
-/**
- * @file src/lemlib/util.cpp
- * @author Liam Teale
- * @brief File containing definitions for utility functions
- * @version 0.4.5
- * @date 2023-01-15
- *
- * @copyright Copyright (c) 2023
- *
- */
 #include <math.h>
 #include <vector>
 #include "lemlib/pose.hpp"


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Adds `README.md`, `LICENSE`, and `VERSION `to the template .zip. And:
- Appends a Github link to the readme 
- Fixes workflows not running when they contain a `/`
- Removes the file comment that was at the top of some of the headers and source files
#### Motivation
<!-- Why are you making this pull request? -->
- The file comments weren't being updated and thus causing confusion
- Its really annoying to write a workflow to maintain/update the file comments

#### Test Plan
<!-- How did you test / plan to test this pull request? -->
I downloaded the .zip produced by pros-build and it installed the `README.md`, `LICENSE`, and `VERSION` files into the include/lemlib directory

#### Additional Notes
<!-- Add any other information you think is relevant -->
The version file contains smth like this:`0.5.0-rc.5+659761`.

- Should I prefix it with `LemLib@`?
- Should I remove the commit hash?
- Should I get rid of the `VERSION` file altogether?
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 4023542f794e29d4128cfcc584dbf82040e350f6 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7362473081)
- via manual download: [LemLib@0.5.0-rc.5+402354.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1140093777.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.5+402354.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1140093777.zip;
pros c fetch LemLib@0.5.0-rc.5+402354.zip;
pros c apply LemLib@0.5.0-rc.5+402354;
rm LemLib@0.5.0-rc.5+402354.zip;
```