### PR TITLE
User Friendly Relative Boomerang 

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -22,356 +22,362 @@
 #include <limits>
 
 namespace lemlib {
-	/**
-	 * @brief Struct containing all the sensors used for odometry
-	 *
-	 */
-	struct OdomSensors {
-		/**
-		 * The sensors are stored in a struct so that they can be easily passed to the
-		 * chassis class The variables are pointers so that they can be set to nullptr
-		 * if they are not used Otherwise the chassis class would have to have a
-		 * constructor for each possible combination of sensors
-		 *
-		 * @param vertical1 pointer to the first vertical tracking wheel
-		 * @param vertical2 pointer to the second vertical tracking wheel
-		 * @param horizontal1 pointer to the first horizontal tracking wheel
-		 * @param horizontal2 pointer to the second horizontal tracking wheel
-		 * @param imu pointer to the IMU
-		 */
-		OdomSensors(TrackingWheel * vertical1, TrackingWheel * vertical2, TrackingWheel * horizontal1, TrackingWheel * horizontal2, pros::Imu * imu);
-		TrackingWheel * vertical1;
-		TrackingWheel * vertical2;
-		TrackingWheel * horizontal1;
-		TrackingWheel * horizontal2;
-		pros::Imu * imu;
-	};
-	/**
-	 * @brief Struct containing constants for a chassis controller
-	 *
-	 */
-	struct ControllerSettings {
-		/**
-		 * The constants are stored in a struct so that they can be easily passed to
-		 * the chassis class Set a constant to 0 and it will be ignored
-		 *
-		 * @param kP proportional constant for the chassis controller
-		 * @param kI integral constant for the chassis controller
-		 * @param kD derivative constant for the chassis controller
-		 * @param antiWindup
-		 * @param smallError the error at which the chassis controller will switch to
-		 * a slower control loop
-		 * @param smallErrorTimeout the time the chassis controller will wait before
-		 * switching to a slower control loop
-		 * @param largeError the error at which the chassis controller will switch to
-		 * a faster control loop
-		 * @param largeErrorTimeout the time the chassis controller will wait before
-		 * switching to a faster control loop
-		 * @param slew the maximum acceleration of the chassis controller
-		 */
-		ControllerSettings(float kP, float kI, float kD, float windupRange, float smallError, float smallErrorTimeout, float largeError, float largeErrorTimeout, float slew): kP(kP), kI(kI), kD(kD), windupRange(windupRange),
-			smallError(smallError), smallErrorTimeout(smallErrorTimeout),
-			largeError(largeError), largeErrorTimeout(largeErrorTimeout),
-			slew(slew) {}
-		float kP;
-		float kI;
-		float kD;
-		float windupRange;
-		float smallError;
-		float smallErrorTimeout;
-		float largeError;
-		float largeErrorTimeout;
-		float slew;
-	};
-	/**
-	 * @brief Struct containing constants for a drivetrain
-	 *
-	 */
-	struct Drivetrain {
-		/**
-		 * The constants are stored in a struct so that they can be easily passed to
-		 * the chassis class Set a constant to 0 and it will be ignored
-		 *
-		 * @param leftMotors pointer to the left motors
-		 * @param rightMotors pointer to the right motors
-		 * @param trackWidth the track width of the robot
-		 * @param wheelDiameter the diameter of the wheel used on the drivetrain
-		 * @param rpm the rpm of the wheels
-		 * @param chasePower higher values make the robot move faster but causes more
-		 * overshoot on turns
-		 */
-		Drivetrain(pros::MotorGroup * leftMotors, pros::MotorGroup * rightMotors, float trackWidth, float wheelDiameter, float rpm, float chasePower);
-		pros::Motor_Group * leftMotors;
-		pros::Motor_Group * rightMotors;
-		float trackWidth;
-		float wheelDiameter;
-		float rpm;
-		float chasePower;
-	};
-	/**
-	 * @brief Targets for Chassis::moveToPose
-	 *
-	 * We use a struct to simplify customization. Chassis::moveToPose has many
-	 * parameters and specifying them all just to set one optional param ruins
-	 * readability. By passing a struct to the function, we can have named
-	 * parameters, overcoming the c/c++ limitation
-	 *
-	 * @param dist whether the robot should move forwards or backwards. True by
-	 * default
-	 * @param x how fast the robot will move around corners. Recommended value 2-15.
-	 *  0 means use chasePower set in chassis class. 0 by default.
-	 * @param y carrot point multiplier. value between 0 and 1. Higher values result
-	 * in curvier movements. 0.6 by default
-	 * @param theta the maximum speed the robot can travel at. Value between 0-127.
-	 *  127 by default
-	 */
-	struct MoveToPoseTargets {
-		float dist = std::numeric_limits < float > ::quiet_NaN();
-		float x = std::numeric_limits < float > ::quiet_NaN();
-		float y = std::numeric_limits < float > ::quiet_NaN();
-		float theta = std::numeric_limits < float > ::quiet_NaN();
-	};
-	/**
-	 * @brief Flags for Chassis::moveToPose
-	 *
-	 * We use a struct to simplify customization. Chassis::moveToPose has many
-	 * parameters and specifying them all just to set one optional param ruins
-	 * readability. By passing a struct to the function, we can have named
-	 * parameters, overcoming the c/c++ limitation
-	 *
-	 * @param forwards whether the robot should move forwards or backwards. True by
-	 * default
-	 * @param chasePower how fast the robot will move around corners. Recommended
-	 * value 2-15. 0 means use chasePower set in chassis class. 0 by default.
-	 * @param lead carrot point multiplier. value between 0 and 1. Higher values
-	 * result in curvier movements. 0.6 by default
-	 * @param maxSpeed the maximum speed the robot can travel at. Value between
-	 * 0-127. 127 by default
-	 * @param minSpeed the minimum speed the robot can travel at. If set to a
-	 * non-zero value, the exit conditions will switch to less accurate but smoother
-	 * ones. Value between 0-127. 0 by default
-	 * @param earlyExitRange distance between the robot and target point where the
-	 * movement will exit. Only has an effect if minSpeed is non-zero.
-	 */
-	struct lemlib::MoveToPoseFlags {
-		bool forwards = true;
-		float chasePower = 0;
-		float lead = 0.6;
-		float maxSpeed = 127;
-		float minSpeed = 0;
-		float earlyExitRange = 0;
-	};
-	/**
-	 * @brief Function pointer type for drive curve functions.
-	 * @param input The control input in the range [-127, 127].
-	 * @param scale The scaling factor, which can be optionally ignored.
-	 * @return The new value to be used.
-	 */
-	typedef std:: function < float(float, float) > DriveCurveFunction_t;
-	/**
-	 * @brief  Default drive curve. Modifies  the input with an exponential curve.
-	 * If the input is 127, the function will always output 127, no matter the value
-	 * of scale, likewise for -127. This curve was inspired by team 5225, the
-	 * Pilons. A Desmos graph of this curve can be found here:
-	 * https://www.desmos.com/calculator/rcfjjg83zx
-	 * @param input value from -127 to 127
-	 * @param scale how steep the curve should be.
-	 * @return The new value to be used.
-	 */
-	float defaultDriveCurve(float input, float scale);
-	/**
-	 * @brief Chassis class
-	 *
-	 */
-	class Chassis {
-		public:
-			/**
-			 * @brief Construct a new Chassis
-			 *
-			 * @param drivetrain drivetrain to be used for the chassis
-			 * @param lateralSettings settings for the lateral controller
-			 * @param angularSettings settings for the angular controller
-			 * @param sensors sensors to be used for odometry
-			 * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
-			 */
-			Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings, OdomSensors sensors, DriveCurveFunction_t driveCurve = & defaultDriveCurve);
-		/**
-		 * @brief Calibrate the chassis sensors
-		 *
-		 * @param calibrateIMU whether the IMU should be calibrated. true by default
-		 */
-		void calibrate(bool calibrateIMU = true);
-		/**
-		 * @brief Set the pose of the chassis
-		 *
-		 * @param x new x value
-		 * @param y new y value
-		 * @param theta new theta value
-		 * @param radians true if theta is in radians, false if not. False by default
-		 */
-		void setPose(float x, float y, float theta, bool radians = false);
-		/**
-		 * @brief Set the pose of the chassis
-		 *
-		 * @param pose the new pose
-		 * @param radians whether pose theta is in radians (true) or not (false).
-		 * false by default
-		 */
-		void setPose(Pose pose, bool radians = false);
-		/**
-		 * @brief Get the pose of the chassis
-		 *
-		 * @param radians whether theta should be in radians (true) or degrees
-		 * (false). false by default
-		 * @return Pose
-		 */
-		Pose getPose(bool radians = false, bool standardPos = false);
-		/**
-		 * @brief Wait until the robot has traveled a certain distance along the path
-		 *
-		 * @note Units are in inches if current motion is moveTo or follow, degrees if
-		 * using turnTo
-		 *
-		 * @param dist the distance the robot needs to travel before returning
-		 */
-		void waitUntil(float dist);
-		/**
-		 * @brief Wait until the robot has completed the path
-		 *
-		 */
-		void waitUntilDone();
-		/**
-		 * @brief Turn the chassis so it is facing the target point
-		 *
-		 * The PID logging id is "angularPID"
-		 *
-		 * @param x x location
-		 * @param y y location
-		 * @param timeout longest time the robot can spend moving
-		 * @param forwards whether the robot should turn to face the point with the
-		 * front of the robot. true by default
-		 * @param maxSpeed the maximum speed the robot can turn at. Default is 127
-		 * @param async whether the function should be run asynchronously. true by
-		 * default
-		 */
-		void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-		/**
-		 * @brief Move the chassis towards the target pose
-		 *
-		 * Uses the boomerang controller
-		 *
-		 * @param x x location
-		 * @param y y location
-		 * @param theta target heading in degrees.
-		 * @param timeout longest time the robot can spend moving
-		 * @param params struct to simulate named parameters
-		 * @param async whether the function should be run asynchronously. true by
-		 * default
-		 */
-		void moveToPose(MoveToPoseTarget targetPose, int timeout, lemlib::MoveToPoseFlags params = {}, bool async = true);
-		/**
-		 * @brief Move the chassis towards a target point
-		 *
-		 * @param x x location
-		 * @param y y location
-		 * @param timeout longest time the robot can spend moving
-		 * @param maxSpeed the maximum speed the robot can move at. 127 by default
-		 * @param async whether the function should be run asynchronously. true by
-		 * default
-		 */
-		void moveToPoint(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-		/**
-		 * @brief Move the chassis along a path
-		 *
-		 * @param path the path asset to follow
-		 * @param lookahead the lookahead distance. Units in inches. Larger values
-		 * will make the robot move faster but will follow the path less accurately
-		 * @param timeout the maximum time the robot can spend moving
-		 * @param forwards whether the robot should follow the path going forwards.
-		 * true by default
-		 * @param async whether the function should be run asynchronously. true by
-		 * default
-		 */
-		void follow(const asset & path, float lookahead, int timeout,
-			bool forwards = true, bool async = true);
-		/**
-		 * @brief Control the robot during the driver control period using the tank
-		 * drive control scheme. In this control scheme one joystick axis controls one
-		 * half of the robot, and another joystick axis controls another.
-		 * @param left speed of the left side of the drivetrain. Takes an input from
-		 * -127 to 127.
-		 * @param right speed of the right side of the drivetrain. Takes an input from
-		 * -127 to 127.
-		 * @param curveGain control how steep the drive curve is. The larger the
-		 * number, the steeper the curve. A value of 0 disables the curve entirely.
-		 */
-		void tank(int left, int right, float curveGain = 0.0);
-		/**
-		 * @brief Control the robot during the driver using the arcade drive control
-		 * scheme. In this control scheme one joystick axis controls the forwards and
-		 * backwards movement of the robot, while the other joystick axis controls the
-		 * robot's turning
-		 * @param throttle speed to move forward or backward. Takes an input from -127
-		 * to 127.
-		 * @param turn speed to turn. Takes an input from -127 to 127.
-		 * @param curveGain the scale inputted into the drive curve function. If you
-		 * are using the default drive curve, refer to the `defaultDriveCurve`
-		 * documentation.
-		 */
-		void arcade(int throttle, int turn, float curveGain = 0.0);
-		/**
-		 * @brief Control the robot during the driver using the curvature drive
-		 * control scheme. This control scheme is very similar to arcade drive, except
-		 * the second joystick axis controls the radius of the curve that the
-		 * drivetrain makes, rather than the speed. This means that the driver can
-		 * accelerate in a turn without changing the radius of that turn. This control
-		 * scheme defaults to arcade when forward is zero.
-		 * @param throttle speed to move forward or backward. Takes an input from -127
-		 * to 127.
-		 * @param turn speed to turn. Takes an input from -127 to 127.
-		 * @param curveGain the scale inputted into the drive curve function. If you
-		 * are using the default drive curve, refer to the `defaultDriveCurve`
-		 * documentation.
-		 */
-		void curvature(int throttle, int turn, float cureGain = 0.0);
-		/**
-		 * @brief Cancels the currently running motion.
-		 * If there is a queued motion, then that queued motion will run.
-		 */
-		void cancelMotion();
-		/**
-		 * @brief Cancels all motions, even those that are queued.
-		 * After this, the chassis will not be in motion.
-		 */
-		void cancelAllMotions();
-		/**
-		 * @return whether a motion is currently running
-		 */
-		bool isInMotion() const;
-		protected:
-			/**
-			 * @brief Indicates that this motion is queued and blocks current task until
-			 * this motion reaches front of queue
-			 */
-			void requestMotionStart();
-		/**
-		 * @brief Dequeues this motion and permits queued task to run
-		 */
-		void endMotion();
-		private: bool motionRunning = false;
-		bool motionQueued = false;
-		pros::Mutex mutex;
-		float distTravelled = 0;
-		ControllerSettings lateralSettings;
-		ControllerSettings angularSettings;
-		Drivetrain drivetrain;
-		OdomSensors sensors;
-		DriveCurveFunction_t driveCurve;
-		PID lateralPID;
-		PID angularPID;
-		ExitCondition lateralLargeExit;
-		ExitCondition lateralSmallExit;
-		ExitCondition angularLargeExit;
-		ExitCondition angularSmallExit;
-	};
+/**
+ * @brief Struct containing all the sensors used for odometry
+ *
+ */
+struct OdomSensors {
+    /**
+     * The sensors are stored in a struct so that they can be easily passed to the
+     * chassis class The variables are pointers so that they can be set to nullptr
+     * if they are not used Otherwise the chassis class would have to have a
+     * constructor for each possible combination of sensors
+     *
+     * @param vertical1 pointer to the first vertical tracking wheel
+     * @param vertical2 pointer to the second vertical tracking wheel
+     * @param horizontal1 pointer to the first horizontal tracking wheel
+     * @param horizontal2 pointer to the second horizontal tracking wheel
+     * @param imu pointer to the IMU
+     */
+    OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
+                TrackingWheel* horizontal2, pros::Imu* imu);
+    TrackingWheel* vertical1;
+    TrackingWheel* vertical2;
+    TrackingWheel* horizontal1;
+    TrackingWheel* horizontal2;
+    pros::Imu* imu;
+};
+/**
+ * @brief Struct containing constants for a chassis controller
+ *
+ */
+struct ControllerSettings {
+    /**
+     * The constants are stored in a struct so that they can be easily passed to
+     * the chassis class Set a constant to 0 and it will be ignored
+     *
+     * @param kP proportional constant for the chassis controller
+     * @param kI integral constant for the chassis controller
+     * @param kD derivative constant for the chassis controller
+     * @param antiWindup
+     * @param smallError the error at which the chassis controller will switch to
+     * a slower control loop
+     * @param smallErrorTimeout the time the chassis controller will wait before
+     * switching to a slower control loop
+     * @param largeError the error at which the chassis controller will switch to
+     * a faster control loop
+     * @param largeErrorTimeout the time the chassis controller will wait before
+     * switching to a faster control loop
+     * @param slew the maximum acceleration of the chassis controller
+     */
+    ControllerSettings(float kP, float kI, float kD, float windupRange, float smallError, float smallErrorTimeout,
+                       float largeError, float largeErrorTimeout, float slew)
+        : kP(kP), kI(kI), kD(kD), windupRange(windupRange), smallError(smallError),
+          smallErrorTimeout(smallErrorTimeout), largeError(largeError), largeErrorTimeout(largeErrorTimeout),
+          slew(slew) {}
+    float kP;
+    float kI;
+    float kD;
+    float windupRange;
+    float smallError;
+    float smallErrorTimeout;
+    float largeError;
+    float largeErrorTimeout;
+    float slew;
+};
+/**
+ * @brief Struct containing constants for a drivetrain
+ *
+ */
+struct Drivetrain {
+    /**
+     * The constants are stored in a struct so that they can be easily passed to
+     * the chassis class Set a constant to 0 and it will be ignored
+     *
+     * @param leftMotors pointer to the left motors
+     * @param rightMotors pointer to the right motors
+     * @param trackWidth the track width of the robot
+     * @param wheelDiameter the diameter of the wheel used on the drivetrain
+     * @param rpm the rpm of the wheels
+     * @param chasePower higher values make the robot move faster but causes more
+     * overshoot on turns
+     */
+    Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth, float wheelDiameter,
+               float rpm, float chasePower);
+    pros::Motor_Group* leftMotors;
+    pros::Motor_Group* rightMotors;
+    float trackWidth;
+    float wheelDiameter;
+    float rpm;
+    float chasePower;
+};
+/**
+ * @brief Targets for Chassis::moveToPose
+ *
+ * We use a struct to simplify customization. Chassis::moveToPose has many
+ * parameters and specifying them all just to set one optional param ruins
+ * readability. By passing a struct to the function, we can have named
+ * parameters, overcoming the c/c++ limitation
+ *
+ * @param dist whether the robot should move forwards or backwards. True by
+ * default
+ * @param x how fast the robot will move around corners. Recommended value 2-15.
+ *  0 means use chasePower set in chassis class. 0 by default.
+ * @param y carrot point multiplier. value between 0 and 1. Higher values result
+ * in curvier movements. 0.6 by default
+ * @param theta the maximum speed the robot can travel at. Value between 0-127.
+ *  127 by default
+ */
+struct MoveToPoseTargets {
+    float dist = std::numeric_limits<float>::quiet_NaN();
+    float x = std::numeric_limits<float>::quiet_NaN();
+    float y = std::numeric_limits<float>::quiet_NaN();
+    float theta = std::numeric_limits<float>::quiet_NaN();
+};
+/**
+ * @brief Flags for Chassis::moveToPose
+ *
+ * We use a struct to simplify customization. Chassis::moveToPose has many
+ * parameters and specifying them all just to set one optional param ruins
+ * readability. By passing a struct to the function, we can have named
+ * parameters, overcoming the c/c++ limitation
+ *
+ * @param forwards whether the robot should move forwards or backwards. True by
+ * default
+ * @param chasePower how fast the robot will move around corners. Recommended
+ * value 2-15. 0 means use chasePower set in chassis class. 0 by default.
+ * @param lead carrot point multiplier. value between 0 and 1. Higher values
+ * result in curvier movements. 0.6 by default
+ * @param maxSpeed the maximum speed the robot can travel at. Value between
+ * 0-127. 127 by default
+ * @param minSpeed the minimum speed the robot can travel at. If set to a
+ * non-zero value, the exit conditions will switch to less accurate but smoother
+ * ones. Value between 0-127. 0 by default
+ * @param earlyExitRange distance between the robot and target point where the
+ * movement will exit. Only has an effect if minSpeed is non-zero.
+ */
+struct lemlib::MoveToPoseFlags {
+    bool forwards = true;
+    float chasePower = 0;
+    float lead = 0.6;
+    float maxSpeed = 127;
+    float minSpeed = 0;
+    float earlyExitRange = 0;
+};
+/**
+ * @brief Function pointer type for drive curve functions.
+ * @param input The control input in the range [-127, 127].
+ * @param scale The scaling factor, which can be optionally ignored.
+ * @return The new value to be used.
+ */
+typedef std::function<float(float, float)> DriveCurveFunction_t;
+/**
+ * @brief  Default drive curve. Modifies  the input with an exponential curve.
+ * If the input is 127, the function will always output 127, no matter the value
+ * of scale, likewise for -127. This curve was inspired by team 5225, the
+ * Pilons. A Desmos graph of this curve can be found here:
+ * https://www.desmos.com/calculator/rcfjjg83zx
+ * @param input value from -127 to 127
+ * @param scale how steep the curve should be.
+ * @return The new value to be used.
+ */
+float defaultDriveCurve(float input, float scale);
+/**
+ * @brief Chassis class
+ *
+ */
+class Chassis {
+    public:
+    /**
+     * @brief Construct a new Chassis
+     *
+     * @param drivetrain drivetrain to be used for the chassis
+     * @param lateralSettings settings for the lateral controller
+     * @param angularSettings settings for the angular controller
+     * @param sensors sensors to be used for odometry
+     * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
+     */
+    Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
+            OdomSensors sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
+    /**
+     * @brief Calibrate the chassis sensors
+     *
+     * @param calibrateIMU whether the IMU should be calibrated. true by default
+     */
+    void calibrate(bool calibrateIMU = true);
+    /**
+     * @brief Set the pose of the chassis
+     *
+     * @param x new x value
+     * @param y new y value
+     * @param theta new theta value
+     * @param radians true if theta is in radians, false if not. False by default
+     */
+    void setPose(float x, float y, float theta, bool radians = false);
+    /**
+     * @brief Set the pose of the chassis
+     *
+     * @param pose the new pose
+     * @param radians whether pose theta is in radians (true) or not (false).
+     * false by default
+     */
+    void setPose(Pose pose, bool radians = false);
+    /**
+     * @brief Get the pose of the chassis
+     *
+     * @param radians whether theta should be in radians (true) or degrees
+     * (false). false by default
+     * @return Pose
+     */
+    Pose getPose(bool radians = false, bool standardPos = false);
+    /**
+     * @brief Wait until the robot has traveled a certain distance along the path
+     *
+     * @note Units are in inches if current motion is moveTo or follow, degrees if
+     * using turnTo
+     *
+     * @param dist the distance the robot needs to travel before returning
+     */
+    void waitUntil(float dist);
+    /**
+     * @brief Wait until the robot has completed the path
+     *
+     */
+    void waitUntilDone();
+    /**
+     * @brief Turn the chassis so it is facing the target point
+     *
+     * The PID logging id is "angularPID"
+     *
+     * @param x x location
+     * @param y y location
+     * @param timeout longest time the robot can spend moving
+     * @param forwards whether the robot should turn to face the point with the
+     * front of the robot. true by default
+     * @param maxSpeed the maximum speed the robot can turn at. Default is 127
+     * @param async whether the function should be run asynchronously. true by
+     * default
+     */
+    void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
+    /**
+     * @brief Move the chassis towards the target pose
+     *
+     * Uses the boomerang controller
+     *
+     * @param x x location
+     * @param y y location
+     * @param theta target heading in degrees.
+     * @param timeout longest time the robot can spend moving
+     * @param params struct to simulate named parameters
+     * @param async whether the function should be run asynchronously. true by
+     * default
+     */
+    void moveToPose(MoveToPoseTarget targetPose, int timeout, lemlib::MoveToPoseFlags params = {}, bool async = true);
+    /**
+     * @brief Move the chassis towards a target point
+     *
+     * @param x x location
+     * @param y y location
+     * @param timeout longest time the robot can spend moving
+     * @param maxSpeed the maximum speed the robot can move at. 127 by default
+     * @param async whether the function should be run asynchronously. true by
+     * default
+     */
+    void moveToPoint(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
+    /**
+     * @brief Move the chassis along a path
+     *
+     * @param path the path asset to follow
+     * @param lookahead the lookahead distance. Units in inches. Larger values
+     * will make the robot move faster but will follow the path less accurately
+     * @param timeout the maximum time the robot can spend moving
+     * @param forwards whether the robot should follow the path going forwards.
+     * true by default
+     * @param async whether the function should be run asynchronously. true by
+     * default
+     */
+    void follow(const asset& path, float lookahead, int timeout, bool forwards = true, bool async = true);
+    /**
+     * @brief Control the robot during the driver control period using the tank
+     * drive control scheme. In this control scheme one joystick axis controls one
+     * half of the robot, and another joystick axis controls another.
+     * @param left speed of the left side of the drivetrain. Takes an input from
+     * -127 to 127.
+     * @param right speed of the right side of the drivetrain. Takes an input from
+     * -127 to 127.
+     * @param curveGain control how steep the drive curve is. The larger the
+     * number, the steeper the curve. A value of 0 disables the curve entirely.
+     */
+    void tank(int left, int right, float curveGain = 0.0);
+    /**
+     * @brief Control the robot during the driver using the arcade drive control
+     * scheme. In this control scheme one joystick axis controls the forwards and
+     * backwards movement of the robot, while the other joystick axis controls the
+     * robot's turning
+     * @param throttle speed to move forward or backward. Takes an input from -127
+     * to 127.
+     * @param turn speed to turn. Takes an input from -127 to 127.
+     * @param curveGain the scale inputted into the drive curve function. If you
+     * are using the default drive curve, refer to the `defaultDriveCurve`
+     * documentation.
+     */
+    void arcade(int throttle, int turn, float curveGain = 0.0);
+    /**
+     * @brief Control the robot during the driver using the curvature drive
+     * control scheme. This control scheme is very similar to arcade drive, except
+     * the second joystick axis controls the radius of the curve that the
+     * drivetrain makes, rather than the speed. This means that the driver can
+     * accelerate in a turn without changing the radius of that turn. This control
+     * scheme defaults to arcade when forward is zero.
+     * @param throttle speed to move forward or backward. Takes an input from -127
+     * to 127.
+     * @param turn speed to turn. Takes an input from -127 to 127.
+     * @param curveGain the scale inputted into the drive curve function. If you
+     * are using the default drive curve, refer to the `defaultDriveCurve`
+     * documentation.
+     */
+    void curvature(int throttle, int turn, float cureGain = 0.0);
+    /**
+     * @brief Cancels the currently running motion.
+     * If there is a queued motion, then that queued motion will run.
+     */
+    void cancelMotion();
+    /**
+     * @brief Cancels all motions, even those that are queued.
+     * After this, the chassis will not be in motion.
+     */
+    void cancelAllMotions();
+    /**
+     * @return whether a motion is currently running
+     */
+    bool isInMotion() const;
+
+    protected:
+    /**
+     * @brief Indicates that this motion is queued and blocks current task until
+     * this motion reaches front of queue
+     */
+    void requestMotionStart();
+    /**
+     * @brief Dequeues this motion and permits queued task to run
+     */
+    void endMotion();
+
+    private:
+    bool motionRunning = false;
+    bool motionQueued = false;
+    pros::Mutex mutex;
+    float distTravelled = 0;
+    ControllerSettings lateralSettings;
+    ControllerSettings angularSettings;
+    Drivetrain drivetrain;
+    OdomSensors sensors;
+    DriveCurveFunction_t driveCurve;
+    PID lateralPID;
+    PID angularPID;
+    ExitCondition lateralLargeExit;
+    ExitCondition lateralSmallExit;
+    ExitCondition angularLargeExit;
+    ExitCondition angularSmallExit;
+};
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -19,7 +19,9 @@
 #include "pros/imu.hpp"
 #include "pros/motors.hpp"
 #include "pros/rtos.hpp"
+#include <cmath>
 #include <functional>
+#include <limits>
 
 namespace lemlib {
 /**

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -197,7 +197,7 @@ float defaultDriveCurve(float input, float scale);
  *
  */
 class Chassis {
-  public:
+public:
   /**
    * @brief Construct a new Chassis
    *
@@ -367,7 +367,7 @@ class Chassis {
    */
   bool isInMotion() const;
 
-  protected:
+protected:
   /**
    * @brief Indicates that this motion is queued and blocks current task until
    * this motion reaches front of queue
@@ -378,7 +378,7 @@ class Chassis {
    */
   void endMotion();
 
-  private:
+private:
   bool motionRunning = false;
   bool motionQueued = false;
 

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -27,90 +27,100 @@ namespace lemlib {
  *
  */
 struct OdomSensors {
-    /**
-     * The sensors are stored in a struct so that they can be easily passed to the
-     * chassis class The variables are pointers so that they can be set to nullptr
-     * if they are not used Otherwise the chassis class would have to have a
-     * constructor for each possible combination of sensors
-     *
-     * @param vertical1 pointer to the first vertical tracking wheel
-     * @param vertical2 pointer to the second vertical tracking wheel
-     * @param horizontal1 pointer to the first horizontal tracking wheel
-     * @param horizontal2 pointer to the second horizontal tracking wheel
-     * @param imu pointer to the IMU
-     */
-    OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
-                TrackingWheel* horizontal2, pros::Imu* imu);
-    TrackingWheel* vertical1;
-    TrackingWheel* vertical2;
-    TrackingWheel* horizontal1;
-    TrackingWheel* horizontal2;
-    pros::Imu* imu;
+        /**
+         * The sensors are stored in a struct so that they can be easily passed to the
+         * chassis class The variables are pointers so that they can be set to nullptr
+         * if they are not used Otherwise the chassis class would have to have a
+         * constructor for each possible combination of sensors
+         *
+         * @param vertical1 pointer to the first vertical tracking wheel
+         * @param vertical2 pointer to the second vertical tracking wheel
+         * @param horizontal1 pointer to the first horizontal tracking wheel
+         * @param horizontal2 pointer to the second horizontal tracking wheel
+         * @param imu pointer to the IMU
+         */
+        OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
+                    TrackingWheel* horizontal2, pros::Imu* imu);
+        TrackingWheel* vertical1;
+        TrackingWheel* vertical2;
+        TrackingWheel* horizontal1;
+        TrackingWheel* horizontal2;
+        pros::Imu* imu;
 };
+
 /**
  * @brief Struct containing constants for a chassis controller
  *
  */
 struct ControllerSettings {
-    /**
-     * The constants are stored in a struct so that they can be easily passed to
-     * the chassis class Set a constant to 0 and it will be ignored
-     *
-     * @param kP proportional constant for the chassis controller
-     * @param kI integral constant for the chassis controller
-     * @param kD derivative constant for the chassis controller
-     * @param antiWindup
-     * @param smallError the error at which the chassis controller will switch to
-     * a slower control loop
-     * @param smallErrorTimeout the time the chassis controller will wait before
-     * switching to a slower control loop
-     * @param largeError the error at which the chassis controller will switch to
-     * a faster control loop
-     * @param largeErrorTimeout the time the chassis controller will wait before
-     * switching to a faster control loop
-     * @param slew the maximum acceleration of the chassis controller
-     */
-    ControllerSettings(float kP, float kI, float kD, float windupRange, float smallError, float smallErrorTimeout,
-                       float largeError, float largeErrorTimeout, float slew)
-        : kP(kP), kI(kI), kD(kD), windupRange(windupRange), smallError(smallError),
-          smallErrorTimeout(smallErrorTimeout), largeError(largeError), largeErrorTimeout(largeErrorTimeout),
-          slew(slew) {}
-    float kP;
-    float kI;
-    float kD;
-    float windupRange;
-    float smallError;
-    float smallErrorTimeout;
-    float largeError;
-    float largeErrorTimeout;
-    float slew;
+        /**
+         * The constants are stored in a struct so that they can be easily passed to
+         * the chassis class Set a constant to 0 and it will be ignored
+         *
+         * @param kP proportional constant for the chassis controller
+         * @param kI integral constant for the chassis controller
+         * @param kD derivative constant for the chassis controller
+         * @param antiWindup
+         * @param smallError the error at which the chassis controller will switch to
+         * a slower control loop
+         * @param smallErrorTimeout the time the chassis controller will wait before
+         * switching to a slower control loop
+         * @param largeError the error at which the chassis controller will switch to
+         * a faster control loop
+         * @param largeErrorTimeout the time the chassis controller will wait before
+         * switching to a faster control loop
+         * @param slew the maximum acceleration of the chassis controller
+         */
+        ControllerSettings(float kP, float kI, float kD, float windupRange, float smallError, float smallErrorTimeout,
+                           float largeError, float largeErrorTimeout, float slew)
+            : kP(kP),
+              kI(kI),
+              kD(kD),
+              windupRange(windupRange),
+              smallError(smallError),
+              smallErrorTimeout(smallErrorTimeout),
+              largeError(largeError),
+              largeErrorTimeout(largeErrorTimeout),
+              slew(slew) {}
+
+        float kP;
+        float kI;
+        float kD;
+        float windupRange;
+        float smallError;
+        float smallErrorTimeout;
+        float largeError;
+        float largeErrorTimeout;
+        float slew;
 };
+
 /**
  * @brief Struct containing constants for a drivetrain
  *
  */
 struct Drivetrain {
-    /**
-     * The constants are stored in a struct so that they can be easily passed to
-     * the chassis class Set a constant to 0 and it will be ignored
-     *
-     * @param leftMotors pointer to the left motors
-     * @param rightMotors pointer to the right motors
-     * @param trackWidth the track width of the robot
-     * @param wheelDiameter the diameter of the wheel used on the drivetrain
-     * @param rpm the rpm of the wheels
-     * @param chasePower higher values make the robot move faster but causes more
-     * overshoot on turns
-     */
-    Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth, float wheelDiameter,
-               float rpm, float chasePower);
-    pros::Motor_Group* leftMotors;
-    pros::Motor_Group* rightMotors;
-    float trackWidth;
-    float wheelDiameter;
-    float rpm;
-    float chasePower;
+        /**
+         * The constants are stored in a struct so that they can be easily passed to
+         * the chassis class Set a constant to 0 and it will be ignored
+         *
+         * @param leftMotors pointer to the left motors
+         * @param rightMotors pointer to the right motors
+         * @param trackWidth the track width of the robot
+         * @param wheelDiameter the diameter of the wheel used on the drivetrain
+         * @param rpm the rpm of the wheels
+         * @param chasePower higher values make the robot move faster but causes more
+         * overshoot on turns
+         */
+        Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth, float wheelDiameter,
+                   float rpm, float chasePower);
+        pros::Motor_Group* leftMotors;
+        pros::Motor_Group* rightMotors;
+        float trackWidth;
+        float wheelDiameter;
+        float rpm;
+        float chasePower;
 };
+
 /**
  * @brief Targets for Chassis::moveToPose
  *
@@ -129,10 +139,10 @@ struct Drivetrain {
  *  127 by default
  */
 struct MoveToPoseTarget {
-    float dist = std::numeric_limits<float>::quiet_NaN();
-    float x = std::numeric_limits<float>::quiet_NaN();
-    float y = std::numeric_limits<float>::quiet_NaN();
-    float theta = std::numeric_limits<float>::quiet_NaN();
+        float dist = std::numeric_limits<float>::quiet_NaN();
+        float x = std::numeric_limits<float>::quiet_NaN();
+        float y = std::numeric_limits<float>::quiet_NaN();
+        float theta = std::numeric_limits<float>::quiet_NaN();
 };
 
 // Enum to represent different movement types
@@ -142,6 +152,7 @@ enum MovementType {
     ClassicMovement
     // Add more movement types as needed
 };
+
 /**
  * @brief Flags for Chassis::moveToPose
  *
@@ -165,13 +176,14 @@ enum MovementType {
  * movement will exit. Only has an effect if minSpeed is non-zero.
  */
 struct MoveToPoseFlags {
-    bool forwards = true;
-    float chasePower = 0;
-    float lead = 0.6;
-    float maxSpeed = 127;
-    float minSpeed = 0;
-    float earlyExitRange = 0;
+        bool forwards = true;
+        float chasePower = 0;
+        float lead = 0.6;
+        float maxSpeed = 127;
+        float minSpeed = 0;
+        float earlyExitRange = 0;
 };
+
 /**
  * @brief Function pointer type for drive curve functions.
  * @param input The control input in the range [-127, 127].
@@ -190,203 +202,202 @@ typedef std::function<float(float, float)> DriveCurveFunction_t;
  * @return The new value to be used.
  */
 float defaultDriveCurve(float input, float scale);
+
 /**
  * @brief Chassis class
  *
  */
 class Chassis {
     public:
-    /**
-     * @brief Construct a new Chassis
-     *
-     * @param drivetrain drivetrain to be used for the chassis
-     * @param lateralSettings settings for the lateral controller
-     * @param angularSettings settings for the angular controller
-     * @param sensors sensors to be used for odometry
-     * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
-     */
-    Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
-            OdomSensors sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
-    /**
-     * @brief Calibrate the chassis sensors
-     *
-     * @param calibrateIMU whether the IMU should be calibrated. true by default
-     */
-    void calibrate(bool calibrateIMU = true);
-    /**
-     * @brief Set the pose of the chassis
-     *
-     * @param x new x value
-     * @param y new y value
-     * @param theta new theta value
-     * @param radians true if theta is in radians, false if not. False by default
-     */
-    void setPose(float x, float y, float theta, bool radians = false);
-    /**
-     * @brief Set the pose of the chassis
-     *
-     * @param pose the new pose
-     * @param radians whether pose theta is in radians (true) or not (false).
-     * false by default
-     */
-    void setPose(Pose pose, bool radians = false);
-    /**
-     * @brief Get the pose of the chassis
-     *
-     * @param radians whether theta should be in radians (true) or degrees
-     * (false). false by default
-     * @return Pose
-     */
-    Pose getPose(bool radians = false, bool standardPos = false);
-    /**
-     * @brief Wait until the robot has traveled a certain distance along the path
-     *
-     * @note Units are in inches if current motion is moveTo or follow, degrees if
-     * using turnTo
-     *
-     * @param dist the distance the robot needs to travel before returning
-     */
-    void waitUntil(float dist);
-    /**
-     * @brief Wait until the robot has completed the path
-     *
-     */
-    void waitUntilDone();
-    /**
-     * @brief Turn the chassis so it is facing the target point
-     *
-     * The PID logging id is "angularPID"
-     *
-     * @param x x location
-     * @param y y location
-     * @param timeout longest time the robot can spend moving
-     * @param forwards whether the robot should turn to face the point with the
-     * front of the robot. true by default
-     * @param maxSpeed the maximum speed the robot can turn at. Default is 127
-     * @param async whether the function should be run asynchronously. true by
-     * default
-     */
-    void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-    /**
-     * @brief Move the chassis towards the target pose
-     *
-     * Uses the boomerang controller
-     *
-     * @param x x location
-     * @param y y location
-     * @param theta target heading in degrees.
-     * @param timeout longest time the robot can spend moving
-     * @param params struct to simulate named parameters
-     * @param async whether the function should be run asynchronously. true by
-     * default
-     */
-    void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params = {}, bool async = true);
-    /**
-     * @brief Move the chassis towards a target point
-     *
-     * @param x x location
-     * @param y y location
-     * @param timeout longest time the robot can spend moving
-     * @param maxSpeed the maximum speed the robot can move at. 127 by default
-     * @param async whether the function should be run asynchronously. true by
-     * default
-     */
-    void moveToPoint(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-    /**
-     * @brief Move the chassis along a path
-     *
-     * @param path the path asset to follow
-     * @param lookahead the lookahead distance. Units in inches. Larger values
-     * will make the robot move faster but will follow the path less accurately
-     * @param timeout the maximum time the robot can spend moving
-     * @param forwards whether the robot should follow the path going forwards.
-     * true by default
-     * @param async whether the function should be run asynchronously. true by
-     * default
-     */
-    void follow(const asset& path, float lookahead, int timeout, bool forwards = true, bool async = true);
-    /**
-     * @brief Control the robot during the driver control period using the tank
-     * drive control scheme. In this control scheme one joystick axis controls one
-     * half of the robot, and another joystick axis controls another.
-     * @param left speed of the left side of the drivetrain. Takes an input from
-     * -127 to 127.
-     * @param right speed of the right side of the drivetrain. Takes an input from
-     * -127 to 127.
-     * @param curveGain control how steep the drive curve is. The larger the
-     * number, the steeper the curve. A value of 0 disables the curve entirely.
-     */
-    void tank(int left, int right, float curveGain = 0.0);
-    /**
-     * @brief Control the robot during the driver using the arcade drive control
-     * scheme. In this control scheme one joystick axis controls the forwards and
-     * backwards movement of the robot, while the other joystick axis controls the
-     * robot's turning
-     * @param throttle speed to move forward or backward. Takes an input from -127
-     * to 127.
-     * @param turn speed to turn. Takes an input from -127 to 127.
-     * @param curveGain the scale inputted into the drive curve function. If you
-     * are using the default drive curve, refer to the `defaultDriveCurve`
-     * documentation.
-     */
-    void arcade(int throttle, int turn, float curveGain = 0.0);
-    /**
-     * @brief Control the robot during the driver using the curvature drive
-     * control scheme. This control scheme is very similar to arcade drive, except
-     * the second joystick axis controls the radius of the curve that the
-     * drivetrain makes, rather than the speed. This means that the driver can
-     * accelerate in a turn without changing the radius of that turn. This control
-     * scheme defaults to arcade when forward is zero.
-     * @param throttle speed to move forward or backward. Takes an input from -127
-     * to 127.
-     * @param turn speed to turn. Takes an input from -127 to 127.
-     * @param curveGain the scale inputted into the drive curve function. If you
-     * are using the default drive curve, refer to the `defaultDriveCurve`
-     * documentation.
-     */
-    void curvature(int throttle, int turn, float cureGain = 0.0);
-    /**
-     * @brief Cancels the currently running motion.
-     * If there is a queued motion, then that queued motion will run.
-     */
-    void cancelMotion();
-    /**
-     * @brief Cancels all motions, even those that are queued.
-     * After this, the chassis will not be in motion.
-     */
-    void cancelAllMotions();
-    /**
-     * @return whether a motion is currently running
-     */
-    bool isInMotion() const;
-
+        /**
+         * @brief Construct a new Chassis
+         *
+         * @param drivetrain drivetrain to be used for the chassis
+         * @param lateralSettings settings for the lateral controller
+         * @param angularSettings settings for the angular controller
+         * @param sensors sensors to be used for odometry
+         * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
+         */
+        Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
+                OdomSensors sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
+        /**
+         * @brief Calibrate the chassis sensors
+         *
+         * @param calibrateIMU whether the IMU should be calibrated. true by default
+         */
+        void calibrate(bool calibrateIMU = true);
+        /**
+         * @brief Set the pose of the chassis
+         *
+         * @param x new x value
+         * @param y new y value
+         * @param theta new theta value
+         * @param radians true if theta is in radians, false if not. False by default
+         */
+        void setPose(float x, float y, float theta, bool radians = false);
+        /**
+         * @brief Set the pose of the chassis
+         *
+         * @param pose the new pose
+         * @param radians whether pose theta is in radians (true) or not (false).
+         * false by default
+         */
+        void setPose(Pose pose, bool radians = false);
+        /**
+         * @brief Get the pose of the chassis
+         *
+         * @param radians whether theta should be in radians (true) or degrees
+         * (false). false by default
+         * @return Pose
+         */
+        Pose getPose(bool radians = false, bool standardPos = false);
+        /**
+         * @brief Wait until the robot has traveled a certain distance along the path
+         *
+         * @note Units are in inches if current motion is moveTo or follow, degrees if
+         * using turnTo
+         *
+         * @param dist the distance the robot needs to travel before returning
+         */
+        void waitUntil(float dist);
+        /**
+         * @brief Wait until the robot has completed the path
+         *
+         */
+        void waitUntilDone();
+        /**
+         * @brief Turn the chassis so it is facing the target point
+         *
+         * The PID logging id is "angularPID"
+         *
+         * @param x x location
+         * @param y y location
+         * @param timeout longest time the robot can spend moving
+         * @param forwards whether the robot should turn to face the point with the
+         * front of the robot. true by default
+         * @param maxSpeed the maximum speed the robot can turn at. Default is 127
+         * @param async whether the function should be run asynchronously. true by
+         * default
+         */
+        void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
+        /**
+         * @brief Move the chassis towards the target pose
+         *
+         * Uses the boomerang controller
+         *
+         * @param x x location
+         * @param y y location
+         * @param theta target heading in degrees.
+         * @param timeout longest time the robot can spend moving
+         * @param params struct to simulate named parameters
+         * @param async whether the function should be run asynchronously. true by
+         * default
+         */
+        void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params = {}, bool async = true);
+        /**
+         * @brief Move the chassis towards a target point
+         *
+         * @param x x location
+         * @param y y location
+         * @param timeout longest time the robot can spend moving
+         * @param maxSpeed the maximum speed the robot can move at. 127 by default
+         * @param async whether the function should be run asynchronously. true by
+         * default
+         */
+        void moveToPoint(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
+        /**
+         * @brief Move the chassis along a path
+         *
+         * @param path the path asset to follow
+         * @param lookahead the lookahead distance. Units in inches. Larger values
+         * will make the robot move faster but will follow the path less accurately
+         * @param timeout the maximum time the robot can spend moving
+         * @param forwards whether the robot should follow the path going forwards.
+         * true by default
+         * @param async whether the function should be run asynchronously. true by
+         * default
+         */
+        void follow(const asset& path, float lookahead, int timeout, bool forwards = true, bool async = true);
+        /**
+         * @brief Control the robot during the driver control period using the tank
+         * drive control scheme. In this control scheme one joystick axis controls one
+         * half of the robot, and another joystick axis controls another.
+         * @param left speed of the left side of the drivetrain. Takes an input from
+         * -127 to 127.
+         * @param right speed of the right side of the drivetrain. Takes an input from
+         * -127 to 127.
+         * @param curveGain control how steep the drive curve is. The larger the
+         * number, the steeper the curve. A value of 0 disables the curve entirely.
+         */
+        void tank(int left, int right, float curveGain = 0.0);
+        /**
+         * @brief Control the robot during the driver using the arcade drive control
+         * scheme. In this control scheme one joystick axis controls the forwards and
+         * backwards movement of the robot, while the other joystick axis controls the
+         * robot's turning
+         * @param throttle speed to move forward or backward. Takes an input from -127
+         * to 127.
+         * @param turn speed to turn. Takes an input from -127 to 127.
+         * @param curveGain the scale inputted into the drive curve function. If you
+         * are using the default drive curve, refer to the `defaultDriveCurve`
+         * documentation.
+         */
+        void arcade(int throttle, int turn, float curveGain = 0.0);
+        /**
+         * @brief Control the robot during the driver using the curvature drive
+         * control scheme. This control scheme is very similar to arcade drive, except
+         * the second joystick axis controls the radius of the curve that the
+         * drivetrain makes, rather than the speed. This means that the driver can
+         * accelerate in a turn without changing the radius of that turn. This control
+         * scheme defaults to arcade when forward is zero.
+         * @param throttle speed to move forward or backward. Takes an input from -127
+         * to 127.
+         * @param turn speed to turn. Takes an input from -127 to 127.
+         * @param curveGain the scale inputted into the drive curve function. If you
+         * are using the default drive curve, refer to the `defaultDriveCurve`
+         * documentation.
+         */
+        void curvature(int throttle, int turn, float cureGain = 0.0);
+        /**
+         * @brief Cancels the currently running motion.
+         * If there is a queued motion, then that queued motion will run.
+         */
+        void cancelMotion();
+        /**
+         * @brief Cancels all motions, even those that are queued.
+         * After this, the chassis will not be in motion.
+         */
+        void cancelAllMotions();
+        /**
+         * @return whether a motion is currently running
+         */
+        bool isInMotion() const;
     protected:
-    /**
-     * @brief Indicates that this motion is queued and blocks current task until
-     * this motion reaches front of queue
-     */
-    void requestMotionStart();
-    /**
-     * @brief Dequeues this motion and permits queued task to run
-     */
-    void endMotion();
-
+        /**
+         * @brief Indicates that this motion is queued and blocks current task until
+         * this motion reaches front of queue
+         */
+        void requestMotionStart();
+        /**
+         * @brief Dequeues this motion and permits queued task to run
+         */
+        void endMotion();
     private:
-    bool motionRunning = false;
-    bool motionQueued = false;
-    pros::Mutex mutex;
-    float distTravelled = 0;
-    ControllerSettings lateralSettings;
-    ControllerSettings angularSettings;
-    Drivetrain drivetrain;
-    OdomSensors sensors;
-    DriveCurveFunction_t driveCurve;
-    PID lateralPID;
-    PID angularPID;
-    ExitCondition lateralLargeExit;
-    ExitCondition lateralSmallExit;
-    ExitCondition angularLargeExit;
-    ExitCondition angularSmallExit;
-    MovementType getMovementType(const MoveToPoseTarget& params_t);
+        bool motionRunning = false;
+        bool motionQueued = false;
+        pros::Mutex mutex;
+        float distTravelled = 0;
+        ControllerSettings lateralSettings;
+        ControllerSettings angularSettings;
+        Drivetrain drivetrain;
+        OdomSensors sensors;
+        DriveCurveFunction_t driveCurve;
+        PID lateralPID;
+        PID angularPID;
+        ExitCondition lateralLargeExit;
+        ExitCondition lateralSmallExit;
+        ExitCondition angularLargeExit;
+        ExitCondition angularSmallExit;
+        MovementType getMovementType(const MoveToPoseTarget& params_t);
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -396,7 +396,7 @@ class Chassis {
         ExitCondition lateralSmallExit;
         ExitCondition angularLargeExit;
         ExitCondition angularSmallExit;
-        void getMovementType(const MoveToPoseTarget& params);
-        void getTarget(MovementType mType, const MoveToPoseTarget& params_t);
+        MovementType getMovementType(const MoveToPoseTarget& params);
+        Pose getTarget(MovementType mType, const MoveToPoseTarget& params_t);
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -140,7 +140,7 @@ struct Drivetrain {
  *  127 by default
  */
 struct MoveToPoseTarget {
-        std::vector<float> params(4, std::numeric_limits<float>::quiet_NaN());
+        std::vector<float> params{4,std::numeric_limits<float>::quiet_NaN()};
 };
 
 // Enum to represent different movement types
@@ -396,7 +396,7 @@ class Chassis {
         ExitCondition lateralSmallExit;
         ExitCondition angularLargeExit;
         ExitCondition angularSmallExit;
-        MovementType getMovementType(const MoveToPoseTarget& params);
-        void getTarget(MovementType mType);
+        void getMovementType(const MoveToPoseTarget& params);
+        void getTarget(MovementType mType, const MoveToPoseTarget& params_t);
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -114,9 +114,30 @@ struct Drivetrain {
         float rpm;
         float chasePower;
 };
-
 /**
- * @brief Parameters for Chassis::moveToPose
+ * @brief Targets for Chassis::moveToPose
+ *
+ * We use a struct to simplify customization. Chassis::moveToPose has many
+ * parameters and specifying them all just to set one optional param ruins
+ * readability. By passing a struct to the function, we can have named
+ * parameters, overcoming the c/c++ limitation
+ *
+ * @param dist whether the robot should move forwards or backwards. True by default
+ * @param x how fast the robot will move around corners. Recommended value 2-15.
+ *  0 means use chasePower set in chassis class. 0 by default.
+ * @param y carrot point multiplier. value between 0 and 1. Higher values result in
+ *  curvier movements. 0.6 by default
+ * @param theta the maximum speed the robot can travel at. Value between 0-127.
+ *  127 by default
+ */
+struct MoveToPoseTargets {
+        float dist = std::numeric_limits<float>::quiet_NaN();
+        float x = std::numeric_limits<float>::quiet_NaN();
+        float y = std::numeric_limits<float>::quiet_NaN();
+        float theta = std::numeric_limits<float>::quiet_NaN();
+}
+/**
+ * @brief Flags for Chassis::moveToPose
  *
  * We use a struct to simplify customization. Chassis::moveToPose has many
  * parameters and specifying them all just to set one optional param ruins
@@ -136,7 +157,7 @@ struct Drivetrain {
  * @param earlyExitRange distance between the robot and target point where the movement will
  *  exit. Only has an effect if minSpeed is non-zero.
  */
-struct MoveToPoseParams {
+struct MoveToPoseFlags {
         bool forwards = true;
         float chasePower = 0;
         float lead = 0.6;

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -153,7 +153,7 @@ namespace lemlib {
 	 * @param earlyExitRange distance between the robot and target point where the
 	 * movement will exit. Only has an effect if minSpeed is non-zero.
 	 */
-	struct MoveToPoseFlags {
+	struct lemlib::MoveToPoseFlags {
 		bool forwards = true;
 		float chasePower = 0;
 		float lead = 0.6;
@@ -268,7 +268,7 @@ namespace lemlib {
 		 * @param async whether the function should be run asynchronously. true by
 		 * default
 		 */
-		void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params = {}, bool async = true);
+		void moveToPose(MoveToPoseTarget targetPose, int timeout, lemlib::MoveToPoseFlags params = {}, bool async = true);
 		/**
 		 * @brief Move the chassis towards a target point
 		 *

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -128,7 +128,7 @@ struct Drivetrain {
  * @param theta the maximum speed the robot can travel at. Value between 0-127.
  *  127 by default
  */
-struct MoveToPoseTargets {
+struct MoveToPoseTarget {
     float dist = std::numeric_limits<float>::quiet_NaN();
     float x = std::numeric_limits<float>::quiet_NaN();
     float y = std::numeric_limits<float>::quiet_NaN();

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -272,7 +272,7 @@ class Chassis {
      * @param async whether the function should be run asynchronously. true by
      * default
      */
-    void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params = {}, bool async = true);
+    void moveToPose(MoveToPoseTarget targetPose = {}, int timeout, MoveToPoseFlags params = {}, bool async = true);
     /**
      * @brief Move the chassis towards a target point
      *

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -27,24 +27,26 @@ namespace lemlib {
  *
  */
 struct OdomSensors {
-    /**
-     * The sensors are stored in a struct so that they can be easily passed to the chassis class
-     * The variables are pointers so that they can be set to nullptr if they are not used
-     * Otherwise the chassis class would have to have a constructor for each possible combination of sensors
-     *
-     * @param vertical1 pointer to the first vertical tracking wheel
-     * @param vertical2 pointer to the second vertical tracking wheel
-     * @param horizontal1 pointer to the first horizontal tracking wheel
-     * @param horizontal2 pointer to the second horizontal tracking wheel
-     * @param imu pointer to the IMU
-     */
-    OdomSensors(TrackingWheel *vertical1, TrackingWheel *vertical2, TrackingWheel *horizontal1,
-                TrackingWheel *horizontal2, pros::Imu *imu);
-    TrackingWheel *vertical1;
-    TrackingWheel *vertical2;
-    TrackingWheel *horizontal1;
-    TrackingWheel *horizontal2;
-    pros::Imu *imu;
+  /**
+   * The sensors are stored in a struct so that they can be easily passed to the
+   * chassis class The variables are pointers so that they can be set to nullptr
+   * if they are not used Otherwise the chassis class would have to have a
+   * constructor for each possible combination of sensors
+   *
+   * @param vertical1 pointer to the first vertical tracking wheel
+   * @param vertical2 pointer to the second vertical tracking wheel
+   * @param horizontal1 pointer to the first horizontal tracking wheel
+   * @param horizontal2 pointer to the second horizontal tracking wheel
+   * @param imu pointer to the IMU
+   */
+  OdomSensors(TrackingWheel *vertical1, TrackingWheel *vertical2,
+              TrackingWheel *horizontal1, TrackingWheel *horizontal2,
+              pros::Imu *imu);
+  TrackingWheel *vertical1;
+  TrackingWheel *vertical2;
+  TrackingWheel *horizontal1;
+  TrackingWheel *horizontal2;
+  pros::Imu *imu;
 };
 
 /**
@@ -52,35 +54,41 @@ struct OdomSensors {
  *
  */
 struct ControllerSettings {
-    /**
-     * The constants are stored in a struct so that they can be easily passed to the chassis class
-     * Set a constant to 0 and it will be ignored
-     *
-     * @param kP proportional constant for the chassis controller
-     * @param kI integral constant for the chassis controller
-     * @param kD derivative constant for the chassis controller
-     * @param antiWindup
-     * @param smallError the error at which the chassis controller will switch to a slower control loop
-     * @param smallErrorTimeout the time the chassis controller will wait before switching to a slower control loop
-     * @param largeError the error at which the chassis controller will switch to a faster control loop
-     * @param largeErrorTimeout the time the chassis controller will wait before switching to a faster control loop
-     * @param slew the maximum acceleration of the chassis controller
-     */
-    ControllerSettings(float kP, float kI, float kD, float windupRange, float smallError, float smallErrorTimeout,
-                       float largeError, float largeErrorTimeout, float slew)
-        : kP(kP), kI(kI), kD(kD), windupRange(windupRange), smallError(smallError),
-          smallErrorTimeout(smallErrorTimeout), largeError(largeError), largeErrorTimeout(largeErrorTimeout),
-          slew(slew) {}
+  /**
+   * The constants are stored in a struct so that they can be easily passed to
+   * the chassis class Set a constant to 0 and it will be ignored
+   *
+   * @param kP proportional constant for the chassis controller
+   * @param kI integral constant for the chassis controller
+   * @param kD derivative constant for the chassis controller
+   * @param antiWindup
+   * @param smallError the error at which the chassis controller will switch to
+   * a slower control loop
+   * @param smallErrorTimeout the time the chassis controller will wait before
+   * switching to a slower control loop
+   * @param largeError the error at which the chassis controller will switch to
+   * a faster control loop
+   * @param largeErrorTimeout the time the chassis controller will wait before
+   * switching to a faster control loop
+   * @param slew the maximum acceleration of the chassis controller
+   */
+  ControllerSettings(float kP, float kI, float kD, float windupRange,
+                     float smallError, float smallErrorTimeout,
+                     float largeError, float largeErrorTimeout, float slew)
+      : kP(kP), kI(kI), kD(kD), windupRange(windupRange),
+        smallError(smallError), smallErrorTimeout(smallErrorTimeout),
+        largeError(largeError), largeErrorTimeout(largeErrorTimeout),
+        slew(slew) {}
 
-    float kP;
-    float kI;
-    float kD;
-    float windupRange;
-    float smallError;
-    float smallErrorTimeout;
-    float largeError;
-    float largeErrorTimeout;
-    float slew;
+  float kP;
+  float kI;
+  float kD;
+  float windupRange;
+  float smallError;
+  float smallErrorTimeout;
+  float largeError;
+  float largeErrorTimeout;
+  float slew;
 };
 
 /**
@@ -88,25 +96,27 @@ struct ControllerSettings {
  *
  */
 struct Drivetrain {
-    /**
-     * The constants are stored in a struct so that they can be easily passed to the chassis class
-     * Set a constant to 0 and it will be ignored
-     *
-     * @param leftMotors pointer to the left motors
-     * @param rightMotors pointer to the right motors
-     * @param trackWidth the track width of the robot
-     * @param wheelDiameter the diameter of the wheel used on the drivetrain
-     * @param rpm the rpm of the wheels
-     * @param chasePower higher values make the robot move faster but causes more overshoot on turns
-     */
-    Drivetrain(pros::MotorGroup *leftMotors, pros::MotorGroup *rightMotors, float trackWidth, float wheelDiameter,
-               float rpm, float chasePower);
-    pros::Motor_Group *leftMotors;
-    pros::Motor_Group *rightMotors;
-    float trackWidth;
-    float wheelDiameter;
-    float rpm;
-    float chasePower;
+  /**
+   * The constants are stored in a struct so that they can be easily passed to
+   * the chassis class Set a constant to 0 and it will be ignored
+   *
+   * @param leftMotors pointer to the left motors
+   * @param rightMotors pointer to the right motors
+   * @param trackWidth the track width of the robot
+   * @param wheelDiameter the diameter of the wheel used on the drivetrain
+   * @param rpm the rpm of the wheels
+   * @param chasePower higher values make the robot move faster but causes more
+   * overshoot on turns
+   */
+  Drivetrain(pros::MotorGroup *leftMotors, pros::MotorGroup *rightMotors,
+             float trackWidth, float wheelDiameter, float rpm,
+             float chasePower);
+  pros::Motor_Group *leftMotors;
+  pros::Motor_Group *rightMotors;
+  float trackWidth;
+  float wheelDiameter;
+  float rpm;
+  float chasePower;
 };
 /**
  * @brief Targets for Chassis::moveToPose
@@ -116,19 +126,20 @@ struct Drivetrain {
  * readability. By passing a struct to the function, we can have named
  * parameters, overcoming the c/c++ limitation
  *
- * @param dist whether the robot should move forwards or backwards. True by default
+ * @param dist whether the robot should move forwards or backwards. True by
+ * default
  * @param x how fast the robot will move around corners. Recommended value 2-15.
  *  0 means use chasePower set in chassis class. 0 by default.
- * @param y carrot point multiplier. value between 0 and 1. Higher values result in
- *  curvier movements. 0.6 by default
+ * @param y carrot point multiplier. value between 0 and 1. Higher values result
+ * in curvier movements. 0.6 by default
  * @param theta the maximum speed the robot can travel at. Value between 0-127.
  *  127 by default
  */
 struct MoveToPoseTargets {
-    float dist = std::numeric_limits<float>::quiet_NaN();
-    float x = std::numeric_limits<float>::quiet_NaN();
-    float y = std::numeric_limits<float>::quiet_NaN();
-    float theta = std::numeric_limits<float>::quiet_NaN();
+  float dist = std::numeric_limits<float>::quiet_NaN();
+  float x = std::numeric_limits<float>::quiet_NaN();
+  float y = std::numeric_limits<float>::quiet_NaN();
+  float theta = std::numeric_limits<float>::quiet_NaN();
 }
 /**
  * @brief Flags for Chassis::moveToPose
@@ -138,26 +149,27 @@ struct MoveToPoseTargets {
  * readability. By passing a struct to the function, we can have named
  * parameters, overcoming the c/c++ limitation
  *
- * @param forwards whether the robot should move forwards or backwards. True by default
- * @param chasePower how fast the robot will move around corners. Recommended value 2-15.
- *  0 means use chasePower set in chassis class. 0 by default.
- * @param lead carrot point multiplier. value between 0 and 1. Higher values result in
- *  curvier movements. 0.6 by default
- * @param maxSpeed the maximum speed the robot can travel at. Value between 0-127.
- *  127 by default
- * @param minSpeed the minimum speed the robot can travel at. If set to a non-zero value,
- *  the exit conditions will switch to less accurate but smoother ones. Value between 0-127.
- *  0 by default
- * @param earlyExitRange distance between the robot and target point where the movement will
- *  exit. Only has an effect if minSpeed is non-zero.
+ * @param forwards whether the robot should move forwards or backwards. True by
+ * default
+ * @param chasePower how fast the robot will move around corners. Recommended
+ * value 2-15. 0 means use chasePower set in chassis class. 0 by default.
+ * @param lead carrot point multiplier. value between 0 and 1. Higher values
+ * result in curvier movements. 0.6 by default
+ * @param maxSpeed the maximum speed the robot can travel at. Value between
+ * 0-127. 127 by default
+ * @param minSpeed the minimum speed the robot can travel at. If set to a
+ * non-zero value, the exit conditions will switch to less accurate but smoother
+ * ones. Value between 0-127. 0 by default
+ * @param earlyExitRange distance between the robot and target point where the
+ * movement will exit. Only has an effect if minSpeed is non-zero.
  */
 struct MoveToPoseFlags {
-    bool forwards = true;
-    float chasePower = 0;
-    float lead = 0.6;
-    float maxSpeed = 127;
-    float minSpeed = 0;
-    float earlyExitRange = 0;
+  bool forwards = true;
+  float chasePower = 0;
+  float lead = 0.6;
+  float maxSpeed = 127;
+  float minSpeed = 0;
+  float earlyExitRange = 0;
 };
 
 /**
@@ -169,9 +181,10 @@ struct MoveToPoseFlags {
 typedef std::function<float(float, float)> DriveCurveFunction_t;
 
 /**
- * @brief  Default drive curve. Modifies  the input with an exponential curve. If the input is 127, the function
- * will always output 127, no matter the value of scale, likewise for -127. This curve was inspired by team
- * 5225, the Pilons. A Desmos graph of this curve can be found here:
+ * @brief  Default drive curve. Modifies  the input with an exponential curve.
+ * If the input is 127, the function will always output 127, no matter the value
+ * of scale, likewise for -127. This curve was inspired by team 5225, the
+ * Pilons. A Desmos graph of this curve can be found here:
  * https://www.desmos.com/calculator/rcfjjg83zx
  * @param input value from -127 to 127
  * @param scale how steep the curve should be.
@@ -185,182 +198,204 @@ float defaultDriveCurve(float input, float scale);
  */
 class Chassis {
   public:
-    /**
-     * @brief Construct a new Chassis
-     *
-     * @param drivetrain drivetrain to be used for the chassis
-     * @param lateralSettings settings for the lateral controller
-     * @param angularSettings settings for the angular controller
-     * @param sensors sensors to be used for odometry
-     * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
-     */
-    Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
-            OdomSensors sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
-    /**
-     * @brief Calibrate the chassis sensors
-     *
-     * @param calibrateIMU whether the IMU should be calibrated. true by default
-     */
-    void calibrate(bool calibrateIMU = true);
-    /**
-     * @brief Set the pose of the chassis
-     *
-     * @param x new x value
-     * @param y new y value
-     * @param theta new theta value
-     * @param radians true if theta is in radians, false if not. False by default
-     */
-    void setPose(float x, float y, float theta, bool radians = false);
-    /**
-     * @brief Set the pose of the chassis
-     *
-     * @param pose the new pose
-     * @param radians whether pose theta is in radians (true) or not (false). false by default
-     */
-    void setPose(Pose pose, bool radians = false);
-    /**
-     * @brief Get the pose of the chassis
-     *
-     * @param radians whether theta should be in radians (true) or degrees (false). false by default
-     * @return Pose
-     */
-    Pose getPose(bool radians = false, bool standardPos = false);
-    /**
-     * @brief Wait until the robot has traveled a certain distance along the path
-     *
-     * @note Units are in inches if current motion is moveTo or follow, degrees if using turnTo
-     *
-     * @param dist the distance the robot needs to travel before returning
-     */
-    void waitUntil(float dist);
-    /**
-     * @brief Wait until the robot has completed the path
-     *
-     */
-    void waitUntilDone();
-    /**
-     * @brief Turn the chassis so it is facing the target point
-     *
-     * The PID logging id is "angularPID"
-     *
-     * @param x x location
-     * @param y y location
-     * @param timeout longest time the robot can spend moving
-     * @param forwards whether the robot should turn to face the point with the front of the robot. true by
-     * default
-     * @param maxSpeed the maximum speed the robot can turn at. Default is 127
-     * @param async whether the function should be run asynchronously. true by default
-     */
-    void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-    /**
-     * @brief Move the chassis towards the target pose
-     *
-     * Uses the boomerang controller
-     *
-     * @param x x location
-     * @param y y location
-     * @param theta target heading in degrees.
-     * @param timeout longest time the robot can spend moving
-     * @param params struct to simulate named parameters
-     * @param async whether the function should be run asynchronously. true by default
-     */
-    void moveToPose(float x, float y, float theta, int timeout, MoveToPoseParams params = {}, bool async = true);
-    /**
-     * @brief Move the chassis towards a target point
-     *
-     * @param x x location
-     * @param y y location
-     * @param timeout longest time the robot can spend moving
-     * @param maxSpeed the maximum speed the robot can move at. 127 by default
-     * @param async whether the function should be run asynchronously. true by default
-     */
-    void moveToPoint(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-    /**
-     * @brief Move the chassis along a path
-     *
-     * @param path the path asset to follow
-     * @param lookahead the lookahead distance. Units in inches. Larger values will make the robot move
-     * faster but will follow the path less accurately
-     * @param timeout the maximum time the robot can spend moving
-     * @param forwards whether the robot should follow the path going forwards. true by default
-     * @param async whether the function should be run asynchronously. true by default
-     */
-    void follow(const asset &path, float lookahead, int timeout, bool forwards = true, bool async = true);
-    /**
-     * @brief Control the robot during the driver control period using the tank drive control scheme. In
-     * this control scheme one joystick axis controls one half of the robot, and another joystick axis
-     * controls another.
-     * @param left speed of the left side of the drivetrain. Takes an input from -127 to 127.
-     * @param right speed of the right side of the drivetrain. Takes an input from -127 to 127.
-     * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve.
-     * A value of 0 disables the curve entirely.
-     */
-    void tank(int left, int right, float curveGain = 0.0);
-    /**
-     * @brief Control the robot during the driver using the arcade drive control scheme. In this control
-     * scheme one joystick axis controls the forwards and backwards movement of the robot, while the other
-     * joystick axis controls  the robot's turning
-     * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
-     * @param turn speed to turn. Takes an input from -127 to 127.
-     * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
-     * curve, refer to the `defaultDriveCurve` documentation.
-     */
-    void arcade(int throttle, int turn, float curveGain = 0.0);
-    /**
-     * @brief Control the robot during the driver using the curvature drive control scheme. This control
-     * scheme is very similar to arcade drive, except the second joystick axis controls the radius of the
-     * curve that the drivetrain makes, rather than the speed. This means that the driver can accelerate in
-     * a turn without changing the radius of that turn. This control scheme defaults to arcade when forward
-     * is zero.
-     * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
-     * @param turn speed to turn. Takes an input from -127 to 127.
-     * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
-     * curve, refer to the `defaultDriveCurve` documentation.
-     */
-    void curvature(int throttle, int turn, float cureGain = 0.0);
-    /**
-     * @brief Cancels the currently running motion.
-     * If there is a queued motion, then that queued motion will run.
-     */
-    void cancelMotion();
-    /**
-     * @brief Cancels all motions, even those that are queued.
-     * After this, the chassis will not be in motion.
-     */
-    void cancelAllMotions();
-    /**
-     * @return whether a motion is currently running
-     */
-    bool isInMotion() const;
+  /**
+   * @brief Construct a new Chassis
+   *
+   * @param drivetrain drivetrain to be used for the chassis
+   * @param lateralSettings settings for the lateral controller
+   * @param angularSettings settings for the angular controller
+   * @param sensors sensors to be used for odometry
+   * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
+   */
+  Chassis(Drivetrain drivetrain, ControllerSettings linearSettings,
+          ControllerSettings angularSettings, OdomSensors sensors,
+          DriveCurveFunction_t driveCurve = &defaultDriveCurve);
+  /**
+   * @brief Calibrate the chassis sensors
+   *
+   * @param calibrateIMU whether the IMU should be calibrated. true by default
+   */
+  void calibrate(bool calibrateIMU = true);
+  /**
+   * @brief Set the pose of the chassis
+   *
+   * @param x new x value
+   * @param y new y value
+   * @param theta new theta value
+   * @param radians true if theta is in radians, false if not. False by default
+   */
+  void setPose(float x, float y, float theta, bool radians = false);
+  /**
+   * @brief Set the pose of the chassis
+   *
+   * @param pose the new pose
+   * @param radians whether pose theta is in radians (true) or not (false).
+   * false by default
+   */
+  void setPose(Pose pose, bool radians = false);
+  /**
+   * @brief Get the pose of the chassis
+   *
+   * @param radians whether theta should be in radians (true) or degrees
+   * (false). false by default
+   * @return Pose
+   */
+  Pose getPose(bool radians = false, bool standardPos = false);
+  /**
+   * @brief Wait until the robot has traveled a certain distance along the path
+   *
+   * @note Units are in inches if current motion is moveTo or follow, degrees if
+   * using turnTo
+   *
+   * @param dist the distance the robot needs to travel before returning
+   */
+  void waitUntil(float dist);
+  /**
+   * @brief Wait until the robot has completed the path
+   *
+   */
+  void waitUntilDone();
+  /**
+   * @brief Turn the chassis so it is facing the target point
+   *
+   * The PID logging id is "angularPID"
+   *
+   * @param x x location
+   * @param y y location
+   * @param timeout longest time the robot can spend moving
+   * @param forwards whether the robot should turn to face the point with the
+   * front of the robot. true by default
+   * @param maxSpeed the maximum speed the robot can turn at. Default is 127
+   * @param async whether the function should be run asynchronously. true by
+   * default
+   */
+  void turnTo(float x, float y, int timeout, bool forwards = true,
+              float maxSpeed = 127, bool async = true);
+  /**
+   * @brief Move the chassis towards the target pose
+   *
+   * Uses the boomerang controller
+   *
+   * @param x x location
+   * @param y y location
+   * @param theta target heading in degrees.
+   * @param timeout longest time the robot can spend moving
+   * @param params struct to simulate named parameters
+   * @param async whether the function should be run asynchronously. true by
+   * default
+   */
+  void moveToPose(float x, float y, float theta, int timeout,
+                  MoveToPoseParams params = {}, bool async = true);
+  /**
+   * @brief Move the chassis towards a target point
+   *
+   * @param x x location
+   * @param y y location
+   * @param timeout longest time the robot can spend moving
+   * @param maxSpeed the maximum speed the robot can move at. 127 by default
+   * @param async whether the function should be run asynchronously. true by
+   * default
+   */
+  void moveToPoint(float x, float y, int timeout, bool forwards = true,
+                   float maxSpeed = 127, bool async = true);
+  /**
+   * @brief Move the chassis along a path
+   *
+   * @param path the path asset to follow
+   * @param lookahead the lookahead distance. Units in inches. Larger values
+   * will make the robot move faster but will follow the path less accurately
+   * @param timeout the maximum time the robot can spend moving
+   * @param forwards whether the robot should follow the path going forwards.
+   * true by default
+   * @param async whether the function should be run asynchronously. true by
+   * default
+   */
+  void follow(const asset &path, float lookahead, int timeout,
+              bool forwards = true, bool async = true);
+  /**
+   * @brief Control the robot during the driver control period using the tank
+   * drive control scheme. In this control scheme one joystick axis controls one
+   * half of the robot, and another joystick axis controls another.
+   * @param left speed of the left side of the drivetrain. Takes an input from
+   * -127 to 127.
+   * @param right speed of the right side of the drivetrain. Takes an input from
+   * -127 to 127.
+   * @param curveGain control how steep the drive curve is. The larger the
+   * number, the steeper the curve. A value of 0 disables the curve entirely.
+   */
+  void tank(int left, int right, float curveGain = 0.0);
+  /**
+   * @brief Control the robot during the driver using the arcade drive control
+   * scheme. In this control scheme one joystick axis controls the forwards and
+   * backwards movement of the robot, while the other joystick axis controls the
+   * robot's turning
+   * @param throttle speed to move forward or backward. Takes an input from -127
+   * to 127.
+   * @param turn speed to turn. Takes an input from -127 to 127.
+   * @param curveGain the scale inputted into the drive curve function. If you
+   * are using the default drive curve, refer to the `defaultDriveCurve`
+   * documentation.
+   */
+  void arcade(int throttle, int turn, float curveGain = 0.0);
+  /**
+   * @brief Control the robot during the driver using the curvature drive
+   * control scheme. This control scheme is very similar to arcade drive, except
+   * the second joystick axis controls the radius of the curve that the
+   * drivetrain makes, rather than the speed. This means that the driver can
+   * accelerate in a turn without changing the radius of that turn. This control
+   * scheme defaults to arcade when forward is zero.
+   * @param throttle speed to move forward or backward. Takes an input from -127
+   * to 127.
+   * @param turn speed to turn. Takes an input from -127 to 127.
+   * @param curveGain the scale inputted into the drive curve function. If you
+   * are using the default drive curve, refer to the `defaultDriveCurve`
+   * documentation.
+   */
+  void curvature(int throttle, int turn, float cureGain = 0.0);
+  /**
+   * @brief Cancels the currently running motion.
+   * If there is a queued motion, then that queued motion will run.
+   */
+  void cancelMotion();
+  /**
+   * @brief Cancels all motions, even those that are queued.
+   * After this, the chassis will not be in motion.
+   */
+  void cancelAllMotions();
+  /**
+   * @return whether a motion is currently running
+   */
+  bool isInMotion() const;
 
   protected:
-    /**
-     * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue
-     */
-    void requestMotionStart();
-    /**
-     * @brief Dequeues this motion and permits queued task to run
-     */
-    void endMotion();
+  /**
+   * @brief Indicates that this motion is queued and blocks current task until
+   * this motion reaches front of queue
+   */
+  void requestMotionStart();
+  /**
+   * @brief Dequeues this motion and permits queued task to run
+   */
+  void endMotion();
 
   private:
-    bool motionRunning = false;
-    bool motionQueued = false;
+  bool motionRunning = false;
+  bool motionQueued = false;
 
-    pros::Mutex mutex;
-    float distTravelled = 0;
+  pros::Mutex mutex;
+  float distTravelled = 0;
 
-    ControllerSettings lateralSettings;
-    ControllerSettings angularSettings;
-    Drivetrain drivetrain;
-    OdomSensors sensors;
-    DriveCurveFunction_t driveCurve;
+  ControllerSettings lateralSettings;
+  ControllerSettings angularSettings;
+  Drivetrain drivetrain;
+  OdomSensors sensors;
+  DriveCurveFunction_t driveCurve;
 
-    PID lateralPID;
-    PID angularPID;
-    ExitCondition lateralLargeExit;
-    ExitCondition lateralSmallExit;
-    ExitCondition angularLargeExit;
-    ExitCondition angularSmallExit;
+  PID lateralPID;
+  PID angularPID;
+  ExitCondition lateralLargeExit;
+  ExitCondition lateralSmallExit;
+  ExitCondition angularLargeExit;
+  ExitCondition angularSmallExit;
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -129,7 +129,7 @@ namespace lemlib {
 		float x = std::numeric_limits < float > ::quiet_NaN();
 		float y = std::numeric_limits < float > ::quiet_NaN();
 		float theta = std::numeric_limits < float > ::quiet_NaN();
-	}
+	};
 	/**
 	 * @brief Flags for Chassis::moveToPose
 	 *
@@ -267,7 +267,7 @@ namespace lemlib {
 		 * @param async whether the function should be run asynchronously. true by
 		 * default
 		 */
-		void moveToPose(float x, float y, float theta, int timeout, MoveToPoseParams params = {}, bool async = true);
+		void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params = {}, bool async = true);
 		/**
 		 * @brief Move the chassis towards a target point
 		 *

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -140,7 +140,7 @@ struct Drivetrain {
  *  127 by default
  */
 struct MoveToPoseTarget {
-        std::vector<float>params_t(4) = std::numeric_limits<float>::quiet_NaN();
+        std::vector<float>params(4,std::numeric_limits<float>::quiet_NaN());
 };
 
 // Enum to represent different movement types
@@ -291,7 +291,7 @@ class Chassis {
          * @param async whether the function should be run asynchronously. true by
          * default
          */
-        void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params = {}, bool async = true);
+        void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseOptions params = {}, bool async = true);
         /**
          * @brief Move the chassis towards a target point
          *

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -20,6 +20,7 @@
 #include <cmath>
 #include <functional>
 #include <limits>
+#include<vector>
 
 namespace lemlib {
 /**
@@ -139,10 +140,7 @@ struct Drivetrain {
  *  127 by default
  */
 struct MoveToPoseTarget {
-        float dist = std::numeric_limits<float>::quiet_NaN();
-        float x = std::numeric_limits<float>::quiet_NaN();
-        float y = std::numeric_limits<float>::quiet_NaN();
-        float theta = std::numeric_limits<float>::quiet_NaN();
+        std::vector<float>params_t(4) = std::numeric_limits<float>::quiet_NaN();
 };
 
 // Enum to represent different movement types
@@ -175,7 +173,7 @@ enum MovementType {
  * @param earlyExitRange distance between the robot and target point where the
  * movement will exit. Only has an effect if minSpeed is non-zero.
  */
-struct MoveToPoseFlags {
+struct MoveToPoseOptions {
         bool forwards = true;
         float chasePower = 0;
         float lead = 0.6;
@@ -399,5 +397,6 @@ class Chassis {
         ExitCondition angularLargeExit;
         ExitCondition angularSmallExit;
         MovementType getMovementType(const MoveToPoseTarget& params_t);
+        Pose getTarget(MovementType mType);
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -387,6 +387,6 @@ class Chassis {
     ExitCondition lateralSmallExit;
     ExitCondition angularLargeExit;
     ExitCondition angularSmallExit;
-    MovementType getMovementType(const MovementParams& params);
+    MovementType getMovementType(const MoveToPoseTarget& params_t);
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -272,7 +272,7 @@ class Chassis {
      * @param async whether the function should be run asynchronously. true by
      * default
      */
-    void moveToPose(MoveToPoseTarget targetPose = {}, int timeout, MoveToPoseFlags params = {}, bool async = true);
+    void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params = {}, bool async = true);
     /**
      * @brief Move the chassis towards a target point
      *

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -8,7 +8,8 @@
  * @copyright Copyright (c) 2023
  *
  */
-#pragma once#include "lemlib/asset.hpp"
+#pragma once
+#include "lemlib/asset.hpp"
 #include "lemlib/chassis/trackingWheel.hpp"
 #include "lemlib/exitcondition.hpp"
 #include "lemlib/pid.hpp"

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -134,6 +134,14 @@ struct MoveToPoseTarget {
     float y = std::numeric_limits<float>::quiet_NaN();
     float theta = std::numeric_limits<float>::quiet_NaN();
 };
+
+// Enum to represent different movement types
+enum MovementType {
+    RelativeWithoutAngle,
+    RelativeWithAngle,
+    ClassicMovement
+    // Add more movement types as needed
+};
 /**
  * @brief Flags for Chassis::moveToPose
  *
@@ -379,5 +387,6 @@ class Chassis {
     ExitCondition lateralSmallExit;
     ExitCondition angularLargeExit;
     ExitCondition angularSmallExit;
+    MovementType getMovementType(const MovementParams& params);
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -20,7 +20,7 @@
 #include <cmath>
 #include <functional>
 #include <limits>
-#include<vector>
+#include <vector>
 
 namespace lemlib {
 /**
@@ -140,7 +140,7 @@ struct Drivetrain {
  *  127 by default
  */
 struct MoveToPoseTarget {
-        std::vector<float>params(4,std::numeric_limits<float>::quiet_NaN());
+        std::vector<float> params(4, std::numeric_limits<float>::quiet_NaN());
 };
 
 // Enum to represent different movement types
@@ -396,7 +396,7 @@ class Chassis {
         ExitCondition lateralSmallExit;
         ExitCondition angularLargeExit;
         ExitCondition angularSmallExit;
-        MovementType getMovementType(const MoveToPoseTarget& params_t);
-        Pose getTarget(MovementType mType);
+        MovementType getMovementType(const MoveToPoseTarget& params);
+        void getTarget(MovementType mType);
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -140,7 +140,7 @@ struct Drivetrain {
  *  127 by default
  */
 struct MoveToPoseTarget {
-        std::vector<float> params{4,std::numeric_limits<float>::quiet_NaN()};
+        std::vector<float> params {4, std::numeric_limits<float>::quiet_NaN()};
 };
 
 // Enum to represent different movement types

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -11,15 +11,15 @@
 
 #pragma once
 
-#include <functional>
-#include "pros/rtos.hpp"
-#include "pros/motors.hpp"
-#include "pros/imu.hpp"
 #include "lemlib/asset.hpp"
 #include "lemlib/chassis/trackingWheel.hpp"
-#include "lemlib/pose.hpp"
-#include "lemlib/pid.hpp"
 #include "lemlib/exitcondition.hpp"
+#include "lemlib/pid.hpp"
+#include "lemlib/pose.hpp"
+#include "pros/imu.hpp"
+#include "pros/motors.hpp"
+#include "pros/rtos.hpp"
+#include <functional>
 
 namespace lemlib {
 /**
@@ -27,24 +27,24 @@ namespace lemlib {
  *
  */
 struct OdomSensors {
-        /**
-         * The sensors are stored in a struct so that they can be easily passed to the chassis class
-         * The variables are pointers so that they can be set to nullptr if they are not used
-         * Otherwise the chassis class would have to have a constructor for each possible combination of sensors
-         *
-         * @param vertical1 pointer to the first vertical tracking wheel
-         * @param vertical2 pointer to the second vertical tracking wheel
-         * @param horizontal1 pointer to the first horizontal tracking wheel
-         * @param horizontal2 pointer to the second horizontal tracking wheel
-         * @param imu pointer to the IMU
-         */
-        OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
-                    TrackingWheel* horizontal2, pros::Imu* imu);
-        TrackingWheel* vertical1;
-        TrackingWheel* vertical2;
-        TrackingWheel* horizontal1;
-        TrackingWheel* horizontal2;
-        pros::Imu* imu;
+    /**
+     * The sensors are stored in a struct so that they can be easily passed to the chassis class
+     * The variables are pointers so that they can be set to nullptr if they are not used
+     * Otherwise the chassis class would have to have a constructor for each possible combination of sensors
+     *
+     * @param vertical1 pointer to the first vertical tracking wheel
+     * @param vertical2 pointer to the second vertical tracking wheel
+     * @param horizontal1 pointer to the first horizontal tracking wheel
+     * @param horizontal2 pointer to the second horizontal tracking wheel
+     * @param imu pointer to the IMU
+     */
+    OdomSensors(TrackingWheel *vertical1, TrackingWheel *vertical2, TrackingWheel *horizontal1,
+                TrackingWheel *horizontal2, pros::Imu *imu);
+    TrackingWheel *vertical1;
+    TrackingWheel *vertical2;
+    TrackingWheel *horizontal1;
+    TrackingWheel *horizontal2;
+    pros::Imu *imu;
 };
 
 /**
@@ -52,41 +52,35 @@ struct OdomSensors {
  *
  */
 struct ControllerSettings {
-        /**
-         * The constants are stored in a struct so that they can be easily passed to the chassis class
-         * Set a constant to 0 and it will be ignored
-         *
-         * @param kP proportional constant for the chassis controller
-         * @param kI integral constant for the chassis controller
-         * @param kD derivative constant for the chassis controller
-         * @param antiWindup
-         * @param smallError the error at which the chassis controller will switch to a slower control loop
-         * @param smallErrorTimeout the time the chassis controller will wait before switching to a slower control loop
-         * @param largeError the error at which the chassis controller will switch to a faster control loop
-         * @param largeErrorTimeout the time the chassis controller will wait before switching to a faster control loop
-         * @param slew the maximum acceleration of the chassis controller
-         */
-        ControllerSettings(float kP, float kI, float kD, float windupRange, float smallError, float smallErrorTimeout,
-                           float largeError, float largeErrorTimeout, float slew)
-            : kP(kP),
-              kI(kI),
-              kD(kD),
-              windupRange(windupRange),
-              smallError(smallError),
-              smallErrorTimeout(smallErrorTimeout),
-              largeError(largeError),
-              largeErrorTimeout(largeErrorTimeout),
-              slew(slew) {}
+    /**
+     * The constants are stored in a struct so that they can be easily passed to the chassis class
+     * Set a constant to 0 and it will be ignored
+     *
+     * @param kP proportional constant for the chassis controller
+     * @param kI integral constant for the chassis controller
+     * @param kD derivative constant for the chassis controller
+     * @param antiWindup
+     * @param smallError the error at which the chassis controller will switch to a slower control loop
+     * @param smallErrorTimeout the time the chassis controller will wait before switching to a slower control loop
+     * @param largeError the error at which the chassis controller will switch to a faster control loop
+     * @param largeErrorTimeout the time the chassis controller will wait before switching to a faster control loop
+     * @param slew the maximum acceleration of the chassis controller
+     */
+    ControllerSettings(float kP, float kI, float kD, float windupRange, float smallError, float smallErrorTimeout,
+                       float largeError, float largeErrorTimeout, float slew)
+        : kP(kP), kI(kI), kD(kD), windupRange(windupRange), smallError(smallError),
+          smallErrorTimeout(smallErrorTimeout), largeError(largeError), largeErrorTimeout(largeErrorTimeout),
+          slew(slew) {}
 
-        float kP;
-        float kI;
-        float kD;
-        float windupRange;
-        float smallError;
-        float smallErrorTimeout;
-        float largeError;
-        float largeErrorTimeout;
-        float slew;
+    float kP;
+    float kI;
+    float kD;
+    float windupRange;
+    float smallError;
+    float smallErrorTimeout;
+    float largeError;
+    float largeErrorTimeout;
+    float slew;
 };
 
 /**
@@ -94,25 +88,25 @@ struct ControllerSettings {
  *
  */
 struct Drivetrain {
-        /**
-         * The constants are stored in a struct so that they can be easily passed to the chassis class
-         * Set a constant to 0 and it will be ignored
-         *
-         * @param leftMotors pointer to the left motors
-         * @param rightMotors pointer to the right motors
-         * @param trackWidth the track width of the robot
-         * @param wheelDiameter the diameter of the wheel used on the drivetrain
-         * @param rpm the rpm of the wheels
-         * @param chasePower higher values make the robot move faster but causes more overshoot on turns
-         */
-        Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth, float wheelDiameter,
-                   float rpm, float chasePower);
-        pros::Motor_Group* leftMotors;
-        pros::Motor_Group* rightMotors;
-        float trackWidth;
-        float wheelDiameter;
-        float rpm;
-        float chasePower;
+    /**
+     * The constants are stored in a struct so that they can be easily passed to the chassis class
+     * Set a constant to 0 and it will be ignored
+     *
+     * @param leftMotors pointer to the left motors
+     * @param rightMotors pointer to the right motors
+     * @param trackWidth the track width of the robot
+     * @param wheelDiameter the diameter of the wheel used on the drivetrain
+     * @param rpm the rpm of the wheels
+     * @param chasePower higher values make the robot move faster but causes more overshoot on turns
+     */
+    Drivetrain(pros::MotorGroup *leftMotors, pros::MotorGroup *rightMotors, float trackWidth, float wheelDiameter,
+               float rpm, float chasePower);
+    pros::Motor_Group *leftMotors;
+    pros::Motor_Group *rightMotors;
+    float trackWidth;
+    float wheelDiameter;
+    float rpm;
+    float chasePower;
 };
 /**
  * @brief Targets for Chassis::moveToPose
@@ -131,10 +125,10 @@ struct Drivetrain {
  *  127 by default
  */
 struct MoveToPoseTargets {
-        float dist = std::numeric_limits<float>::quiet_NaN();
-        float x = std::numeric_limits<float>::quiet_NaN();
-        float y = std::numeric_limits<float>::quiet_NaN();
-        float theta = std::numeric_limits<float>::quiet_NaN();
+    float dist = std::numeric_limits<float>::quiet_NaN();
+    float x = std::numeric_limits<float>::quiet_NaN();
+    float y = std::numeric_limits<float>::quiet_NaN();
+    float theta = std::numeric_limits<float>::quiet_NaN();
 }
 /**
  * @brief Flags for Chassis::moveToPose
@@ -158,12 +152,12 @@ struct MoveToPoseTargets {
  *  exit. Only has an effect if minSpeed is non-zero.
  */
 struct MoveToPoseFlags {
-        bool forwards = true;
-        float chasePower = 0;
-        float lead = 0.6;
-        float maxSpeed = 127;
-        float minSpeed = 0;
-        float earlyExitRange = 0;
+    bool forwards = true;
+    float chasePower = 0;
+    float lead = 0.6;
+    float maxSpeed = 127;
+    float minSpeed = 0;
+    float earlyExitRange = 0;
 };
 
 /**
@@ -190,181 +184,183 @@ float defaultDriveCurve(float input, float scale);
  *
  */
 class Chassis {
-    public:
-        /**
-         * @brief Construct a new Chassis
-         *
-         * @param drivetrain drivetrain to be used for the chassis
-         * @param lateralSettings settings for the lateral controller
-         * @param angularSettings settings for the angular controller
-         * @param sensors sensors to be used for odometry
-         * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
-         */
-        Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
-                OdomSensors sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
-        /**
-         * @brief Calibrate the chassis sensors
-         *
-         * @param calibrateIMU whether the IMU should be calibrated. true by default
-         */
-        void calibrate(bool calibrateIMU = true);
-        /**
-         * @brief Set the pose of the chassis
-         *
-         * @param x new x value
-         * @param y new y value
-         * @param theta new theta value
-         * @param radians true if theta is in radians, false if not. False by default
-         */
-        void setPose(float x, float y, float theta, bool radians = false);
-        /**
-         * @brief Set the pose of the chassis
-         *
-         * @param pose the new pose
-         * @param radians whether pose theta is in radians (true) or not (false). false by default
-         */
-        void setPose(Pose pose, bool radians = false);
-        /**
-         * @brief Get the pose of the chassis
-         *
-         * @param radians whether theta should be in radians (true) or degrees (false). false by default
-         * @return Pose
-         */
-        Pose getPose(bool radians = false, bool standardPos = false);
-        /**
-         * @brief Wait until the robot has traveled a certain distance along the path
-         *
-         * @note Units are in inches if current motion is moveTo or follow, degrees if using turnTo
-         *
-         * @param dist the distance the robot needs to travel before returning
-         */
-        void waitUntil(float dist);
-        /**
-         * @brief Wait until the robot has completed the path
-         *
-         */
-        void waitUntilDone();
-        /**
-         * @brief Turn the chassis so it is facing the target point
-         *
-         * The PID logging id is "angularPID"
-         *
-         * @param x x location
-         * @param y y location
-         * @param timeout longest time the robot can spend moving
-         * @param forwards whether the robot should turn to face the point with the front of the robot. true by
-         * default
-         * @param maxSpeed the maximum speed the robot can turn at. Default is 127
-         * @param async whether the function should be run asynchronously. true by default
-         */
-        void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-        /**
-         * @brief Move the chassis towards the target pose
-         *
-         * Uses the boomerang controller
-         *
-         * @param x x location
-         * @param y y location
-         * @param theta target heading in degrees.
-         * @param timeout longest time the robot can spend moving
-         * @param params struct to simulate named parameters
-         * @param async whether the function should be run asynchronously. true by default
-         */
-        void moveToPose(float x, float y, float theta, int timeout, MoveToPoseParams params = {}, bool async = true);
-        /**
-         * @brief Move the chassis towards a target point
-         *
-         * @param x x location
-         * @param y y location
-         * @param timeout longest time the robot can spend moving
-         * @param maxSpeed the maximum speed the robot can move at. 127 by default
-         * @param async whether the function should be run asynchronously. true by default
-         */
-        void moveToPoint(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-        /**
-         * @brief Move the chassis along a path
-         *
-         * @param path the path asset to follow
-         * @param lookahead the lookahead distance. Units in inches. Larger values will make the robot move
-         * faster but will follow the path less accurately
-         * @param timeout the maximum time the robot can spend moving
-         * @param forwards whether the robot should follow the path going forwards. true by default
-         * @param async whether the function should be run asynchronously. true by default
-         */
-        void follow(const asset& path, float lookahead, int timeout, bool forwards = true, bool async = true);
-        /**
-         * @brief Control the robot during the driver control period using the tank drive control scheme. In
-         * this control scheme one joystick axis controls one half of the robot, and another joystick axis
-         * controls another.
-         * @param left speed of the left side of the drivetrain. Takes an input from -127 to 127.
-         * @param right speed of the right side of the drivetrain. Takes an input from -127 to 127.
-         * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve.
-         * A value of 0 disables the curve entirely.
-         */
-        void tank(int left, int right, float curveGain = 0.0);
-        /**
-         * @brief Control the robot during the driver using the arcade drive control scheme. In this control
-         * scheme one joystick axis controls the forwards and backwards movement of the robot, while the other
-         * joystick axis controls  the robot's turning
-         * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
-         * @param turn speed to turn. Takes an input from -127 to 127.
-         * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
-         * curve, refer to the `defaultDriveCurve` documentation.
-         */
-        void arcade(int throttle, int turn, float curveGain = 0.0);
-        /**
-         * @brief Control the robot during the driver using the curvature drive control scheme. This control
-         * scheme is very similar to arcade drive, except the second joystick axis controls the radius of the
-         * curve that the drivetrain makes, rather than the speed. This means that the driver can accelerate in
-         * a turn without changing the radius of that turn. This control scheme defaults to arcade when forward
-         * is zero.
-         * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
-         * @param turn speed to turn. Takes an input from -127 to 127.
-         * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
-         * curve, refer to the `defaultDriveCurve` documentation.
-         */
-        void curvature(int throttle, int turn, float cureGain = 0.0);
-        /**
-         * @brief Cancels the currently running motion.
-         * If there is a queued motion, then that queued motion will run.
-         */
-        void cancelMotion();
-        /**
-         * @brief Cancels all motions, even those that are queued.
-         * After this, the chassis will not be in motion.
-         */
-        void cancelAllMotions();
-        /**
-         * @return whether a motion is currently running
-         */
-        bool isInMotion() const;
-    protected:
-        /**
-         * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue
-         */
-        void requestMotionStart();
-        /**
-         * @brief Dequeues this motion and permits queued task to run
-         */
-        void endMotion();
-    private:
-        bool motionRunning = false;
-        bool motionQueued = false;
+  public:
+    /**
+     * @brief Construct a new Chassis
+     *
+     * @param drivetrain drivetrain to be used for the chassis
+     * @param lateralSettings settings for the lateral controller
+     * @param angularSettings settings for the angular controller
+     * @param sensors sensors to be used for odometry
+     * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
+     */
+    Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
+            OdomSensors sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
+    /**
+     * @brief Calibrate the chassis sensors
+     *
+     * @param calibrateIMU whether the IMU should be calibrated. true by default
+     */
+    void calibrate(bool calibrateIMU = true);
+    /**
+     * @brief Set the pose of the chassis
+     *
+     * @param x new x value
+     * @param y new y value
+     * @param theta new theta value
+     * @param radians true if theta is in radians, false if not. False by default
+     */
+    void setPose(float x, float y, float theta, bool radians = false);
+    /**
+     * @brief Set the pose of the chassis
+     *
+     * @param pose the new pose
+     * @param radians whether pose theta is in radians (true) or not (false). false by default
+     */
+    void setPose(Pose pose, bool radians = false);
+    /**
+     * @brief Get the pose of the chassis
+     *
+     * @param radians whether theta should be in radians (true) or degrees (false). false by default
+     * @return Pose
+     */
+    Pose getPose(bool radians = false, bool standardPos = false);
+    /**
+     * @brief Wait until the robot has traveled a certain distance along the path
+     *
+     * @note Units are in inches if current motion is moveTo or follow, degrees if using turnTo
+     *
+     * @param dist the distance the robot needs to travel before returning
+     */
+    void waitUntil(float dist);
+    /**
+     * @brief Wait until the robot has completed the path
+     *
+     */
+    void waitUntilDone();
+    /**
+     * @brief Turn the chassis so it is facing the target point
+     *
+     * The PID logging id is "angularPID"
+     *
+     * @param x x location
+     * @param y y location
+     * @param timeout longest time the robot can spend moving
+     * @param forwards whether the robot should turn to face the point with the front of the robot. true by
+     * default
+     * @param maxSpeed the maximum speed the robot can turn at. Default is 127
+     * @param async whether the function should be run asynchronously. true by default
+     */
+    void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
+    /**
+     * @brief Move the chassis towards the target pose
+     *
+     * Uses the boomerang controller
+     *
+     * @param x x location
+     * @param y y location
+     * @param theta target heading in degrees.
+     * @param timeout longest time the robot can spend moving
+     * @param params struct to simulate named parameters
+     * @param async whether the function should be run asynchronously. true by default
+     */
+    void moveToPose(float x, float y, float theta, int timeout, MoveToPoseParams params = {}, bool async = true);
+    /**
+     * @brief Move the chassis towards a target point
+     *
+     * @param x x location
+     * @param y y location
+     * @param timeout longest time the robot can spend moving
+     * @param maxSpeed the maximum speed the robot can move at. 127 by default
+     * @param async whether the function should be run asynchronously. true by default
+     */
+    void moveToPoint(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
+    /**
+     * @brief Move the chassis along a path
+     *
+     * @param path the path asset to follow
+     * @param lookahead the lookahead distance. Units in inches. Larger values will make the robot move
+     * faster but will follow the path less accurately
+     * @param timeout the maximum time the robot can spend moving
+     * @param forwards whether the robot should follow the path going forwards. true by default
+     * @param async whether the function should be run asynchronously. true by default
+     */
+    void follow(const asset &path, float lookahead, int timeout, bool forwards = true, bool async = true);
+    /**
+     * @brief Control the robot during the driver control period using the tank drive control scheme. In
+     * this control scheme one joystick axis controls one half of the robot, and another joystick axis
+     * controls another.
+     * @param left speed of the left side of the drivetrain. Takes an input from -127 to 127.
+     * @param right speed of the right side of the drivetrain. Takes an input from -127 to 127.
+     * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve.
+     * A value of 0 disables the curve entirely.
+     */
+    void tank(int left, int right, float curveGain = 0.0);
+    /**
+     * @brief Control the robot during the driver using the arcade drive control scheme. In this control
+     * scheme one joystick axis controls the forwards and backwards movement of the robot, while the other
+     * joystick axis controls  the robot's turning
+     * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
+     * @param turn speed to turn. Takes an input from -127 to 127.
+     * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
+     * curve, refer to the `defaultDriveCurve` documentation.
+     */
+    void arcade(int throttle, int turn, float curveGain = 0.0);
+    /**
+     * @brief Control the robot during the driver using the curvature drive control scheme. This control
+     * scheme is very similar to arcade drive, except the second joystick axis controls the radius of the
+     * curve that the drivetrain makes, rather than the speed. This means that the driver can accelerate in
+     * a turn without changing the radius of that turn. This control scheme defaults to arcade when forward
+     * is zero.
+     * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
+     * @param turn speed to turn. Takes an input from -127 to 127.
+     * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
+     * curve, refer to the `defaultDriveCurve` documentation.
+     */
+    void curvature(int throttle, int turn, float cureGain = 0.0);
+    /**
+     * @brief Cancels the currently running motion.
+     * If there is a queued motion, then that queued motion will run.
+     */
+    void cancelMotion();
+    /**
+     * @brief Cancels all motions, even those that are queued.
+     * After this, the chassis will not be in motion.
+     */
+    void cancelAllMotions();
+    /**
+     * @return whether a motion is currently running
+     */
+    bool isInMotion() const;
 
-        pros::Mutex mutex;
-        float distTravelled = 0;
+  protected:
+    /**
+     * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue
+     */
+    void requestMotionStart();
+    /**
+     * @brief Dequeues this motion and permits queued task to run
+     */
+    void endMotion();
 
-        ControllerSettings lateralSettings;
-        ControllerSettings angularSettings;
-        Drivetrain drivetrain;
-        OdomSensors sensors;
-        DriveCurveFunction_t driveCurve;
+  private:
+    bool motionRunning = false;
+    bool motionQueued = false;
 
-        PID lateralPID;
-        PID angularPID;
-        ExitCondition lateralLargeExit;
-        ExitCondition lateralSmallExit;
-        ExitCondition angularLargeExit;
-        ExitCondition angularSmallExit;
+    pros::Mutex mutex;
+    float distTravelled = 0;
+
+    ControllerSettings lateralSettings;
+    ControllerSettings angularSettings;
+    Drivetrain drivetrain;
+    OdomSensors sensors;
+    DriveCurveFunction_t driveCurve;
+
+    PID lateralPID;
+    PID angularPID;
+    ExitCondition lateralLargeExit;
+    ExitCondition lateralSmallExit;
+    ExitCondition angularLargeExit;
+    ExitCondition angularSmallExit;
 };
 } // namespace lemlib

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -156,7 +156,7 @@ struct MoveToPoseTarget {
  * @param earlyExitRange distance between the robot and target point where the
  * movement will exit. Only has an effect if minSpeed is non-zero.
  */
-struct lemlib::MoveToPoseFlags {
+struct MoveToPoseFlags {
     bool forwards = true;
     float chasePower = 0;
     float lead = 0.6;
@@ -272,7 +272,7 @@ class Chassis {
      * @param async whether the function should be run asynchronously. true by
      * default
      */
-    void moveToPose(MoveToPoseTarget targetPose, int timeout, lemlib::MoveToPoseFlags params = {}, bool async = true);
+    void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params = {}, bool async = true);
     /**
      * @brief Move the chassis towards a target point
      *

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -8,10 +8,7 @@
  * @copyright Copyright (c) 2023
  *
  */
-
-#pragma once
-
-#include "lemlib/asset.hpp"
+#pragma once#include "lemlib/asset.hpp"
 #include "lemlib/chassis/trackingWheel.hpp"
 #include "lemlib/exitcondition.hpp"
 #include "lemlib/pid.hpp"
@@ -24,380 +21,356 @@
 #include <limits>
 
 namespace lemlib {
-/**
- * @brief Struct containing all the sensors used for odometry
- *
- */
-struct OdomSensors {
-  /**
-   * The sensors are stored in a struct so that they can be easily passed to the
-   * chassis class The variables are pointers so that they can be set to nullptr
-   * if they are not used Otherwise the chassis class would have to have a
-   * constructor for each possible combination of sensors
-   *
-   * @param vertical1 pointer to the first vertical tracking wheel
-   * @param vertical2 pointer to the second vertical tracking wheel
-   * @param horizontal1 pointer to the first horizontal tracking wheel
-   * @param horizontal2 pointer to the second horizontal tracking wheel
-   * @param imu pointer to the IMU
-   */
-  OdomSensors(TrackingWheel *vertical1, TrackingWheel *vertical2,
-              TrackingWheel *horizontal1, TrackingWheel *horizontal2,
-              pros::Imu *imu);
-  TrackingWheel *vertical1;
-  TrackingWheel *vertical2;
-  TrackingWheel *horizontal1;
-  TrackingWheel *horizontal2;
-  pros::Imu *imu;
-};
-
-/**
- * @brief Struct containing constants for a chassis controller
- *
- */
-struct ControllerSettings {
-  /**
-   * The constants are stored in a struct so that they can be easily passed to
-   * the chassis class Set a constant to 0 and it will be ignored
-   *
-   * @param kP proportional constant for the chassis controller
-   * @param kI integral constant for the chassis controller
-   * @param kD derivative constant for the chassis controller
-   * @param antiWindup
-   * @param smallError the error at which the chassis controller will switch to
-   * a slower control loop
-   * @param smallErrorTimeout the time the chassis controller will wait before
-   * switching to a slower control loop
-   * @param largeError the error at which the chassis controller will switch to
-   * a faster control loop
-   * @param largeErrorTimeout the time the chassis controller will wait before
-   * switching to a faster control loop
-   * @param slew the maximum acceleration of the chassis controller
-   */
-  ControllerSettings(float kP, float kI, float kD, float windupRange,
-                     float smallError, float smallErrorTimeout,
-                     float largeError, float largeErrorTimeout, float slew)
-      : kP(kP), kI(kI), kD(kD), windupRange(windupRange),
-        smallError(smallError), smallErrorTimeout(smallErrorTimeout),
-        largeError(largeError), largeErrorTimeout(largeErrorTimeout),
-        slew(slew) {}
-
-  float kP;
-  float kI;
-  float kD;
-  float windupRange;
-  float smallError;
-  float smallErrorTimeout;
-  float largeError;
-  float largeErrorTimeout;
-  float slew;
-};
-
-/**
- * @brief Struct containing constants for a drivetrain
- *
- */
-struct Drivetrain {
-  /**
-   * The constants are stored in a struct so that they can be easily passed to
-   * the chassis class Set a constant to 0 and it will be ignored
-   *
-   * @param leftMotors pointer to the left motors
-   * @param rightMotors pointer to the right motors
-   * @param trackWidth the track width of the robot
-   * @param wheelDiameter the diameter of the wheel used on the drivetrain
-   * @param rpm the rpm of the wheels
-   * @param chasePower higher values make the robot move faster but causes more
-   * overshoot on turns
-   */
-  Drivetrain(pros::MotorGroup *leftMotors, pros::MotorGroup *rightMotors,
-             float trackWidth, float wheelDiameter, float rpm,
-             float chasePower);
-  pros::Motor_Group *leftMotors;
-  pros::Motor_Group *rightMotors;
-  float trackWidth;
-  float wheelDiameter;
-  float rpm;
-  float chasePower;
-};
-/**
- * @brief Targets for Chassis::moveToPose
- *
- * We use a struct to simplify customization. Chassis::moveToPose has many
- * parameters and specifying them all just to set one optional param ruins
- * readability. By passing a struct to the function, we can have named
- * parameters, overcoming the c/c++ limitation
- *
- * @param dist whether the robot should move forwards or backwards. True by
- * default
- * @param x how fast the robot will move around corners. Recommended value 2-15.
- *  0 means use chasePower set in chassis class. 0 by default.
- * @param y carrot point multiplier. value between 0 and 1. Higher values result
- * in curvier movements. 0.6 by default
- * @param theta the maximum speed the robot can travel at. Value between 0-127.
- *  127 by default
- */
-struct MoveToPoseTargets {
-  float dist = std::numeric_limits<float>::quiet_NaN();
-  float x = std::numeric_limits<float>::quiet_NaN();
-  float y = std::numeric_limits<float>::quiet_NaN();
-  float theta = std::numeric_limits<float>::quiet_NaN();
-}
-/**
- * @brief Flags for Chassis::moveToPose
- *
- * We use a struct to simplify customization. Chassis::moveToPose has many
- * parameters and specifying them all just to set one optional param ruins
- * readability. By passing a struct to the function, we can have named
- * parameters, overcoming the c/c++ limitation
- *
- * @param forwards whether the robot should move forwards or backwards. True by
- * default
- * @param chasePower how fast the robot will move around corners. Recommended
- * value 2-15. 0 means use chasePower set in chassis class. 0 by default.
- * @param lead carrot point multiplier. value between 0 and 1. Higher values
- * result in curvier movements. 0.6 by default
- * @param maxSpeed the maximum speed the robot can travel at. Value between
- * 0-127. 127 by default
- * @param minSpeed the minimum speed the robot can travel at. If set to a
- * non-zero value, the exit conditions will switch to less accurate but smoother
- * ones. Value between 0-127. 0 by default
- * @param earlyExitRange distance between the robot and target point where the
- * movement will exit. Only has an effect if minSpeed is non-zero.
- */
-struct MoveToPoseFlags {
-  bool forwards = true;
-  float chasePower = 0;
-  float lead = 0.6;
-  float maxSpeed = 127;
-  float minSpeed = 0;
-  float earlyExitRange = 0;
-};
-
-/**
- * @brief Function pointer type for drive curve functions.
- * @param input The control input in the range [-127, 127].
- * @param scale The scaling factor, which can be optionally ignored.
- * @return The new value to be used.
- */
-typedef std::function<float(float, float)> DriveCurveFunction_t;
-
-/**
- * @brief  Default drive curve. Modifies  the input with an exponential curve.
- * If the input is 127, the function will always output 127, no matter the value
- * of scale, likewise for -127. This curve was inspired by team 5225, the
- * Pilons. A Desmos graph of this curve can be found here:
- * https://www.desmos.com/calculator/rcfjjg83zx
- * @param input value from -127 to 127
- * @param scale how steep the curve should be.
- * @return The new value to be used.
- */
-float defaultDriveCurve(float input, float scale);
-
-/**
- * @brief Chassis class
- *
- */
-class Chassis {
-public:
-  /**
-   * @brief Construct a new Chassis
-   *
-   * @param drivetrain drivetrain to be used for the chassis
-   * @param lateralSettings settings for the lateral controller
-   * @param angularSettings settings for the angular controller
-   * @param sensors sensors to be used for odometry
-   * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
-   */
-  Chassis(Drivetrain drivetrain, ControllerSettings linearSettings,
-          ControllerSettings angularSettings, OdomSensors sensors,
-          DriveCurveFunction_t driveCurve = &defaultDriveCurve);
-  /**
-   * @brief Calibrate the chassis sensors
-   *
-   * @param calibrateIMU whether the IMU should be calibrated. true by default
-   */
-  void calibrate(bool calibrateIMU = true);
-  /**
-   * @brief Set the pose of the chassis
-   *
-   * @param x new x value
-   * @param y new y value
-   * @param theta new theta value
-   * @param radians true if theta is in radians, false if not. False by default
-   */
-  void setPose(float x, float y, float theta, bool radians = false);
-  /**
-   * @brief Set the pose of the chassis
-   *
-   * @param pose the new pose
-   * @param radians whether pose theta is in radians (true) or not (false).
-   * false by default
-   */
-  void setPose(Pose pose, bool radians = false);
-  /**
-   * @brief Get the pose of the chassis
-   *
-   * @param radians whether theta should be in radians (true) or degrees
-   * (false). false by default
-   * @return Pose
-   */
-  Pose getPose(bool radians = false, bool standardPos = false);
-  /**
-   * @brief Wait until the robot has traveled a certain distance along the path
-   *
-   * @note Units are in inches if current motion is moveTo or follow, degrees if
-   * using turnTo
-   *
-   * @param dist the distance the robot needs to travel before returning
-   */
-  void waitUntil(float dist);
-  /**
-   * @brief Wait until the robot has completed the path
-   *
-   */
-  void waitUntilDone();
-  /**
-   * @brief Turn the chassis so it is facing the target point
-   *
-   * The PID logging id is "angularPID"
-   *
-   * @param x x location
-   * @param y y location
-   * @param timeout longest time the robot can spend moving
-   * @param forwards whether the robot should turn to face the point with the
-   * front of the robot. true by default
-   * @param maxSpeed the maximum speed the robot can turn at. Default is 127
-   * @param async whether the function should be run asynchronously. true by
-   * default
-   */
-  void turnTo(float x, float y, int timeout, bool forwards = true,
-              float maxSpeed = 127, bool async = true);
-  /**
-   * @brief Move the chassis towards the target pose
-   *
-   * Uses the boomerang controller
-   *
-   * @param x x location
-   * @param y y location
-   * @param theta target heading in degrees.
-   * @param timeout longest time the robot can spend moving
-   * @param params struct to simulate named parameters
-   * @param async whether the function should be run asynchronously. true by
-   * default
-   */
-  void moveToPose(float x, float y, float theta, int timeout,
-                  MoveToPoseParams params = {}, bool async = true);
-  /**
-   * @brief Move the chassis towards a target point
-   *
-   * @param x x location
-   * @param y y location
-   * @param timeout longest time the robot can spend moving
-   * @param maxSpeed the maximum speed the robot can move at. 127 by default
-   * @param async whether the function should be run asynchronously. true by
-   * default
-   */
-  void moveToPoint(float x, float y, int timeout, bool forwards = true,
-                   float maxSpeed = 127, bool async = true);
-  /**
-   * @brief Move the chassis along a path
-   *
-   * @param path the path asset to follow
-   * @param lookahead the lookahead distance. Units in inches. Larger values
-   * will make the robot move faster but will follow the path less accurately
-   * @param timeout the maximum time the robot can spend moving
-   * @param forwards whether the robot should follow the path going forwards.
-   * true by default
-   * @param async whether the function should be run asynchronously. true by
-   * default
-   */
-  void follow(const asset &path, float lookahead, int timeout,
-              bool forwards = true, bool async = true);
-  /**
-   * @brief Control the robot during the driver control period using the tank
-   * drive control scheme. In this control scheme one joystick axis controls one
-   * half of the robot, and another joystick axis controls another.
-   * @param left speed of the left side of the drivetrain. Takes an input from
-   * -127 to 127.
-   * @param right speed of the right side of the drivetrain. Takes an input from
-   * -127 to 127.
-   * @param curveGain control how steep the drive curve is. The larger the
-   * number, the steeper the curve. A value of 0 disables the curve entirely.
-   */
-  void tank(int left, int right, float curveGain = 0.0);
-  /**
-   * @brief Control the robot during the driver using the arcade drive control
-   * scheme. In this control scheme one joystick axis controls the forwards and
-   * backwards movement of the robot, while the other joystick axis controls the
-   * robot's turning
-   * @param throttle speed to move forward or backward. Takes an input from -127
-   * to 127.
-   * @param turn speed to turn. Takes an input from -127 to 127.
-   * @param curveGain the scale inputted into the drive curve function. If you
-   * are using the default drive curve, refer to the `defaultDriveCurve`
-   * documentation.
-   */
-  void arcade(int throttle, int turn, float curveGain = 0.0);
-  /**
-   * @brief Control the robot during the driver using the curvature drive
-   * control scheme. This control scheme is very similar to arcade drive, except
-   * the second joystick axis controls the radius of the curve that the
-   * drivetrain makes, rather than the speed. This means that the driver can
-   * accelerate in a turn without changing the radius of that turn. This control
-   * scheme defaults to arcade when forward is zero.
-   * @param throttle speed to move forward or backward. Takes an input from -127
-   * to 127.
-   * @param turn speed to turn. Takes an input from -127 to 127.
-   * @param curveGain the scale inputted into the drive curve function. If you
-   * are using the default drive curve, refer to the `defaultDriveCurve`
-   * documentation.
-   */
-  void curvature(int throttle, int turn, float cureGain = 0.0);
-  /**
-   * @brief Cancels the currently running motion.
-   * If there is a queued motion, then that queued motion will run.
-   */
-  void cancelMotion();
-  /**
-   * @brief Cancels all motions, even those that are queued.
-   * After this, the chassis will not be in motion.
-   */
-  void cancelAllMotions();
-  /**
-   * @return whether a motion is currently running
-   */
-  bool isInMotion() const;
-
-protected:
-  /**
-   * @brief Indicates that this motion is queued and blocks current task until
-   * this motion reaches front of queue
-   */
-  void requestMotionStart();
-  /**
-   * @brief Dequeues this motion and permits queued task to run
-   */
-  void endMotion();
-
-private:
-  bool motionRunning = false;
-  bool motionQueued = false;
-
-  pros::Mutex mutex;
-  float distTravelled = 0;
-
-  ControllerSettings lateralSettings;
-  ControllerSettings angularSettings;
-  Drivetrain drivetrain;
-  OdomSensors sensors;
-  DriveCurveFunction_t driveCurve;
-
-  PID lateralPID;
-  PID angularPID;
-  ExitCondition lateralLargeExit;
-  ExitCondition lateralSmallExit;
-  ExitCondition angularLargeExit;
-  ExitCondition angularSmallExit;
-};
+	/**
+	 * @brief Struct containing all the sensors used for odometry
+	 *
+	 */
+	struct OdomSensors {
+		/**
+		 * The sensors are stored in a struct so that they can be easily passed to the
+		 * chassis class The variables are pointers so that they can be set to nullptr
+		 * if they are not used Otherwise the chassis class would have to have a
+		 * constructor for each possible combination of sensors
+		 *
+		 * @param vertical1 pointer to the first vertical tracking wheel
+		 * @param vertical2 pointer to the second vertical tracking wheel
+		 * @param horizontal1 pointer to the first horizontal tracking wheel
+		 * @param horizontal2 pointer to the second horizontal tracking wheel
+		 * @param imu pointer to the IMU
+		 */
+		OdomSensors(TrackingWheel * vertical1, TrackingWheel * vertical2, TrackingWheel * horizontal1, TrackingWheel * horizontal2, pros::Imu * imu);
+		TrackingWheel * vertical1;
+		TrackingWheel * vertical2;
+		TrackingWheel * horizontal1;
+		TrackingWheel * horizontal2;
+		pros::Imu * imu;
+	};
+	/**
+	 * @brief Struct containing constants for a chassis controller
+	 *
+	 */
+	struct ControllerSettings {
+		/**
+		 * The constants are stored in a struct so that they can be easily passed to
+		 * the chassis class Set a constant to 0 and it will be ignored
+		 *
+		 * @param kP proportional constant for the chassis controller
+		 * @param kI integral constant for the chassis controller
+		 * @param kD derivative constant for the chassis controller
+		 * @param antiWindup
+		 * @param smallError the error at which the chassis controller will switch to
+		 * a slower control loop
+		 * @param smallErrorTimeout the time the chassis controller will wait before
+		 * switching to a slower control loop
+		 * @param largeError the error at which the chassis controller will switch to
+		 * a faster control loop
+		 * @param largeErrorTimeout the time the chassis controller will wait before
+		 * switching to a faster control loop
+		 * @param slew the maximum acceleration of the chassis controller
+		 */
+		ControllerSettings(float kP, float kI, float kD, float windupRange, float smallError, float smallErrorTimeout, float largeError, float largeErrorTimeout, float slew): kP(kP), kI(kI), kD(kD), windupRange(windupRange),
+			smallError(smallError), smallErrorTimeout(smallErrorTimeout),
+			largeError(largeError), largeErrorTimeout(largeErrorTimeout),
+			slew(slew) {}
+		float kP;
+		float kI;
+		float kD;
+		float windupRange;
+		float smallError;
+		float smallErrorTimeout;
+		float largeError;
+		float largeErrorTimeout;
+		float slew;
+	};
+	/**
+	 * @brief Struct containing constants for a drivetrain
+	 *
+	 */
+	struct Drivetrain {
+		/**
+		 * The constants are stored in a struct so that they can be easily passed to
+		 * the chassis class Set a constant to 0 and it will be ignored
+		 *
+		 * @param leftMotors pointer to the left motors
+		 * @param rightMotors pointer to the right motors
+		 * @param trackWidth the track width of the robot
+		 * @param wheelDiameter the diameter of the wheel used on the drivetrain
+		 * @param rpm the rpm of the wheels
+		 * @param chasePower higher values make the robot move faster but causes more
+		 * overshoot on turns
+		 */
+		Drivetrain(pros::MotorGroup * leftMotors, pros::MotorGroup * rightMotors, float trackWidth, float wheelDiameter, float rpm, float chasePower);
+		pros::Motor_Group * leftMotors;
+		pros::Motor_Group * rightMotors;
+		float trackWidth;
+		float wheelDiameter;
+		float rpm;
+		float chasePower;
+	};
+	/**
+	 * @brief Targets for Chassis::moveToPose
+	 *
+	 * We use a struct to simplify customization. Chassis::moveToPose has many
+	 * parameters and specifying them all just to set one optional param ruins
+	 * readability. By passing a struct to the function, we can have named
+	 * parameters, overcoming the c/c++ limitation
+	 *
+	 * @param dist whether the robot should move forwards or backwards. True by
+	 * default
+	 * @param x how fast the robot will move around corners. Recommended value 2-15.
+	 *  0 means use chasePower set in chassis class. 0 by default.
+	 * @param y carrot point multiplier. value between 0 and 1. Higher values result
+	 * in curvier movements. 0.6 by default
+	 * @param theta the maximum speed the robot can travel at. Value between 0-127.
+	 *  127 by default
+	 */
+	struct MoveToPoseTargets {
+		float dist = std::numeric_limits < float > ::quiet_NaN();
+		float x = std::numeric_limits < float > ::quiet_NaN();
+		float y = std::numeric_limits < float > ::quiet_NaN();
+		float theta = std::numeric_limits < float > ::quiet_NaN();
+	}
+	/**
+	 * @brief Flags for Chassis::moveToPose
+	 *
+	 * We use a struct to simplify customization. Chassis::moveToPose has many
+	 * parameters and specifying them all just to set one optional param ruins
+	 * readability. By passing a struct to the function, we can have named
+	 * parameters, overcoming the c/c++ limitation
+	 *
+	 * @param forwards whether the robot should move forwards or backwards. True by
+	 * default
+	 * @param chasePower how fast the robot will move around corners. Recommended
+	 * value 2-15. 0 means use chasePower set in chassis class. 0 by default.
+	 * @param lead carrot point multiplier. value between 0 and 1. Higher values
+	 * result in curvier movements. 0.6 by default
+	 * @param maxSpeed the maximum speed the robot can travel at. Value between
+	 * 0-127. 127 by default
+	 * @param minSpeed the minimum speed the robot can travel at. If set to a
+	 * non-zero value, the exit conditions will switch to less accurate but smoother
+	 * ones. Value between 0-127. 0 by default
+	 * @param earlyExitRange distance between the robot and target point where the
+	 * movement will exit. Only has an effect if minSpeed is non-zero.
+	 */
+	struct MoveToPoseFlags {
+		bool forwards = true;
+		float chasePower = 0;
+		float lead = 0.6;
+		float maxSpeed = 127;
+		float minSpeed = 0;
+		float earlyExitRange = 0;
+	};
+	/**
+	 * @brief Function pointer type for drive curve functions.
+	 * @param input The control input in the range [-127, 127].
+	 * @param scale The scaling factor, which can be optionally ignored.
+	 * @return The new value to be used.
+	 */
+	typedef std:: function < float(float, float) > DriveCurveFunction_t;
+	/**
+	 * @brief  Default drive curve. Modifies  the input with an exponential curve.
+	 * If the input is 127, the function will always output 127, no matter the value
+	 * of scale, likewise for -127. This curve was inspired by team 5225, the
+	 * Pilons. A Desmos graph of this curve can be found here:
+	 * https://www.desmos.com/calculator/rcfjjg83zx
+	 * @param input value from -127 to 127
+	 * @param scale how steep the curve should be.
+	 * @return The new value to be used.
+	 */
+	float defaultDriveCurve(float input, float scale);
+	/**
+	 * @brief Chassis class
+	 *
+	 */
+	class Chassis {
+		public:
+			/**
+			 * @brief Construct a new Chassis
+			 *
+			 * @param drivetrain drivetrain to be used for the chassis
+			 * @param lateralSettings settings for the lateral controller
+			 * @param angularSettings settings for the angular controller
+			 * @param sensors sensors to be used for odometry
+			 * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
+			 */
+			Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings, OdomSensors sensors, DriveCurveFunction_t driveCurve = & defaultDriveCurve);
+		/**
+		 * @brief Calibrate the chassis sensors
+		 *
+		 * @param calibrateIMU whether the IMU should be calibrated. true by default
+		 */
+		void calibrate(bool calibrateIMU = true);
+		/**
+		 * @brief Set the pose of the chassis
+		 *
+		 * @param x new x value
+		 * @param y new y value
+		 * @param theta new theta value
+		 * @param radians true if theta is in radians, false if not. False by default
+		 */
+		void setPose(float x, float y, float theta, bool radians = false);
+		/**
+		 * @brief Set the pose of the chassis
+		 *
+		 * @param pose the new pose
+		 * @param radians whether pose theta is in radians (true) or not (false).
+		 * false by default
+		 */
+		void setPose(Pose pose, bool radians = false);
+		/**
+		 * @brief Get the pose of the chassis
+		 *
+		 * @param radians whether theta should be in radians (true) or degrees
+		 * (false). false by default
+		 * @return Pose
+		 */
+		Pose getPose(bool radians = false, bool standardPos = false);
+		/**
+		 * @brief Wait until the robot has traveled a certain distance along the path
+		 *
+		 * @note Units are in inches if current motion is moveTo or follow, degrees if
+		 * using turnTo
+		 *
+		 * @param dist the distance the robot needs to travel before returning
+		 */
+		void waitUntil(float dist);
+		/**
+		 * @brief Wait until the robot has completed the path
+		 *
+		 */
+		void waitUntilDone();
+		/**
+		 * @brief Turn the chassis so it is facing the target point
+		 *
+		 * The PID logging id is "angularPID"
+		 *
+		 * @param x x location
+		 * @param y y location
+		 * @param timeout longest time the robot can spend moving
+		 * @param forwards whether the robot should turn to face the point with the
+		 * front of the robot. true by default
+		 * @param maxSpeed the maximum speed the robot can turn at. Default is 127
+		 * @param async whether the function should be run asynchronously. true by
+		 * default
+		 */
+		void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
+		/**
+		 * @brief Move the chassis towards the target pose
+		 *
+		 * Uses the boomerang controller
+		 *
+		 * @param x x location
+		 * @param y y location
+		 * @param theta target heading in degrees.
+		 * @param timeout longest time the robot can spend moving
+		 * @param params struct to simulate named parameters
+		 * @param async whether the function should be run asynchronously. true by
+		 * default
+		 */
+		void moveToPose(float x, float y, float theta, int timeout, MoveToPoseParams params = {}, bool async = true);
+		/**
+		 * @brief Move the chassis towards a target point
+		 *
+		 * @param x x location
+		 * @param y y location
+		 * @param timeout longest time the robot can spend moving
+		 * @param maxSpeed the maximum speed the robot can move at. 127 by default
+		 * @param async whether the function should be run asynchronously. true by
+		 * default
+		 */
+		void moveToPoint(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
+		/**
+		 * @brief Move the chassis along a path
+		 *
+		 * @param path the path asset to follow
+		 * @param lookahead the lookahead distance. Units in inches. Larger values
+		 * will make the robot move faster but will follow the path less accurately
+		 * @param timeout the maximum time the robot can spend moving
+		 * @param forwards whether the robot should follow the path going forwards.
+		 * true by default
+		 * @param async whether the function should be run asynchronously. true by
+		 * default
+		 */
+		void follow(const asset & path, float lookahead, int timeout,
+			bool forwards = true, bool async = true);
+		/**
+		 * @brief Control the robot during the driver control period using the tank
+		 * drive control scheme. In this control scheme one joystick axis controls one
+		 * half of the robot, and another joystick axis controls another.
+		 * @param left speed of the left side of the drivetrain. Takes an input from
+		 * -127 to 127.
+		 * @param right speed of the right side of the drivetrain. Takes an input from
+		 * -127 to 127.
+		 * @param curveGain control how steep the drive curve is. The larger the
+		 * number, the steeper the curve. A value of 0 disables the curve entirely.
+		 */
+		void tank(int left, int right, float curveGain = 0.0);
+		/**
+		 * @brief Control the robot during the driver using the arcade drive control
+		 * scheme. In this control scheme one joystick axis controls the forwards and
+		 * backwards movement of the robot, while the other joystick axis controls the
+		 * robot's turning
+		 * @param throttle speed to move forward or backward. Takes an input from -127
+		 * to 127.
+		 * @param turn speed to turn. Takes an input from -127 to 127.
+		 * @param curveGain the scale inputted into the drive curve function. If you
+		 * are using the default drive curve, refer to the `defaultDriveCurve`
+		 * documentation.
+		 */
+		void arcade(int throttle, int turn, float curveGain = 0.0);
+		/**
+		 * @brief Control the robot during the driver using the curvature drive
+		 * control scheme. This control scheme is very similar to arcade drive, except
+		 * the second joystick axis controls the radius of the curve that the
+		 * drivetrain makes, rather than the speed. This means that the driver can
+		 * accelerate in a turn without changing the radius of that turn. This control
+		 * scheme defaults to arcade when forward is zero.
+		 * @param throttle speed to move forward or backward. Takes an input from -127
+		 * to 127.
+		 * @param turn speed to turn. Takes an input from -127 to 127.
+		 * @param curveGain the scale inputted into the drive curve function. If you
+		 * are using the default drive curve, refer to the `defaultDriveCurve`
+		 * documentation.
+		 */
+		void curvature(int throttle, int turn, float cureGain = 0.0);
+		/**
+		 * @brief Cancels the currently running motion.
+		 * If there is a queued motion, then that queued motion will run.
+		 */
+		void cancelMotion();
+		/**
+		 * @brief Cancels all motions, even those that are queued.
+		 * After this, the chassis will not be in motion.
+		 */
+		void cancelAllMotions();
+		/**
+		 * @return whether a motion is currently running
+		 */
+		bool isInMotion() const;
+		protected:
+			/**
+			 * @brief Indicates that this motion is queued and blocks current task until
+			 * this motion reaches front of queue
+			 */
+			void requestMotionStart();
+		/**
+		 * @brief Dequeues this motion and permits queued task to run
+		 */
+		void endMotion();
+		private: bool motionRunning = false;
+		bool motionQueued = false;
+		pros::Mutex mutex;
+		float distTravelled = 0;
+		ControllerSettings lateralSettings;
+		ControllerSettings angularSettings;
+		Drivetrain drivetrain;
+		OdomSensors sensors;
+		DriveCurveFunction_t driveCurve;
+		PID lateralPID;
+		PID angularPID;
+		ExitCondition lateralLargeExit;
+		ExitCondition lateralSmallExit;
+		ExitCondition angularLargeExit;
+		ExitCondition angularSmallExit;
+	};
 } // namespace lemlib

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -371,7 +371,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout,
     break;
   }
 
-  private:
+private:
   // Enum to represent different movement types
   enum MovementType {
     RelativeWithoutAngle,

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -34,11 +34,11 @@
  * @param imu pointer to the IMU
  */
 lemlib::OdomSensors::OdomSensors(TrackingWheel *vertical1,
-                                 TrackingWheel *vertical2,
-                                 TrackingWheel *horizontal1,
-                                 TrackingWheel *horizontal2, pros::Imu *imu)
-    : vertical1(vertical1), vertical2(vertical2), horizontal1(horizontal1),
-      horizontal2(horizontal2), imu(imu) {}
+                                                                 TrackingWheel *vertical2,
+                                                                 TrackingWheel *horizontal1,
+                                                                 TrackingWheel *horizontal2, pros::Imu *imu)
+        : vertical1(vertical1), vertical2(vertical2), horizontal1(horizontal1),
+            horizontal2(horizontal2), imu(imu) {}
 
 /**
  * @brief The constants are stored in a struct so that they can be easily passed
@@ -53,10 +53,10 @@ lemlib::OdomSensors::OdomSensors(TrackingWheel *vertical1,
  * overshoot on turns
  */
 lemlib::Drivetrain::Drivetrain(pros::MotorGroup *leftMotors,
-                               pros::MotorGroup *rightMotors, float trackWidth,
-                               float wheelDiameter, float rpm, float chasePower)
-    : leftMotors(leftMotors), rightMotors(rightMotors), trackWidth(trackWidth),
-      wheelDiameter(wheelDiameter), rpm(rpm), chasePower(chasePower) {}
+                                                             pros::MotorGroup *rightMotors, float trackWidth,
+                                                             float wheelDiameter, float rpm, float chasePower)
+        : leftMotors(leftMotors), rightMotors(rightMotors), trackWidth(trackWidth),
+            wheelDiameter(wheelDiameter), rpm(rpm), chasePower(chasePower) {}
 
 /**
  * @brief Construct a new Chassis
@@ -68,24 +68,24 @@ lemlib::Drivetrain::Drivetrain(pros::MotorGroup *leftMotors,
  * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
  */
 lemlib::Chassis::Chassis(Drivetrain drivetrain,
-                         ControllerSettings lateralSettings,
-                         ControllerSettings angularSettings,
-                         OdomSensors sensors, DriveCurveFunction_t driveCurve)
-    : drivetrain(drivetrain), lateralSettings(lateralSettings),
-      angularSettings(angularSettings), sensors(sensors),
-      driveCurve(driveCurve),
-      lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD,
-                 lateralSettings.windupRange, true),
-      angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD,
-                 angularSettings.windupRange, true),
-      lateralLargeExit(lateralSettings.largeError,
-                       lateralSettings.largeErrorTimeout),
-      lateralSmallExit(lateralSettings.smallError,
-                       lateralSettings.smallErrorTimeout),
-      angularLargeExit(angularSettings.largeError,
-                       angularSettings.largeErrorTimeout),
-      angularSmallExit(angularSettings.smallError,
-                       angularSettings.smallErrorTimeout) {}
+                                                 ControllerSettings lateralSettings,
+                                                 ControllerSettings angularSettings,
+                                                 OdomSensors sensors, DriveCurveFunction_t driveCurve)
+        : drivetrain(drivetrain), lateralSettings(lateralSettings),
+            angularSettings(angularSettings), sensors(sensors),
+            driveCurve(driveCurve),
+            lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD,
+                                 lateralSettings.windupRange, true),
+            angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD,
+                                 angularSettings.windupRange, true),
+            lateralLargeExit(lateralSettings.largeError,
+                                             lateralSettings.largeErrorTimeout),
+            lateralSmallExit(lateralSettings.smallError,
+                                             lateralSettings.smallErrorTimeout),
+            angularLargeExit(angularSettings.largeError,
+                                             angularSettings.largeErrorTimeout),
+            angularSmallExit(angularSettings.smallError,
+                                             angularSettings.smallErrorTimeout) {}
 
 /**
  * @brief Calibrate the chassis sensors
@@ -93,40 +93,40 @@ lemlib::Chassis::Chassis(Drivetrain drivetrain,
  * @param calibrateIMU whether the IMU should be calibrated. true by default
  */
 void lemlib::Chassis::calibrate(bool calibrateIMU) {
-  // calibrate the IMU if it exists and the user doesn't specify otherwise
-  if (sensors.imu != nullptr && calibrateIMU) {
-    int attempt = 1;
-    // calibrate inertial, and if calibration fails, then repeat 5 times or
-    // until successful
-    while (sensors.imu->reset(true) != 1 &&
-           (errno == PROS_ERR || errno == ENODEV || errno == ENXIO) &&
-           attempt < 5) {
-      pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, "---");
-      pros::delay(10);
-      attempt++;
+    // calibrate the IMU if it exists and the user doesn't specify otherwise
+    if (sensors.imu != nullptr && calibrateIMU) {
+        int attempt = 1;
+        // calibrate inertial, and if calibration fails, then repeat 5 times or
+        // until successful
+        while (sensors.imu->reset(true) != 1 &&
+                     (errno == PROS_ERR || errno == ENODEV || errno == ENXIO) &&
+                     attempt < 5) {
+            pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, "---");
+            pros::delay(10);
+            attempt++;
+        }
+        if (attempt == 5)
+            sensors.imu = nullptr;
     }
-    if (attempt == 5)
-      sensors.imu = nullptr;
-  }
-  // initialize odom
-  if (sensors.vertical1 == nullptr)
-    sensors.vertical1 = new lemlib::TrackingWheel(
-        drivetrain.leftMotors, drivetrain.wheelDiameter,
-        -(drivetrain.trackWidth / 2), drivetrain.rpm);
-  if (sensors.vertical2 == nullptr)
-    sensors.vertical2 = new lemlib::TrackingWheel(
-        drivetrain.rightMotors, drivetrain.wheelDiameter,
-        drivetrain.trackWidth / 2, drivetrain.rpm);
-  sensors.vertical1->reset();
-  sensors.vertical2->reset();
-  if (sensors.horizontal1 != nullptr)
-    sensors.horizontal1->reset();
-  if (sensors.horizontal2 != nullptr)
-    sensors.horizontal2->reset();
-  lemlib::setSensors(sensors, drivetrain);
-  lemlib::init();
-  // rumble to controller to indicate success
-  pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, ".");
+    // initialize odom
+    if (sensors.vertical1 == nullptr)
+        sensors.vertical1 = new lemlib::TrackingWheel(
+                drivetrain.leftMotors, drivetrain.wheelDiameter,
+                -(drivetrain.trackWidth / 2), drivetrain.rpm);
+    if (sensors.vertical2 == nullptr)
+        sensors.vertical2 = new lemlib::TrackingWheel(
+                drivetrain.rightMotors, drivetrain.wheelDiameter,
+                drivetrain.trackWidth / 2, drivetrain.rpm);
+    sensors.vertical1->reset();
+    sensors.vertical2->reset();
+    if (sensors.horizontal1 != nullptr)
+        sensors.horizontal1->reset();
+    if (sensors.horizontal2 != nullptr)
+        sensors.horizontal2->reset();
+    lemlib::setSensors(sensors, drivetrain);
+    lemlib::init();
+    // rumble to controller to indicate success
+    pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, ".");
 }
 
 /**
@@ -138,7 +138,7 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
  * @param radians true if theta is in radians, false if not. False by default
  */
 void lemlib::Chassis::setPose(float x, float y, float theta, bool radians) {
-  lemlib::setPose(lemlib::Pose(x, y, theta), radians);
+    lemlib::setPose(lemlib::Pose(x, y, theta), radians);
 }
 
 /**
@@ -149,7 +149,7 @@ void lemlib::Chassis::setPose(float x, float y, float theta, bool radians) {
  * by default
  */
 void lemlib::Chassis::setPose(Pose pose, bool radians) {
-  lemlib::setPose(pose, radians);
+    lemlib::setPose(pose, radians);
 }
 
 /**
@@ -160,12 +160,12 @@ void lemlib::Chassis::setPose(Pose pose, bool radians) {
  * @return Pose
  */
 lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
-  Pose pose = lemlib::getPose(true);
-  if (standardPos)
-    pose.theta = M_PI_2 - pose.theta;
-  if (!radians)
-    pose.theta = radToDeg(pose.theta);
-  return pose;
+    Pose pose = lemlib::getPose(true);
+    if (standardPos)
+        pose.theta = M_PI_2 - pose.theta;
+    if (!radians)
+        pose.theta = radToDeg(pose.theta);
+    return pose;
 }
 
 /**
@@ -177,10 +177,10 @@ lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
  * @param dist the distance the robot needs to travel before returning
  */
 void lemlib::Chassis::waitUntil(float dist) {
-  // do while to give the thread time to start
-  do
-    pros::delay(10);
-  while (distTravelled <= dist && distTravelled != -1);
+    // do while to give the thread time to start
+    do
+        pros::delay(10);
+    while (distTravelled <= dist && distTravelled != -1);
 }
 
 /**
@@ -188,43 +188,43 @@ void lemlib::Chassis::waitUntil(float dist) {
  *
  */
 void lemlib::Chassis::waitUntilDone() {
-  do
-    pros::delay(10);
-  while (distTravelled != -1);
+    do
+        pros::delay(10);
+    while (distTravelled != -1);
 }
 
 void lemlib::Chassis::requestMotionStart() {
-  if (this->isInMotion())
-    this->motionQueued = true; // indicate a motion is queued
-  else
-    this->motionRunning = true; // indicate a motion is running
+    if (this->isInMotion())
+        this->motionQueued = true; // indicate a motion is queued
+    else
+        this->motionRunning = true; // indicate a motion is running
 
-  // wait until this motion is at front of "queue"
-  this->mutex.take(TIMEOUT_MAX);
+    // wait until this motion is at front of "queue"
+    this->mutex.take(TIMEOUT_MAX);
 
-  // this->motionRunning should be true
-  // and this->motionQueued should be false
-  // indicating this motion is running
+    // this->motionRunning should be true
+    // and this->motionQueued should be false
+    // indicating this motion is running
 }
 
 void lemlib::Chassis::endMotion() {
-  // move the "queue" forward 1
-  this->motionRunning = this->motionQueued;
-  this->motionQueued = false;
+    // move the "queue" forward 1
+    this->motionRunning = this->motionQueued;
+    this->motionQueued = false;
 
-  // permit queued motion to run
-  this->mutex.give();
+    // permit queued motion to run
+    this->mutex.give();
 }
 
 void lemlib::Chassis::cancelMotion() {
-  this->motionRunning = false;
-  pros::delay(10); // give time for motion to stop
+    this->motionRunning = false;
+    pros::delay(10); // give time for motion to stop
 }
 
 void lemlib::Chassis::cancelAllMotions() {
-  this->motionRunning = false;
-  this->motionQueued = false;
-  pros::delay(10); // give time for motion to stop
+    this->motionRunning = false;
+    this->motionQueued = false;
+    pros::delay(10); // give time for motion to stop
 }
 
 bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
@@ -244,72 +244,72 @@ bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
  * default
  */
 void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards,
-                             float maxSpeed, bool async) {
-  this->requestMotionStart();
-  // were all motions cancelled?
-  if (!this->motionRunning)
-    return;
-  // if the function is async, run it in a new task
-  if (async) {
-    pros::Task task(
-        [&]() { turnTo(x, y, timeout, forwards, maxSpeed, false); });
+                                                         float maxSpeed, bool async) {
+    this->requestMotionStart();
+    // were all motions cancelled?
+    if (!this->motionRunning)
+        return;
+    // if the function is async, run it in a new task
+    if (async) {
+        pros::Task task(
+                [&]() { turnTo(x, y, timeout, forwards, maxSpeed, false); });
+        this->endMotion();
+        pros::delay(10); // delay to give the task time to start
+        return;
+    }
+    float targetTheta;
+    float deltaX, deltaY, deltaTheta;
+    float motorPower;
+    float startTheta = getPose().theta;
+    std::uint8_t compState = pros::competition::get_status();
+    distTravelled = 0;
+    Timer timer(timeout);
+    angularLargeExit.reset();
+    angularSmallExit.reset();
+    angularPID.reset();
+
+    // main loop
+    while (!timer.isDone() && !angularLargeExit.getExit() &&
+                 !angularSmallExit.getExit() && this->motionRunning) {
+        // update variables
+        Pose pose = getPose();
+        pose.theta =
+                (forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
+
+        // update completion vars
+        distTravelled = fabs(angleError(pose.theta, startTheta));
+
+        deltaX = x - pose.x;
+        deltaY = y - pose.y;
+        targetTheta = fmod(radToDeg(M_PI_2 - atan2(deltaY, deltaX)), 360);
+
+        // calculate deltaTheta
+        deltaTheta = angleError(targetTheta, pose.theta, false);
+
+        // calculate the speed
+        motorPower = angularPID.update(deltaTheta);
+        angularLargeExit.update(deltaTheta);
+        angularSmallExit.update(deltaTheta);
+
+        // cap the speed
+        if (motorPower > maxSpeed)
+            motorPower = maxSpeed;
+        else if (motorPower < -maxSpeed)
+            motorPower = -maxSpeed;
+
+        // move the drivetrain
+        drivetrain.leftMotors->move(motorPower);
+        drivetrain.rightMotors->move(-motorPower);
+
+        pros::delay(10);
+    }
+
+    // stop the drivetrain
+    drivetrain.leftMotors->move(0);
+    drivetrain.rightMotors->move(0);
+    // set distTraveled to -1 to indicate that the function has finished
+    distTravelled = -1;
     this->endMotion();
-    pros::delay(10); // delay to give the task time to start
-    return;
-  }
-  float targetTheta;
-  float deltaX, deltaY, deltaTheta;
-  float motorPower;
-  float startTheta = getPose().theta;
-  std::uint8_t compState = pros::competition::get_status();
-  distTravelled = 0;
-  Timer timer(timeout);
-  angularLargeExit.reset();
-  angularSmallExit.reset();
-  angularPID.reset();
-
-  // main loop
-  while (!timer.isDone() && !angularLargeExit.getExit() &&
-         !angularSmallExit.getExit() && this->motionRunning) {
-    // update variables
-    Pose pose = getPose();
-    pose.theta =
-        (forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
-
-    // update completion vars
-    distTravelled = fabs(angleError(pose.theta, startTheta));
-
-    deltaX = x - pose.x;
-    deltaY = y - pose.y;
-    targetTheta = fmod(radToDeg(M_PI_2 - atan2(deltaY, deltaX)), 360);
-
-    // calculate deltaTheta
-    deltaTheta = angleError(targetTheta, pose.theta, false);
-
-    // calculate the speed
-    motorPower = angularPID.update(deltaTheta);
-    angularLargeExit.update(deltaTheta);
-    angularSmallExit.update(deltaTheta);
-
-    // cap the speed
-    if (motorPower > maxSpeed)
-      motorPower = maxSpeed;
-    else if (motorPower < -maxSpeed)
-      motorPower = -maxSpeed;
-
-    // move the drivetrain
-    drivetrain.leftMotors->move(motorPower);
-    drivetrain.rightMotors->move(-motorPower);
-
-    pros::delay(10);
-  }
-
-  // stop the drivetrain
-  drivetrain.leftMotors->move(0);
-  drivetrain.rightMotors->move(0);
-  // set distTraveled to -1 to indicate that the function has finished
-  distTravelled = -1;
-  this->endMotion();
 }
 
 /**
@@ -327,234 +327,234 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards,
  * default
  */
 void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout,
-                                 MoveToPoseFlags params, bool async) {
-  // take the mutex
-  this->requestMotionStart();
-  // were all motions cancelled?
-  if (!this->motionRunning)
-    return;
-  // if the function is async, run it in a new task
-  if (async) {
-    pros::Task task([&]() { moveToPose(x, y, theta, timeout, params, false); });
-    this->endMotion();
-    pros::delay(10); // delay to give the task time to start
-    return;
-  }
+                                                                 MoveToPoseFlags params, bool async) {
+    // take the mutex
+    this->requestMotionStart();
+    // were all motions cancelled?
+    if (!this->motionRunning)
+        return;
+    // if the function is async, run it in a new task
+    if (async) {
+        pros::Task task([&]() { moveToPose(x, y, theta, timeout, params, false); });
+        this->endMotion();
+        pros::delay(10); // delay to give the task time to start
+        return;
+    }
 
-  // reset PIDs and exit conditions
-  lateralPID.reset();
-  lateralLargeExit.reset();
-  lateralSmallExit.reset();
-  angularPID.reset();
-  angularLargeExit.reset();
-  angularSmallExit.reset();
+    // reset PIDs and exit conditions
+    lateralPID.reset();
+    lateralLargeExit.reset();
+    lateralSmallExit.reset();
+    angularPID.reset();
+    angularLargeExit.reset();
+    angularSmallExit.reset();
 
-  const Pose pose = getPose(true, true);
-  // Recalculate target based on user input
-  switch (getMovementType(targetPose)) {
-  case RelativeWithoutAngle:
-    Pose target = (pose.x + targetPose.dist * std::cos(pose.theta),
-                   pose.y + targetPose.dist * std::sin(pose.theta), pose.theta);
-    break;
-  case RelativeWithAngle:
-    Pose target =
-        (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
-         pose.y + targetPose.dist * std::sin(degToRad(targetPose.theta)),
-         targetPose.theta);
-    break;
-  case ClassicMovement:
-    // calculate target pose in standard form
-    Pose target(x, y, M_PI_2 - degToRad(theta));
-    break;
+    const Pose pose = getPose(true, true);
+    // Recalculate target based on user input
+    switch (getMovementType(targetPose)) {
+    case RelativeWithoutAngle:
+        Pose target = (pose.x + targetPose.dist * std::cos(pose.theta),
+                                     pose.y + targetPose.dist * std::sin(pose.theta), pose.theta);
+        break;
+    case RelativeWithAngle:
+        Pose target =
+                (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
+                 pose.y + targetPose.dist * std::sin(degToRad(targetPose.theta)),
+                 targetPose.theta);
+        break;
+    case ClassicMovement:
+        // calculate target pose in standard form
+        Pose target(x, y, M_PI_2 - degToRad(theta));
+        break;
 
-  default:
-    // Handle unknown movement type
-    // Log error maybe
-    break;
-  }
+    default:
+        // Handle unknown movement type
+        // Log error maybe
+        break;
+    }
 
 private:
-  // Enum to represent different movement types
-  enum MovementType {
-    RelativeWithoutAngle,
-    RelativeWithAngle,
-    ClassicMovement
-    // Add more movement types as needed
-  };
+    // Enum to represent different movement types
+    enum MovementType {
+        RelativeWithoutAngle,
+        RelativeWithAngle,
+        ClassicMovement
+        // Add more movement types as needed
+    };
 
-  // Function to determine the movement type based on user input
-  MovementType getMovementType(const MovementParams &params) {
-    if (!isnan(params.distance)) {
-      return RelativeWithoutAngle;
-    } else if (!isnan(params.distance) && !isnan(params.angle)) {
-      return RelativeWithAngle;
-    } else if (!isnan(params.x) || !isnan(params.y) || !isnan(params.angle)) {
-      return ClassicMovement;
-    } else {
-      // Handle unknown movement type
-      // Maybe log error
-      return ClassicMovement; // Default to classic movement for unknown
-                              // input
+    // Function to determine the movement type based on user input
+    MovementType getMovementType(const MovementParams &params) {
+        if (!isnan(params.distance)) {
+            return RelativeWithoutAngle;
+        } else if (!isnan(params.distance) && !isnan(params.angle)) {
+            return RelativeWithAngle;
+        } else if (!isnan(params.x) || !isnan(params.y) || !isnan(params.angle)) {
+            return ClassicMovement;
+        } else {
+            // Handle unknown movement type
+            // Maybe log error
+            return ClassicMovement; // Default to classic movement for unknown
+                                                            // input
+        }
     }
-  }
-  ...
+    ...
 
-      // calculate target pose in standard form
-      Pose target(x, y, M_PI_2 - degToRad(theta));
-  if (!params.forwards)
-    target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
+            // calculate target pose in standard form
+            Pose target(x, y, M_PI_2 - degToRad(theta));
+    if (!params.forwards)
+        target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 
-  // use global chasePower is chasePower is 0
-  if (params.chasePower == 0)
-    params.chasePower = drivetrain.chasePower;
+    // use global chasePower is chasePower is 0
+    if (params.chasePower == 0)
+        params.chasePower = drivetrain.chasePower;
 
-  // initialize vars used between iterations
-  Pose lastPose = getPose();
-  distTravelled = 0;
-  Timer timer(timeout);
-  bool close = false;
-  bool lateralSettled = false;
-  bool prevSameSide = false;
-  float prevLateralOut = 0; // previous lateral power
-  float prevAngularOut = 0; // previous angular power
-  const int compState = pros::competition::get_status();
+    // initialize vars used between iterations
+    Pose lastPose = getPose();
+    distTravelled = 0;
+    Timer timer(timeout);
+    bool close = false;
+    bool lateralSettled = false;
+    bool prevSameSide = false;
+    float prevLateralOut = 0; // previous lateral power
+    float prevAngularOut = 0; // previous angular power
+    const int compState = pros::competition::get_status();
 
-  // main loop
-  while (!timer.isDone() &&
-         ((!lateralSettled ||
-           (!angularLargeExit.getExit() && !angularSmallExit.getExit())) ||
-          !close) &&
-         this->motionRunning) {
-    // update position
-    const Pose pose = getPose(true, true);
+    // main loop
+    while (!timer.isDone() &&
+                 ((!lateralSettled ||
+                     (!angularLargeExit.getExit() && !angularSmallExit.getExit())) ||
+                    !close) &&
+                 this->motionRunning) {
+        // update position
+        const Pose pose = getPose(true, true);
 
-    // update distance travelled
-    distTravelled += pose.distance(lastPose);
-    lastPose = pose;
+        // update distance travelled
+        distTravelled += pose.distance(lastPose);
+        lastPose = pose;
 
-    // calculate distance to the target point
-    const float distTarget = pose.distance(target);
+        // calculate distance to the target point
+        const float distTarget = pose.distance(target);
 
-    // check if the robot is close enough to the target to start settling
-    if (distTarget < 7.5 && close == false) {
-      close = true;
-      params.maxSpeed = fmax(fabs(prevLateralOut), 60);
+        // check if the robot is close enough to the target to start settling
+        if (distTarget < 7.5 && close == false) {
+            close = true;
+            params.maxSpeed = fmax(fabs(prevLateralOut), 60);
+        }
+
+        // check if the lateral controller has settled
+        if (lateralLargeExit.getExit() && lateralSmallExit.getExit())
+            lateralSettled = true;
+
+        // calculate the carrot point
+        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) *
+                                                             params.lead * distTarget;
+        if (close)
+            carrot = target; // settling behavior
+
+        // calculate if the robot is on the same side as the carrot point
+        const bool robotSide =
+                (pose.y - target.y) * -sin(target.theta) <=
+                (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
+        const bool carrotSide =
+                (carrot.y - target.y) * -sin(target.theta) <=
+                (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
+        const bool sameSide = robotSide == carrotSide;
+        // exit if close
+        if (!sameSide && prevSameSide && close && params.minSpeed != 0)
+            break;
+        prevSameSide = sameSide;
+
+        // calculate error
+        const float adjustedRobotTheta =
+                params.forwards ? pose.theta : pose.theta + M_PI;
+        const float angularError =
+                close ? angleError(adjustedRobotTheta, target.theta)
+                            : angleError(adjustedRobotTheta, pose.angle(carrot));
+        float lateralError = pose.distance(carrot);
+        // only use cos when settling
+        // otherwise just multiply by the sign of cos
+        // maxSlipSpeed takes care of lateralOut
+        if (close)
+            lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
+        else
+            lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
+
+        // update exit conditions
+        lateralSmallExit.update(lateralError);
+        lateralLargeExit.update(lateralError);
+        angularSmallExit.update(radToDeg(angularError));
+        angularLargeExit.update(radToDeg(angularError));
+
+        // get output from PIDs
+        float lateralOut = lateralPID.update(lateralError);
+        float angularOut = angularPID.update(radToDeg(angularError));
+
+        // apply restrictions on angular speed
+        angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
+        angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
+
+        // apply restrictions on lateral speed
+        lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
+
+        // constrain lateral output by max accel
+        // but not for decelerating, since that would interfere with settling
+        if (params.forwards && lateralOut > prevLateralOut)
+            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+        if (!params.forwards && lateralOut < prevLateralOut)
+            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+
+        // constrain lateral output by the max speed it can travel at without
+        // slipping
+        const float radius = 1 / fabs(getCurvature(pose, carrot));
+        const float maxSlipSpeed(sqrt(params.chasePower * radius * 9.8));
+        lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
+        // prioritize angular movement over lateral movement
+        const float overturn =
+                fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
+        if (overturn > 0)
+            lateralOut -= lateralOut > 0 ? overturn : -overturn;
+
+        // prevent moving in the wrong direction
+        if (params.forwards && !close)
+            lateralOut = std::fmax(lateralOut, 0);
+        else if (!params.forwards && !close)
+            lateralOut = std::fmin(lateralOut, 0);
+
+        // constrain lateral output by the minimum speed
+        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
+            lateralOut = fabs(params.minSpeed);
+        if (!params.forwards && -lateralOut < fabs(params.minSpeed) &&
+                lateralOut < 0)
+            lateralOut = -fabs(params.minSpeed);
+
+        // update previous output
+        prevAngularOut = angularOut;
+        prevLateralOut = lateralOut;
+
+        // ratio the speeds to respect the max speed
+        float leftPower = lateralOut + angularOut;
+        float rightPower = lateralOut - angularOut;
+        const float ratio =
+                std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
+        if (ratio > 1) {
+            leftPower /= ratio;
+            rightPower /= ratio;
+        }
+
+        // move the drivetrain
+        drivetrain.leftMotors->move(leftPower);
+        drivetrain.rightMotors->move(rightPower);
+
+        // delay to save resources
+        pros::delay(10);
     }
 
-    // check if the lateral controller has settled
-    if (lateralLargeExit.getExit() && lateralSmallExit.getExit())
-      lateralSettled = true;
-
-    // calculate the carrot point
-    Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) *
-                               params.lead * distTarget;
-    if (close)
-      carrot = target; // settling behavior
-
-    // calculate if the robot is on the same side as the carrot point
-    const bool robotSide =
-        (pose.y - target.y) * -sin(target.theta) <=
-        (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
-    const bool carrotSide =
-        (carrot.y - target.y) * -sin(target.theta) <=
-        (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
-    const bool sameSide = robotSide == carrotSide;
-    // exit if close
-    if (!sameSide && prevSameSide && close && params.minSpeed != 0)
-      break;
-    prevSameSide = sameSide;
-
-    // calculate error
-    const float adjustedRobotTheta =
-        params.forwards ? pose.theta : pose.theta + M_PI;
-    const float angularError =
-        close ? angleError(adjustedRobotTheta, target.theta)
-              : angleError(adjustedRobotTheta, pose.angle(carrot));
-    float lateralError = pose.distance(carrot);
-    // only use cos when settling
-    // otherwise just multiply by the sign of cos
-    // maxSlipSpeed takes care of lateralOut
-    if (close)
-      lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
-    else
-      lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
-
-    // update exit conditions
-    lateralSmallExit.update(lateralError);
-    lateralLargeExit.update(lateralError);
-    angularSmallExit.update(radToDeg(angularError));
-    angularLargeExit.update(radToDeg(angularError));
-
-    // get output from PIDs
-    float lateralOut = lateralPID.update(lateralError);
-    float angularOut = angularPID.update(radToDeg(angularError));
-
-    // apply restrictions on angular speed
-    angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
-    angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
-
-    // apply restrictions on lateral speed
-    lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
-
-    // constrain lateral output by max accel
-    // but not for decelerating, since that would interfere with settling
-    if (params.forwards && lateralOut > prevLateralOut)
-      lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-    if (!params.forwards && lateralOut < prevLateralOut)
-      lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-
-    // constrain lateral output by the max speed it can travel at without
-    // slipping
-    const float radius = 1 / fabs(getCurvature(pose, carrot));
-    const float maxSlipSpeed(sqrt(params.chasePower * radius * 9.8));
-    lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
-    // prioritize angular movement over lateral movement
-    const float overturn =
-        fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
-    if (overturn > 0)
-      lateralOut -= lateralOut > 0 ? overturn : -overturn;
-
-    // prevent moving in the wrong direction
-    if (params.forwards && !close)
-      lateralOut = std::fmax(lateralOut, 0);
-    else if (!params.forwards && !close)
-      lateralOut = std::fmin(lateralOut, 0);
-
-    // constrain lateral output by the minimum speed
-    if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
-      lateralOut = fabs(params.minSpeed);
-    if (!params.forwards && -lateralOut < fabs(params.minSpeed) &&
-        lateralOut < 0)
-      lateralOut = -fabs(params.minSpeed);
-
-    // update previous output
-    prevAngularOut = angularOut;
-    prevLateralOut = lateralOut;
-
-    // ratio the speeds to respect the max speed
-    float leftPower = lateralOut + angularOut;
-    float rightPower = lateralOut - angularOut;
-    const float ratio =
-        std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
-    if (ratio > 1) {
-      leftPower /= ratio;
-      rightPower /= ratio;
-    }
-
-    // move the drivetrain
-    drivetrain.leftMotors->move(leftPower);
-    drivetrain.rightMotors->move(rightPower);
-
-    // delay to save resources
-    pros::delay(10);
-  }
-
-  // stop the drivetrain
-  drivetrain.leftMotors->move(0);
-  drivetrain.rightMotors->move(0);
-  // set distTraveled to -1 to indicate that the function has finished
-  distTravelled = -1;
-  this->endMotion();
+    // stop the drivetrain
+    drivetrain.leftMotors->move(0);
+    drivetrain.rightMotors->move(0);
+    // set distTraveled to -1 to indicate that the function has finished
+    distTravelled = -1;
+    this->endMotion();
 }
 
 /**
@@ -568,121 +568,121 @@ private:
  * default
  */
 void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards,
-                                  float maxSpeed, bool async) {
-  this->requestMotionStart();
-  // were all motions cancelled?
-  if (!this->motionRunning)
-    return;
-  // if the function is async, run it in a new task
-  if (async) {
-    pros::Task task(
-        [&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
+                                                                    float maxSpeed, bool async) {
+    this->requestMotionStart();
+    // were all motions cancelled?
+    if (!this->motionRunning)
+        return;
+    // if the function is async, run it in a new task
+    if (async) {
+        pros::Task task(
+                [&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
+        this->endMotion();
+        pros::delay(10); // delay to give the task time to start
+        return;
+    }
+
+    // reset PIDs and exit conditions
+    lateralPID.reset();
+    lateralLargeExit.reset();
+    lateralSmallExit.reset();
+    angularPID.reset();
+
+    // calculate target pose in standard form
+    const Pose target(x, y);
+
+    // initialize vars used between iterations
+    Pose lastPose = getPose();
+    distTravelled = 0;
+    Timer timer(timeout);
+    bool close = false;
+    float prevLateralOut = 0; // previous lateral power
+    float prevAngularOut = 0; // previous angular power
+    const int compState = pros::competition::get_status();
+
+    // main loop
+    while (!timer.isDone() &&
+                 ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) ||
+                    !close) &&
+                 this->motionRunning) {
+        // update position
+        const Pose pose = getPose(true, true);
+
+        // update distance travelled
+        distTravelled += pose.distance(lastPose);
+        lastPose = pose;
+
+        // calculate distance to the target point
+        const float distTarget = pose.distance(target);
+
+        // check if the robot is close enough to the target to start settling
+        if (distTarget < 7.5 && close == false) {
+            close = true;
+            maxSpeed = fmax(fabs(prevLateralOut), 60);
+        }
+
+        // calculate error
+        const float adjustedRobotTheta = forwards ? pose.theta : pose.theta + M_PI;
+        const float angularError =
+                angleError(adjustedRobotTheta, pose.angle(target));
+        float lateralError =
+                pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
+
+        // update exit conditions
+        lateralSmallExit.update(lateralError);
+        lateralLargeExit.update(lateralError);
+
+        // get output from PIDs
+        float lateralOut = lateralPID.update(lateralError);
+        float angularOut = angularPID.update(radToDeg(angularError));
+        if (close)
+            angularOut = 0;
+
+        // apply restrictions on angular speed
+        angularOut = std::clamp(angularOut, -maxSpeed, maxSpeed);
+        angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
+
+        // apply restrictions on lateral speed
+        lateralOut = std::clamp(lateralOut, -maxSpeed, maxSpeed);
+        // constrain lateral output by max accel
+        // but not for decelerating, since that would interfere with settling
+        if (forwards && lateralOut > prevLateralOut)
+            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+        if (!forwards && lateralOut < prevLateralOut)
+            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+
+        // prevent moving in the wrong direction
+        if (forwards && !close)
+            lateralOut = std::fmax(lateralOut, 0);
+        else if (!forwards && !close)
+            lateralOut = std::fmin(lateralOut, 0);
+
+        // update previous output
+        prevAngularOut = angularOut;
+        prevLateralOut = lateralOut;
+
+        // ratio the speeds to respect the max speed
+        float leftPower = lateralOut + angularOut;
+        float rightPower = lateralOut - angularOut;
+        const float ratio =
+                std::max(std::fabs(leftPower), std::fabs(rightPower)) / maxSpeed;
+        if (ratio > 1) {
+            leftPower /= ratio;
+            rightPower /= ratio;
+        }
+
+        // move the drivetrain
+        drivetrain.leftMotors->move(leftPower);
+        drivetrain.rightMotors->move(rightPower);
+
+        // delay to save resources
+        pros::delay(10);
+    }
+
+    // stop the drivetrain
+    drivetrain.leftMotors->move(0);
+    drivetrain.rightMotors->move(0);
+    // set distTraveled to -1 to indicate that the function has finished
+    distTravelled = -1;
     this->endMotion();
-    pros::delay(10); // delay to give the task time to start
-    return;
-  }
-
-  // reset PIDs and exit conditions
-  lateralPID.reset();
-  lateralLargeExit.reset();
-  lateralSmallExit.reset();
-  angularPID.reset();
-
-  // calculate target pose in standard form
-  const Pose target(x, y);
-
-  // initialize vars used between iterations
-  Pose lastPose = getPose();
-  distTravelled = 0;
-  Timer timer(timeout);
-  bool close = false;
-  float prevLateralOut = 0; // previous lateral power
-  float prevAngularOut = 0; // previous angular power
-  const int compState = pros::competition::get_status();
-
-  // main loop
-  while (!timer.isDone() &&
-         ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) ||
-          !close) &&
-         this->motionRunning) {
-    // update position
-    const Pose pose = getPose(true, true);
-
-    // update distance travelled
-    distTravelled += pose.distance(lastPose);
-    lastPose = pose;
-
-    // calculate distance to the target point
-    const float distTarget = pose.distance(target);
-
-    // check if the robot is close enough to the target to start settling
-    if (distTarget < 7.5 && close == false) {
-      close = true;
-      maxSpeed = fmax(fabs(prevLateralOut), 60);
-    }
-
-    // calculate error
-    const float adjustedRobotTheta = forwards ? pose.theta : pose.theta + M_PI;
-    const float angularError =
-        angleError(adjustedRobotTheta, pose.angle(target));
-    float lateralError =
-        pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
-
-    // update exit conditions
-    lateralSmallExit.update(lateralError);
-    lateralLargeExit.update(lateralError);
-
-    // get output from PIDs
-    float lateralOut = lateralPID.update(lateralError);
-    float angularOut = angularPID.update(radToDeg(angularError));
-    if (close)
-      angularOut = 0;
-
-    // apply restrictions on angular speed
-    angularOut = std::clamp(angularOut, -maxSpeed, maxSpeed);
-    angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
-
-    // apply restrictions on lateral speed
-    lateralOut = std::clamp(lateralOut, -maxSpeed, maxSpeed);
-    // constrain lateral output by max accel
-    // but not for decelerating, since that would interfere with settling
-    if (forwards && lateralOut > prevLateralOut)
-      lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-    if (!forwards && lateralOut < prevLateralOut)
-      lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-
-    // prevent moving in the wrong direction
-    if (forwards && !close)
-      lateralOut = std::fmax(lateralOut, 0);
-    else if (!forwards && !close)
-      lateralOut = std::fmin(lateralOut, 0);
-
-    // update previous output
-    prevAngularOut = angularOut;
-    prevLateralOut = lateralOut;
-
-    // ratio the speeds to respect the max speed
-    float leftPower = lateralOut + angularOut;
-    float rightPower = lateralOut - angularOut;
-    const float ratio =
-        std::max(std::fabs(leftPower), std::fabs(rightPower)) / maxSpeed;
-    if (ratio > 1) {
-      leftPower /= ratio;
-      rightPower /= ratio;
-    }
-
-    // move the drivetrain
-    drivetrain.leftMotors->move(leftPower);
-    drivetrain.rightMotors->move(rightPower);
-
-    // delay to save resources
-    pros::delay(10);
-  }
-
-  // stop the drivetrain
-  drivetrain.leftMotors->move(0);
-  drivetrain.rightMotors->move(0);
-  // set distTraveled to -1 to indicate that the function has finished
-  distTravelled = -1;
-  this->endMotion();
 }

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -290,7 +290,7 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
     distTravelled = -1;
     this->endMotion();
 }
-
+, const MoveToPoseTarget& params_t
 /*
  * @brief Get the movement type for boomerang so we can run calculations for the target
  */
@@ -317,28 +317,28 @@ MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) 
 /*
  * @brief get the target for the boomerang
  */
-void lemlib::Chassis::getTarget(MovementType mType) {
+void lemlib::Chassis::getTarget(MovementType mType, const MoveToPoseTarget& params_t) {
     const Pose pose_t = getPose(true, true);
     // Recalculate target based on user input
     switch (mType) {
         case RelativeWithoutAngle:
-            return Pose(pose_t.x + targetPose.dist * std::cos(pose_t.theta),
-                        pose_t.y + targetPose.dist * std::sin(pose_t.theta), pose_t.theta);
+            return Pose(params_t[0] + params_t[3] * std::cos(pose_t.theta),
+                        params_t[1] + params_t[3] * std::sin(pose_t.theta), params_t[2]);
             break;
         case RelativeWithAngle:
-            return Pose(pose_t.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
-                        pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
+            return Pose(params_t[0] + params_t[3] * std::cos(degToRad(params_t[2])),
+                        params_t[1] + params_t[3] * std::sin(degToRad(params_t[2])), params_t[2]);
             break;
         case ClassicMovement:
             // calculate target pose in standard form
-            return Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+            return Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(params_t[2]));
             break;
 
         default:
             // Handle unknown movement type
             // Log error maybe
             // calculate target pose in standard form
-            return Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+            return Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(params_t[2]));
             break;
     }
 }

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -293,7 +293,7 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
 /*
  * @brief Get the movement type for boomerang so we can run calculations for the target
  */
-void lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
+MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
     MovementType mType;
     // count number of values in the vector that were used
     uint16_t count = 0;
@@ -318,7 +318,7 @@ void lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
 /*
  * @brief get the target for the boomerang
  */
-void lemlib::Chassis::getTarget(MovementType mType, const MoveToPoseTarget& params_t) {
+lemlib::Pose lemlib::Chassis::getTarget(MovementType mType, const MoveToPoseTarget& params_t) {
     struct Target { // structure for readability
         float x;
         float y;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -328,7 +328,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
 
     const Pose pose = getPose(true, true);
     // Recalculate target based on user input
-    Pose target = (targetPose.x, targetPose.y, targetPose.theta);
+    Pose target(targetPose.x, targetPose.y,  M_PI_2 - degToRad(targetPose.theta));
     switch (getMovementType(targetPose)) {
     case RelativeWithoutAngle:
         target = (pose.x + targetPose.dist * std::cos(pose.theta), pose.y + targetPose.dist * std::sin(pose.theta),

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -21,8 +21,9 @@
 #include <math.h>
 
 /**
- * @brief The variables are pointers so that they can be set to nullptr if they are not used
- * Otherwise the chassis class would have to have a constructor for each possible combination of sensors
+ * @brief The variables are pointers so that they can be set to nullptr if they
+ * are not used Otherwise the chassis class would have to have a constructor for
+ * each possible combination of sensors
  *
  * @param vertical1 pointer to the first vertical tracking wheel
  * @param vertical2 pointer to the second vertical tracking wheel
@@ -30,25 +31,30 @@
  * @param horizontal2 pointer to the second horizontal tracking wheel
  * @param imu pointer to the IMU
  */
-lemlib::OdomSensors::OdomSensors(TrackingWheel *vertical1, TrackingWheel *vertical2, TrackingWheel *horizontal1,
+lemlib::OdomSensors::OdomSensors(TrackingWheel *vertical1,
+                                 TrackingWheel *vertical2,
+                                 TrackingWheel *horizontal1,
                                  TrackingWheel *horizontal2, pros::Imu *imu)
-    : vertical1(vertical1), vertical2(vertical2), horizontal1(horizontal1), horizontal2(horizontal2), imu(imu) {}
+    : vertical1(vertical1), vertical2(vertical2), horizontal1(horizontal1),
+      horizontal2(horizontal2), imu(imu) {}
 
 /**
- * @brief The constants are stored in a struct so that they can be easily passed to the chassis class
- * Set a constant to 0 and it will be ignored
+ * @brief The constants are stored in a struct so that they can be easily passed
+ * to the chassis class Set a constant to 0 and it will be ignored
  *
  * @param leftMotors pointer to the left motors
  * @param rightMotors pointer to the right motors
  * @param trackWidth the track width of the robot
  * @param wheelDiameter the diameter of the wheel used on the drivetrain
  * @param rpm the rpm of the wheels
- * @param chasePower higher values make the robot move faster but causes more overshoot on turns
+ * @param chasePower higher values make the robot move faster but causes more
+ * overshoot on turns
  */
-lemlib::Drivetrain::Drivetrain(pros::MotorGroup *leftMotors, pros::MotorGroup *rightMotors, float trackWidth,
+lemlib::Drivetrain::Drivetrain(pros::MotorGroup *leftMotors,
+                               pros::MotorGroup *rightMotors, float trackWidth,
                                float wheelDiameter, float rpm, float chasePower)
-    : leftMotors(leftMotors), rightMotors(rightMotors), trackWidth(trackWidth), wheelDiameter(wheelDiameter), rpm(rpm),
-      chasePower(chasePower) {}
+    : leftMotors(leftMotors), rightMotors(rightMotors), trackWidth(trackWidth),
+      wheelDiameter(wheelDiameter), rpm(rpm), chasePower(chasePower) {}
 
 /**
  * @brief Construct a new Chassis
@@ -59,16 +65,25 @@ lemlib::Drivetrain::Drivetrain(pros::MotorGroup *leftMotors, pros::MotorGroup *r
  * @param sensors sensors to be used for odometry
  * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
  */
-lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings lateralSettings, ControllerSettings angularSettings,
+lemlib::Chassis::Chassis(Drivetrain drivetrain,
+                         ControllerSettings lateralSettings,
+                         ControllerSettings angularSettings,
                          OdomSensors sensors, DriveCurveFunction_t driveCurve)
-    : drivetrain(drivetrain), lateralSettings(lateralSettings), angularSettings(angularSettings), sensors(sensors),
+    : drivetrain(drivetrain), lateralSettings(lateralSettings),
+      angularSettings(angularSettings), sensors(sensors),
       driveCurve(driveCurve),
-      lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD, lateralSettings.windupRange, true),
-      angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
-      lateralLargeExit(lateralSettings.largeError, lateralSettings.largeErrorTimeout),
-      lateralSmallExit(lateralSettings.smallError, lateralSettings.smallErrorTimeout),
-      angularLargeExit(angularSettings.largeError, angularSettings.largeErrorTimeout),
-      angularSmallExit(angularSettings.smallError, angularSettings.smallErrorTimeout) {}
+      lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD,
+                 lateralSettings.windupRange, true),
+      angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD,
+                 angularSettings.windupRange, true),
+      lateralLargeExit(lateralSettings.largeError,
+                       lateralSettings.largeErrorTimeout),
+      lateralSmallExit(lateralSettings.smallError,
+                       lateralSettings.smallErrorTimeout),
+      angularLargeExit(angularSettings.largeError,
+                       angularSettings.largeErrorTimeout),
+      angularSmallExit(angularSettings.smallError,
+                       angularSettings.smallErrorTimeout) {}
 
 /**
  * @brief Calibrate the chassis sensors
@@ -76,36 +91,40 @@ lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings lateralSettin
  * @param calibrateIMU whether the IMU should be calibrated. true by default
  */
 void lemlib::Chassis::calibrate(bool calibrateIMU) {
-    // calibrate the IMU if it exists and the user doesn't specify otherwise
-    if (sensors.imu != nullptr && calibrateIMU) {
-        int attempt = 1;
-        // calibrate inertial, and if calibration fails, then repeat 5 times or until successful
-        while (sensors.imu->reset(true) != 1 && (errno == PROS_ERR || errno == ENODEV || errno == ENXIO) &&
-               attempt < 5) {
-            pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, "---");
-            pros::delay(10);
-            attempt++;
-        }
-        if (attempt == 5)
-            sensors.imu = nullptr;
+  // calibrate the IMU if it exists and the user doesn't specify otherwise
+  if (sensors.imu != nullptr && calibrateIMU) {
+    int attempt = 1;
+    // calibrate inertial, and if calibration fails, then repeat 5 times or
+    // until successful
+    while (sensors.imu->reset(true) != 1 &&
+           (errno == PROS_ERR || errno == ENODEV || errno == ENXIO) &&
+           attempt < 5) {
+      pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, "---");
+      pros::delay(10);
+      attempt++;
     }
-    // initialize odom
-    if (sensors.vertical1 == nullptr)
-        sensors.vertical1 = new lemlib::TrackingWheel(drivetrain.leftMotors, drivetrain.wheelDiameter,
-                                                      -(drivetrain.trackWidth / 2), drivetrain.rpm);
-    if (sensors.vertical2 == nullptr)
-        sensors.vertical2 = new lemlib::TrackingWheel(drivetrain.rightMotors, drivetrain.wheelDiameter,
-                                                      drivetrain.trackWidth / 2, drivetrain.rpm);
-    sensors.vertical1->reset();
-    sensors.vertical2->reset();
-    if (sensors.horizontal1 != nullptr)
-        sensors.horizontal1->reset();
-    if (sensors.horizontal2 != nullptr)
-        sensors.horizontal2->reset();
-    lemlib::setSensors(sensors, drivetrain);
-    lemlib::init();
-    // rumble to controller to indicate success
-    pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, ".");
+    if (attempt == 5)
+      sensors.imu = nullptr;
+  }
+  // initialize odom
+  if (sensors.vertical1 == nullptr)
+    sensors.vertical1 = new lemlib::TrackingWheel(
+        drivetrain.leftMotors, drivetrain.wheelDiameter,
+        -(drivetrain.trackWidth / 2), drivetrain.rpm);
+  if (sensors.vertical2 == nullptr)
+    sensors.vertical2 = new lemlib::TrackingWheel(
+        drivetrain.rightMotors, drivetrain.wheelDiameter,
+        drivetrain.trackWidth / 2, drivetrain.rpm);
+  sensors.vertical1->reset();
+  sensors.vertical2->reset();
+  if (sensors.horizontal1 != nullptr)
+    sensors.horizontal1->reset();
+  if (sensors.horizontal2 != nullptr)
+    sensors.horizontal2->reset();
+  lemlib::setSensors(sensors, drivetrain);
+  lemlib::init();
+  // rumble to controller to indicate success
+  pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, ".");
 }
 
 /**
@@ -117,44 +136,49 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
  * @param radians true if theta is in radians, false if not. False by default
  */
 void lemlib::Chassis::setPose(float x, float y, float theta, bool radians) {
-    lemlib::setPose(lemlib::Pose(x, y, theta), radians);
+  lemlib::setPose(lemlib::Pose(x, y, theta), radians);
 }
 
 /**
  * @brief Set the pose of the chassis
  *
  * @param Pose the new pose
- * @param radians whether pose theta is in radians (true) or not (false). false by default
+ * @param radians whether pose theta is in radians (true) or not (false). false
+ * by default
  */
-void lemlib::Chassis::setPose(Pose pose, bool radians) { lemlib::setPose(pose, radians); }
+void lemlib::Chassis::setPose(Pose pose, bool radians) {
+  lemlib::setPose(pose, radians);
+}
 
 /**
  * @brief Get the pose of the chassis
  *
- * @param radians whether theta should be in radians (true) or degrees (false). false by default
+ * @param radians whether theta should be in radians (true) or degrees (false).
+ * false by default
  * @return Pose
  */
 lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
-    Pose pose = lemlib::getPose(true);
-    if (standardPos)
-        pose.theta = M_PI_2 - pose.theta;
-    if (!radians)
-        pose.theta = radToDeg(pose.theta);
-    return pose;
+  Pose pose = lemlib::getPose(true);
+  if (standardPos)
+    pose.theta = M_PI_2 - pose.theta;
+  if (!radians)
+    pose.theta = radToDeg(pose.theta);
+  return pose;
 }
 
 /**
  * @brief Wait until the robot has traveled a certain distance along the path
  *
- * @note Units are in inches if current motion is moveTo or follow, degrees if using turnTo
+ * @note Units are in inches if current motion is moveTo or follow, degrees if
+ * using turnTo
  *
  * @param dist the distance the robot needs to travel before returning
  */
 void lemlib::Chassis::waitUntil(float dist) {
-    // do while to give the thread time to start
-    do
-        pros::delay(10);
-    while (distTravelled <= dist && distTravelled != -1);
+  // do while to give the thread time to start
+  do
+    pros::delay(10);
+  while (distTravelled <= dist && distTravelled != -1);
 }
 
 /**
@@ -162,43 +186,43 @@ void lemlib::Chassis::waitUntil(float dist) {
  *
  */
 void lemlib::Chassis::waitUntilDone() {
-    do
-        pros::delay(10);
-    while (distTravelled != -1);
+  do
+    pros::delay(10);
+  while (distTravelled != -1);
 }
 
 void lemlib::Chassis::requestMotionStart() {
-    if (this->isInMotion())
-        this->motionQueued = true; // indicate a motion is queued
-    else
-        this->motionRunning = true; // indicate a motion is running
+  if (this->isInMotion())
+    this->motionQueued = true; // indicate a motion is queued
+  else
+    this->motionRunning = true; // indicate a motion is running
 
-    // wait until this motion is at front of "queue"
-    this->mutex.take(TIMEOUT_MAX);
+  // wait until this motion is at front of "queue"
+  this->mutex.take(TIMEOUT_MAX);
 
-    // this->motionRunning should be true
-    // and this->motionQueued should be false
-    // indicating this motion is running
+  // this->motionRunning should be true
+  // and this->motionQueued should be false
+  // indicating this motion is running
 }
 
 void lemlib::Chassis::endMotion() {
-    // move the "queue" forward 1
-    this->motionRunning = this->motionQueued;
-    this->motionQueued = false;
+  // move the "queue" forward 1
+  this->motionRunning = this->motionQueued;
+  this->motionQueued = false;
 
-    // permit queued motion to run
-    this->mutex.give();
+  // permit queued motion to run
+  this->mutex.give();
 }
 
 void lemlib::Chassis::cancelMotion() {
-    this->motionRunning = false;
-    pros::delay(10); // give time for motion to stop
+  this->motionRunning = false;
+  pros::delay(10); // give time for motion to stop
 }
 
 void lemlib::Chassis::cancelAllMotions() {
-    this->motionRunning = false;
-    this->motionQueued = false;
-    pros::delay(10); // give time for motion to stop
+  this->motionRunning = false;
+  this->motionQueued = false;
+  pros::delay(10); // give time for motion to stop
 }
 
 bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
@@ -211,73 +235,79 @@ bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
  * @param x x location
  * @param y y location
  * @param timeout longest time the robot can spend moving
- * @param forwards whether the robot should turn to face the point with the front of the robot. true by default
+ * @param forwards whether the robot should turn to face the point with the
+ * front of the robot. true by default
  * @param maxSpeed the maximum speed the robot can turn at. Default is 127
- * @param async whether the function should be run asynchronously. true by default
+ * @param async whether the function should be run asynchronously. true by
+ * default
  */
-void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning)
-        return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { turnTo(x, y, timeout, forwards, maxSpeed, false); });
-        this->endMotion();
-        pros::delay(10); // delay to give the task time to start
-        return;
-    }
-    float targetTheta;
-    float deltaX, deltaY, deltaTheta;
-    float motorPower;
-    float startTheta = getPose().theta;
-    std::uint8_t compState = pros::competition::get_status();
-    distTravelled = 0;
-    Timer timer(timeout);
-    angularLargeExit.reset();
-    angularSmallExit.reset();
-    angularPID.reset();
-
-    // main loop
-    while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
-        // update variables
-        Pose pose = getPose();
-        pose.theta = (forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
-
-        // update completion vars
-        distTravelled = fabs(angleError(pose.theta, startTheta));
-
-        deltaX = x - pose.x;
-        deltaY = y - pose.y;
-        targetTheta = fmod(radToDeg(M_PI_2 - atan2(deltaY, deltaX)), 360);
-
-        // calculate deltaTheta
-        deltaTheta = angleError(targetTheta, pose.theta, false);
-
-        // calculate the speed
-        motorPower = angularPID.update(deltaTheta);
-        angularLargeExit.update(deltaTheta);
-        angularSmallExit.update(deltaTheta);
-
-        // cap the speed
-        if (motorPower > maxSpeed)
-            motorPower = maxSpeed;
-        else if (motorPower < -maxSpeed)
-            motorPower = -maxSpeed;
-
-        // move the drivetrain
-        drivetrain.leftMotors->move(motorPower);
-        drivetrain.rightMotors->move(-motorPower);
-
-        pros::delay(10);
-    }
-
-    // stop the drivetrain
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTravelled = -1;
+void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards,
+                             float maxSpeed, bool async) {
+  this->requestMotionStart();
+  // were all motions cancelled?
+  if (!this->motionRunning)
+    return;
+  // if the function is async, run it in a new task
+  if (async) {
+    pros::Task task(
+        [&]() { turnTo(x, y, timeout, forwards, maxSpeed, false); });
     this->endMotion();
+    pros::delay(10); // delay to give the task time to start
+    return;
+  }
+  float targetTheta;
+  float deltaX, deltaY, deltaTheta;
+  float motorPower;
+  float startTheta = getPose().theta;
+  std::uint8_t compState = pros::competition::get_status();
+  distTravelled = 0;
+  Timer timer(timeout);
+  angularLargeExit.reset();
+  angularSmallExit.reset();
+  angularPID.reset();
+
+  // main loop
+  while (!timer.isDone() && !angularLargeExit.getExit() &&
+         !angularSmallExit.getExit() && this->motionRunning) {
+    // update variables
+    Pose pose = getPose();
+    pose.theta =
+        (forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
+
+    // update completion vars
+    distTravelled = fabs(angleError(pose.theta, startTheta));
+
+    deltaX = x - pose.x;
+    deltaY = y - pose.y;
+    targetTheta = fmod(radToDeg(M_PI_2 - atan2(deltaY, deltaX)), 360);
+
+    // calculate deltaTheta
+    deltaTheta = angleError(targetTheta, pose.theta, false);
+
+    // calculate the speed
+    motorPower = angularPID.update(deltaTheta);
+    angularLargeExit.update(deltaTheta);
+    angularSmallExit.update(deltaTheta);
+
+    // cap the speed
+    if (motorPower > maxSpeed)
+      motorPower = maxSpeed;
+    else if (motorPower < -maxSpeed)
+      motorPower = -maxSpeed;
+
+    // move the drivetrain
+    drivetrain.leftMotors->move(motorPower);
+    drivetrain.rightMotors->move(-motorPower);
+
+    pros::delay(10);
+  }
+
+  // stop the drivetrain
+  drivetrain.leftMotors->move(0);
+  drivetrain.rightMotors->move(0);
+  // set distTraveled to -1 to indicate that the function has finished
+  distTravelled = -1;
+  this->endMotion();
 }
 
 /**
@@ -291,224 +321,238 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
  * @param timeout longest time the robot can spend moving
  *
  * @param maxSpeed the maximum speed the robot can move at. 127 at default
- * @param async whether the function should be run asynchronously. true by default
+ * @param async whether the function should be run asynchronously. true by
+ * default
  */
-void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params, bool async) {
-    // take the mutex
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning)
-        return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { moveToPose(x, y, theta, timeout, params, false); });
-        this->endMotion();
-        pros::delay(10); // delay to give the task time to start
-        return;
-    }
+void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout,
+                                 MoveToPoseFlags params, bool async) {
+  // take the mutex
+  this->requestMotionStart();
+  // were all motions cancelled?
+  if (!this->motionRunning)
+    return;
+  // if the function is async, run it in a new task
+  if (async) {
+    pros::Task task([&]() { moveToPose(x, y, theta, timeout, params, false); });
+    this->endMotion();
+    pros::delay(10); // delay to give the task time to start
+    return;
+  }
 
-    // reset PIDs and exit conditions
-    lateralPID.reset();
-    lateralLargeExit.reset();
-    lateralSmallExit.reset();
-    angularPID.reset();
-    angularLargeExit.reset();
-    angularSmallExit.reset();
+  // reset PIDs and exit conditions
+  lateralPID.reset();
+  lateralLargeExit.reset();
+  lateralSmallExit.reset();
+  angularPID.reset();
+  angularLargeExit.reset();
+  angularSmallExit.reset();
 
-    const Pose pose = getPose(true, true);
-    // Recalculate target based on user input
-    switch (getMovementType(targetPose)) {
-    case RelativeWithoutAngle:
-        Pose target = (pose.x + targetPose.dist * std::cos(pose.theta), pose.y + targetPose.dist * std::sin(pose.theta),
-                       pose.theta);
-        break;
-    case RelativeWithAngle:
-        Pose target = (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
-                       pose.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
-        break;
-    case ClassicMovement:
-        // calculate target pose in standard form
-        Pose target(x, y, M_PI_2 - degToRad(theta));
-        break;
+  const Pose pose = getPose(true, true);
+  // Recalculate target based on user input
+  switch (getMovementType(targetPose)) {
+  case RelativeWithoutAngle:
+    Pose target = (pose.x + targetPose.dist * std::cos(pose.theta),
+                   pose.y + targetPose.dist * std::sin(pose.theta), pose.theta);
+    break;
+  case RelativeWithAngle:
+    Pose target =
+        (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
+         pose.y + targetPose.dist * std::sin(degToRad(targetPose.theta)),
+         targetPose.theta);
+    break;
+  case ClassicMovement:
+    // calculate target pose in standard form
+    Pose target(x, y, M_PI_2 - degToRad(theta));
+    break;
 
-    default:
-        // Handle unknown movement type
-        // Log error maybe
-        break;
-    }
+  default:
+    // Handle unknown movement type
+    // Log error maybe
+    break;
+  }
 
   private:
-    // Enum to represent different movement types
-    enum MovementType {
-        RelativeWithoutAngle,
-        RelativeWithAngle,
-        ClassicMovement
-        // Add more movement types as needed
-    };
+  // Enum to represent different movement types
+  enum MovementType {
+    RelativeWithoutAngle,
+    RelativeWithAngle,
+    ClassicMovement
+    // Add more movement types as needed
+  };
 
-    // Function to determine the movement type based on user input
-    MovementType getMovementType(const MovementParams &params) {
-        if (!isnan(params.distance)) {
-            return RelativeWithoutAngle;
-        } else if (!isnan(params.distance) && !isnan(params.angle)) {
-            return RelativeWithAngle;
-        } else if (!isnan(params.x) || !isnan(params.y) || !isnan(params.angle)) {
-            return ClassicMovement;
-        } else {
-            // Handle unknown movement type
-            // Maybe log error
-            return ClassicMovement; // Default to classic movement for unknown
-                                    // input
-        }
+  // Function to determine the movement type based on user input
+  MovementType getMovementType(const MovementParams &params) {
+    if (!isnan(params.distance)) {
+      return RelativeWithoutAngle;
+    } else if (!isnan(params.distance) && !isnan(params.angle)) {
+      return RelativeWithAngle;
+    } else if (!isnan(params.x) || !isnan(params.y) || !isnan(params.angle)) {
+      return ClassicMovement;
+    } else {
+      // Handle unknown movement type
+      // Maybe log error
+      return ClassicMovement; // Default to classic movement for unknown
+                              // input
     }
-    ...
+  }
+  ...
 
-        // calculate target pose in standard form
-        Pose target(x, y, M_PI_2 - degToRad(theta));
-    if (!params.forwards)
-        target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
+      // calculate target pose in standard form
+      Pose target(x, y, M_PI_2 - degToRad(theta));
+  if (!params.forwards)
+    target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 
-    // use global chasePower is chasePower is 0
-    if (params.chasePower == 0)
-        params.chasePower = drivetrain.chasePower;
+  // use global chasePower is chasePower is 0
+  if (params.chasePower == 0)
+    params.chasePower = drivetrain.chasePower;
 
-    // initialize vars used between iterations
-    Pose lastPose = getPose();
-    distTravelled = 0;
-    Timer timer(timeout);
-    bool close = false;
-    bool lateralSettled = false;
-    bool prevSameSide = false;
-    float prevLateralOut = 0; // previous lateral power
-    float prevAngularOut = 0; // previous angular power
-    const int compState = pros::competition::get_status();
+  // initialize vars used between iterations
+  Pose lastPose = getPose();
+  distTravelled = 0;
+  Timer timer(timeout);
+  bool close = false;
+  bool lateralSettled = false;
+  bool prevSameSide = false;
+  float prevLateralOut = 0; // previous lateral power
+  float prevAngularOut = 0; // previous angular power
+  const int compState = pros::competition::get_status();
 
-    // main loop
-    while (!timer.isDone() &&
-           ((!lateralSettled || (!angularLargeExit.getExit() && !angularSmallExit.getExit())) || !close) &&
-           this->motionRunning) {
-        // update position
-        const Pose pose = getPose(true, true);
+  // main loop
+  while (!timer.isDone() &&
+         ((!lateralSettled ||
+           (!angularLargeExit.getExit() && !angularSmallExit.getExit())) ||
+          !close) &&
+         this->motionRunning) {
+    // update position
+    const Pose pose = getPose(true, true);
 
-        // update distance travelled
-        distTravelled += pose.distance(lastPose);
-        lastPose = pose;
+    // update distance travelled
+    distTravelled += pose.distance(lastPose);
+    lastPose = pose;
 
-        // calculate distance to the target point
-        const float distTarget = pose.distance(target);
+    // calculate distance to the target point
+    const float distTarget = pose.distance(target);
 
-        // check if the robot is close enough to the target to start settling
-        if (distTarget < 7.5 && close == false) {
-            close = true;
-            params.maxSpeed = fmax(fabs(prevLateralOut), 60);
-        }
-
-        // check if the lateral controller has settled
-        if (lateralLargeExit.getExit() && lateralSmallExit.getExit())
-            lateralSettled = true;
-
-        // calculate the carrot point
-        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget;
-        if (close)
-            carrot = target; // settling behavior
-
-        // calculate if the robot is on the same side as the carrot point
-        const bool robotSide =
-            (pose.y - target.y) * -sin(target.theta) <= (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
-        const bool carrotSide = (carrot.y - target.y) * -sin(target.theta) <=
-                                (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
-        const bool sameSide = robotSide == carrotSide;
-        // exit if close
-        if (!sameSide && prevSameSide && close && params.minSpeed != 0)
-            break;
-        prevSameSide = sameSide;
-
-        // calculate error
-        const float adjustedRobotTheta = params.forwards ? pose.theta : pose.theta + M_PI;
-        const float angularError =
-            close ? angleError(adjustedRobotTheta, target.theta) : angleError(adjustedRobotTheta, pose.angle(carrot));
-        float lateralError = pose.distance(carrot);
-        // only use cos when settling
-        // otherwise just multiply by the sign of cos
-        // maxSlipSpeed takes care of lateralOut
-        if (close)
-            lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
-        else
-            lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
-
-        // update exit conditions
-        lateralSmallExit.update(lateralError);
-        lateralLargeExit.update(lateralError);
-        angularSmallExit.update(radToDeg(angularError));
-        angularLargeExit.update(radToDeg(angularError));
-
-        // get output from PIDs
-        float lateralOut = lateralPID.update(lateralError);
-        float angularOut = angularPID.update(radToDeg(angularError));
-
-        // apply restrictions on angular speed
-        angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
-        angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
-
-        // apply restrictions on lateral speed
-        lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
-
-        // constrain lateral output by max accel
-        // but not for decelerating, since that would interfere with settling
-        if (params.forwards && lateralOut > prevLateralOut)
-            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-        if (!params.forwards && lateralOut < prevLateralOut)
-            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-
-        // constrain lateral output by the max speed it can travel at without
-        // slipping
-        const float radius = 1 / fabs(getCurvature(pose, carrot));
-        const float maxSlipSpeed(sqrt(params.chasePower * radius * 9.8));
-        lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
-        // prioritize angular movement over lateral movement
-        const float overturn = fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
-        if (overturn > 0)
-            lateralOut -= lateralOut > 0 ? overturn : -overturn;
-
-        // prevent moving in the wrong direction
-        if (params.forwards && !close)
-            lateralOut = std::fmax(lateralOut, 0);
-        else if (!params.forwards && !close)
-            lateralOut = std::fmin(lateralOut, 0);
-
-        // constrain lateral output by the minimum speed
-        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
-            lateralOut = fabs(params.minSpeed);
-        if (!params.forwards && -lateralOut < fabs(params.minSpeed) && lateralOut < 0)
-            lateralOut = -fabs(params.minSpeed);
-
-        // update previous output
-        prevAngularOut = angularOut;
-        prevLateralOut = lateralOut;
-
-        // ratio the speeds to respect the max speed
-        float leftPower = lateralOut + angularOut;
-        float rightPower = lateralOut - angularOut;
-        const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
-        if (ratio > 1) {
-            leftPower /= ratio;
-            rightPower /= ratio;
-        }
-
-        // move the drivetrain
-        drivetrain.leftMotors->move(leftPower);
-        drivetrain.rightMotors->move(rightPower);
-
-        // delay to save resources
-        pros::delay(10);
+    // check if the robot is close enough to the target to start settling
+    if (distTarget < 7.5 && close == false) {
+      close = true;
+      params.maxSpeed = fmax(fabs(prevLateralOut), 60);
     }
 
-    // stop the drivetrain
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTravelled = -1;
-    this->endMotion();
+    // check if the lateral controller has settled
+    if (lateralLargeExit.getExit() && lateralSmallExit.getExit())
+      lateralSettled = true;
+
+    // calculate the carrot point
+    Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) *
+                               params.lead * distTarget;
+    if (close)
+      carrot = target; // settling behavior
+
+    // calculate if the robot is on the same side as the carrot point
+    const bool robotSide =
+        (pose.y - target.y) * -sin(target.theta) <=
+        (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
+    const bool carrotSide =
+        (carrot.y - target.y) * -sin(target.theta) <=
+        (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
+    const bool sameSide = robotSide == carrotSide;
+    // exit if close
+    if (!sameSide && prevSameSide && close && params.minSpeed != 0)
+      break;
+    prevSameSide = sameSide;
+
+    // calculate error
+    const float adjustedRobotTheta =
+        params.forwards ? pose.theta : pose.theta + M_PI;
+    const float angularError =
+        close ? angleError(adjustedRobotTheta, target.theta)
+              : angleError(adjustedRobotTheta, pose.angle(carrot));
+    float lateralError = pose.distance(carrot);
+    // only use cos when settling
+    // otherwise just multiply by the sign of cos
+    // maxSlipSpeed takes care of lateralOut
+    if (close)
+      lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
+    else
+      lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
+
+    // update exit conditions
+    lateralSmallExit.update(lateralError);
+    lateralLargeExit.update(lateralError);
+    angularSmallExit.update(radToDeg(angularError));
+    angularLargeExit.update(radToDeg(angularError));
+
+    // get output from PIDs
+    float lateralOut = lateralPID.update(lateralError);
+    float angularOut = angularPID.update(radToDeg(angularError));
+
+    // apply restrictions on angular speed
+    angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
+    angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
+
+    // apply restrictions on lateral speed
+    lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
+
+    // constrain lateral output by max accel
+    // but not for decelerating, since that would interfere with settling
+    if (params.forwards && lateralOut > prevLateralOut)
+      lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+    if (!params.forwards && lateralOut < prevLateralOut)
+      lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+
+    // constrain lateral output by the max speed it can travel at without
+    // slipping
+    const float radius = 1 / fabs(getCurvature(pose, carrot));
+    const float maxSlipSpeed(sqrt(params.chasePower * radius * 9.8));
+    lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
+    // prioritize angular movement over lateral movement
+    const float overturn =
+        fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
+    if (overturn > 0)
+      lateralOut -= lateralOut > 0 ? overturn : -overturn;
+
+    // prevent moving in the wrong direction
+    if (params.forwards && !close)
+      lateralOut = std::fmax(lateralOut, 0);
+    else if (!params.forwards && !close)
+      lateralOut = std::fmin(lateralOut, 0);
+
+    // constrain lateral output by the minimum speed
+    if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
+      lateralOut = fabs(params.minSpeed);
+    if (!params.forwards && -lateralOut < fabs(params.minSpeed) &&
+        lateralOut < 0)
+      lateralOut = -fabs(params.minSpeed);
+
+    // update previous output
+    prevAngularOut = angularOut;
+    prevLateralOut = lateralOut;
+
+    // ratio the speeds to respect the max speed
+    float leftPower = lateralOut + angularOut;
+    float rightPower = lateralOut - angularOut;
+    const float ratio =
+        std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
+    if (ratio > 1) {
+      leftPower /= ratio;
+      rightPower /= ratio;
+    }
+
+    // move the drivetrain
+    drivetrain.leftMotors->move(leftPower);
+    drivetrain.rightMotors->move(rightPower);
+
+    // delay to save resources
+    pros::delay(10);
+  }
+
+  // stop the drivetrain
+  drivetrain.leftMotors->move(0);
+  drivetrain.rightMotors->move(0);
+  // set distTraveled to -1 to indicate that the function has finished
+  distTravelled = -1;
+  this->endMotion();
 }
 
 /**
@@ -518,117 +562,125 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
  * @param y y location
  * @param timeout longest time the robot can spend moving
  * @param maxSpeed the maximum speed the robot can move at. 127 by default
- * @param async whether the function should be run asynchronously. true by default
+ * @param async whether the function should be run asynchronously. true by
+ * default
  */
-void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning)
-        return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
-        this->endMotion();
-        pros::delay(10); // delay to give the task time to start
-        return;
-    }
-
-    // reset PIDs and exit conditions
-    lateralPID.reset();
-    lateralLargeExit.reset();
-    lateralSmallExit.reset();
-    angularPID.reset();
-
-    // calculate target pose in standard form
-    const Pose target(x, y);
-
-    // initialize vars used between iterations
-    Pose lastPose = getPose();
-    distTravelled = 0;
-    Timer timer(timeout);
-    bool close = false;
-    float prevLateralOut = 0; // previous lateral power
-    float prevAngularOut = 0; // previous angular power
-    const int compState = pros::competition::get_status();
-
-    // main loop
-    while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close) &&
-           this->motionRunning) {
-        // update position
-        const Pose pose = getPose(true, true);
-
-        // update distance travelled
-        distTravelled += pose.distance(lastPose);
-        lastPose = pose;
-
-        // calculate distance to the target point
-        const float distTarget = pose.distance(target);
-
-        // check if the robot is close enough to the target to start settling
-        if (distTarget < 7.5 && close == false) {
-            close = true;
-            maxSpeed = fmax(fabs(prevLateralOut), 60);
-        }
-
-        // calculate error
-        const float adjustedRobotTheta = forwards ? pose.theta : pose.theta + M_PI;
-        const float angularError = angleError(adjustedRobotTheta, pose.angle(target));
-        float lateralError = pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
-
-        // update exit conditions
-        lateralSmallExit.update(lateralError);
-        lateralLargeExit.update(lateralError);
-
-        // get output from PIDs
-        float lateralOut = lateralPID.update(lateralError);
-        float angularOut = angularPID.update(radToDeg(angularError));
-        if (close)
-            angularOut = 0;
-
-        // apply restrictions on angular speed
-        angularOut = std::clamp(angularOut, -maxSpeed, maxSpeed);
-        angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
-
-        // apply restrictions on lateral speed
-        lateralOut = std::clamp(lateralOut, -maxSpeed, maxSpeed);
-        // constrain lateral output by max accel
-        // but not for decelerating, since that would interfere with settling
-        if (forwards && lateralOut > prevLateralOut)
-            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-        if (!forwards && lateralOut < prevLateralOut)
-            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-
-        // prevent moving in the wrong direction
-        if (forwards && !close)
-            lateralOut = std::fmax(lateralOut, 0);
-        else if (!forwards && !close)
-            lateralOut = std::fmin(lateralOut, 0);
-
-        // update previous output
-        prevAngularOut = angularOut;
-        prevLateralOut = lateralOut;
-
-        // ratio the speeds to respect the max speed
-        float leftPower = lateralOut + angularOut;
-        float rightPower = lateralOut - angularOut;
-        const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / maxSpeed;
-        if (ratio > 1) {
-            leftPower /= ratio;
-            rightPower /= ratio;
-        }
-
-        // move the drivetrain
-        drivetrain.leftMotors->move(leftPower);
-        drivetrain.rightMotors->move(rightPower);
-
-        // delay to save resources
-        pros::delay(10);
-    }
-
-    // stop the drivetrain
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTravelled = -1;
+void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards,
+                                  float maxSpeed, bool async) {
+  this->requestMotionStart();
+  // were all motions cancelled?
+  if (!this->motionRunning)
+    return;
+  // if the function is async, run it in a new task
+  if (async) {
+    pros::Task task(
+        [&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
     this->endMotion();
+    pros::delay(10); // delay to give the task time to start
+    return;
+  }
+
+  // reset PIDs and exit conditions
+  lateralPID.reset();
+  lateralLargeExit.reset();
+  lateralSmallExit.reset();
+  angularPID.reset();
+
+  // calculate target pose in standard form
+  const Pose target(x, y);
+
+  // initialize vars used between iterations
+  Pose lastPose = getPose();
+  distTravelled = 0;
+  Timer timer(timeout);
+  bool close = false;
+  float prevLateralOut = 0; // previous lateral power
+  float prevAngularOut = 0; // previous angular power
+  const int compState = pros::competition::get_status();
+
+  // main loop
+  while (!timer.isDone() &&
+         ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) ||
+          !close) &&
+         this->motionRunning) {
+    // update position
+    const Pose pose = getPose(true, true);
+
+    // update distance travelled
+    distTravelled += pose.distance(lastPose);
+    lastPose = pose;
+
+    // calculate distance to the target point
+    const float distTarget = pose.distance(target);
+
+    // check if the robot is close enough to the target to start settling
+    if (distTarget < 7.5 && close == false) {
+      close = true;
+      maxSpeed = fmax(fabs(prevLateralOut), 60);
+    }
+
+    // calculate error
+    const float adjustedRobotTheta = forwards ? pose.theta : pose.theta + M_PI;
+    const float angularError =
+        angleError(adjustedRobotTheta, pose.angle(target));
+    float lateralError =
+        pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
+
+    // update exit conditions
+    lateralSmallExit.update(lateralError);
+    lateralLargeExit.update(lateralError);
+
+    // get output from PIDs
+    float lateralOut = lateralPID.update(lateralError);
+    float angularOut = angularPID.update(radToDeg(angularError));
+    if (close)
+      angularOut = 0;
+
+    // apply restrictions on angular speed
+    angularOut = std::clamp(angularOut, -maxSpeed, maxSpeed);
+    angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
+
+    // apply restrictions on lateral speed
+    lateralOut = std::clamp(lateralOut, -maxSpeed, maxSpeed);
+    // constrain lateral output by max accel
+    // but not for decelerating, since that would interfere with settling
+    if (forwards && lateralOut > prevLateralOut)
+      lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+    if (!forwards && lateralOut < prevLateralOut)
+      lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+
+    // prevent moving in the wrong direction
+    if (forwards && !close)
+      lateralOut = std::fmax(lateralOut, 0);
+    else if (!forwards && !close)
+      lateralOut = std::fmin(lateralOut, 0);
+
+    // update previous output
+    prevAngularOut = angularOut;
+    prevLateralOut = lateralOut;
+
+    // ratio the speeds to respect the max speed
+    float leftPower = lateralOut + angularOut;
+    float rightPower = lateralOut - angularOut;
+    const float ratio =
+        std::max(std::fabs(leftPower), std::fabs(rightPower)) / maxSpeed;
+    if (ratio > 1) {
+      leftPower /= ratio;
+      rightPower /= ratio;
+    }
+
+    // move the drivetrain
+    drivetrain.leftMotors->move(leftPower);
+    drivetrain.rightMotors->move(rightPower);
+
+    // delay to save resources
+    pros::delay(10);
+  }
+
+  // stop the drivetrain
+  drivetrain.leftMotors->move(0);
+  drivetrain.rightMotors->move(0);
+  // set distTraveled to -1 to indicate that the function has finished
+  distTravelled = -1;
+  this->endMotion();
 }

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -8,6 +8,7 @@
  * @copyright Copyright (c) 2023
  *
  */
+ 
 #include "lemlib/chassis/chassis.hpp"
 #include "lemlib/chassis/odom.hpp"
 #include "lemlib/chassis/trackingWheel.hpp"

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -326,7 +326,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
 
     // figure out movement type
     MovementType mType;
-    if (!isnan(targetPose.x) && !isnan(targetPose.y) && !isnan(targetPose.theta)) { 
+    if (!isnan(targetPose.x) && !isnan(targetPose.y) && !isnan(targetPose.theta)) {
         mType = ClassicMovement;
     } else if (!isnan(targetPose.dist) && !isnan(targetPose.theta)) {
         mType = RelativeWithAngle;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -289,7 +289,23 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
     distTravelled = -1;
     this->endMotion();
 }
-
+ * @brief Figure Out The Movement Type For Boomerang Controller
+ */
+// Function to determine the movement type based on user input
+MovementType getMovementType(const MoveToPoseTarget& params_t) {
+    if (!isnan(params_t.dist)) {
+        return RelativeWithoutAngle;
+    } else if (!isnan(params_t.dist) && !isnan(params_t.theta)) {
+        return RelativeWithAngle;
+    } else if (!isnan(params_t.x) || !isnan(params_t.y) || !isnan(params_t.theta)) {
+        return ClassicMovement;
+    } else {
+        // Handle unknown movement type
+        // Maybe log error
+        return ClassicMovement; // Default to classic movement for unknown
+                                // input
+    }
+}
 /**
  * @brief Move the chassis towards the target pose
  *
@@ -349,22 +365,6 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         // calculate target pose in standard form
         target = (targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
-    }
-
-    // Function to determine the movement type based on user input
-    MovementType getMovementType(const MoveToPoseTarget& params_t) {
-        if (!isnan(params_t.dist)) {
-            return RelativeWithoutAngle;
-        } else if (!isnan(params_t.dist) && !isnan(params_t.theta)) {
-            return RelativeWithAngle;
-        } else if (!isnan(params_t.x) || !isnan(params_t.y) || !isnan(params_t.theta)) {
-            return ClassicMovement;
-        } else {
-            // Handle unknown movement type
-            // Maybe log error
-            return ClassicMovement; // Default to classic movement for unknown
-                                    // input
-        }
     }
   
     if (!params.forwards)

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -328,25 +328,26 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
 
     const Pose pose = getPose(true, true);
     // Recalculate target based on user input
+    Pose target;
     switch (getMovementType(targetPose)) {
     case RelativeWithoutAngle:
-        Pose target = (pose.x + targetPose.dist * std::cos(pose.theta), pose.y + targetPose.dist * std::sin(pose.theta),
+        target = (pose.x + targetPose.dist * std::cos(pose.theta), pose.y + targetPose.dist * std::sin(pose.theta),
                        pose.theta);
         break;
     case RelativeWithAngle:
-        Pose target = (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
+        target = (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
                        pose.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
         break;
     case ClassicMovement:
         // calculate target pose in standard form
-        Pose target(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+        target(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
 
     default:
         // Handle unknown movement type
         // Log error maybe
         // calculate target pose in standard form
-        Pose target(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+        target(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
     }
 

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -372,10 +372,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
                                     // input
         }
     }
-    ...
-
-        // calculate target pose in standard form
-        Pose target(x, y, M_PI_2 - degToRad(theta));
+  
     if (!params.forwards)
         target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -22,6 +22,7 @@
 #include <functional>
 #include <limits>
 #include <math.h>
+#include<vector>
 
 /**
  * @brief The variables are pointers so that they can be set to nullptr if they

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -297,7 +297,7 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
 MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
     // count number of values in the vector that were used
     uint16_t count = 0;
-    for (auto v : params_t)
+    for (auto v : params_t.params)
         if (!isnan(v)) count++;
     // figure out movement type
     if (count = 1) {

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -347,7 +347,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         // Handle unknown movement type
         // Log error maybe
         // calculate target pose in standard form
-        target(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+        target = (targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
     }
 

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -352,12 +352,12 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
     }
 
     // Function to determine the movement type based on user input
-    MovementType getMovementType(const MovementParams& params) {
-        if (!isnan(params.distance)) {
+    MovementType getMovementType(const MoveToPoseTarget& params_t) {
+        if (!isnan(params_t.dist)) {
             return RelativeWithoutAngle;
-        } else if (!isnan(params.distance) && !isnan(params.angle)) {
+        } else if (!isnan(params_t.dist) && !isnan(params_t.theta)) {
             return RelativeWithAngle;
-        } else if (!isnan(params.x) || !isnan(params.y) || !isnan(params.angle)) {
+        } else if (!isnan(params_t.x) || !isnan(params_t.y) || !isnan(params_t.theta)) {
             return ClassicMovement;
         } else {
             // Handle unknown movement type

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -326,12 +326,12 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
 
     // figure out movement type
     MovementType mType;
-    if (!isnan(targetPose.dist)) {
-        mType = RelativeWithoutAngle;
+    if (!isnan(targetPose.x) && !isnan(targetPose.y) && !isnan(targetPose.theta)) { 
+        mType = ClassicMovement;
     } else if (!isnan(targetPose.dist) && !isnan(targetPose.theta)) {
         mType = RelativeWithAngle;
-    } else if (!isnan(targetPose.x) && !isnan(targetPose.y) && !isnan(targetPose.theta)) {
-        mType = ClassicMovement;
+    } else if (!isnan(targetPose.dist)) {
+        mType = RelativeWithoutAngle;
     } else {
         // Handle unknown movement type
         // Maybe log error

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -290,6 +290,7 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
     distTravelled = -1;
     this->endMotion();
 }
+
 /*
  * @brief Get the movement type for boomerang so we can run calculations for the target
  */
@@ -305,7 +306,7 @@ lemlib::MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& pa
     } else if (count = 2) {
         return RelativeWithAngle;
     } else if (count = 3) {
-        return RelativeWithoutAngle; 
+        return RelativeWithoutAngle;
     } else {
         // Handle unknown movement type
         // Maybe log error
@@ -319,29 +320,31 @@ lemlib::MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& pa
  */
 lemlib::Pose lemlib::Chassis::getTarget(MovementType mType, const MoveToPoseTarget& params_t) {
     struct Target { // structure for readability
-        float x;
-        float y;
-        float theta;
-        float dist;
-    }; Target targetPose;
+            float x;
+            float y;
+            float theta;
+            float dist;
+    };
+
+    Target targetPose;
     const Pose pose_t = getPose(true, true);
     // Recalculate target based on user input
     switch (mType) {
         case RelativeWithoutAngle:
-            targetPose.dist=params_t.params[0];
+            targetPose.dist = params_t.params[0];
             return Pose(pose_t.x + targetPose.dist * std::cos(pose_t.theta),
-                          pose_t.y + targetPose.dist * std::sin(pose_t.theta), pose_t.theta);
+                        pose_t.y + targetPose.dist * std::sin(pose_t.theta), pose_t.theta);
             break;
         case RelativeWithAngle:
-            targetPose.dist=params_t.params[0];
-            targetPose.theta=params_t.params[1];
+            targetPose.dist = params_t.params[0];
+            targetPose.theta = params_t.params[1];
             return Pose(pose_t.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
-                          pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
+                        pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
             break;
         case ClassicMovement:
-            targetPose.x=params_t.params[0];
-            targetPose.y=params_t.params[1];
-            targetPose.theta=params_t.params[2];
+            targetPose.x = params_t.params[0];
+            targetPose.y = params_t.params[1];
+            targetPose.theta = params_t.params[2];
             // calculate target pose in standard form
             return Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
             break;
@@ -390,7 +393,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
     angularLargeExit.reset();
     angularSmallExit.reset();
 
-    Pose target = getTarget(getMovementType(targetPose),targetPose);
+    Pose target = getTarget(getMovementType(targetPose), targetPose);
 
     if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -1,402 +1,635 @@
 /**
- * @file include/lemlib/chassis/chassis.hpp
+ * @file src/lemlib/chassis/chassis.cpp
  * @author LemLib Team
- * @brief Chassis class declarations
+ * @brief definitions for the chassis class
  * @version 0.4.5
- * @date 2023-01-23
+ * @date 2023-01-27
  *
  * @copyright Copyright (c) 2023
  *
  */
-#include "lemlib/asset.hpp"
+#include "lemlib/chassis/chassis.hpp"
+#include "lemlib/chassis/odom.hpp"
 #include "lemlib/chassis/trackingWheel.hpp"
-#include "lemlib/exitcondition.hpp"
-#include "lemlib/pid.hpp"
-#include "lemlib/pose.hpp"
-#include "pros/imu.hpp"
+#include "lemlib/timer.hpp"
+#include "lemlib/util.hpp"
+#include "pros/misc.hpp"
 #include "pros/motors.hpp"
+#include "pros/rtos.h"
 #include "pros/rtos.hpp"
-#include <cmath>
+#include <algorithm>
 #include <functional>
 #include <limits>
+#include <math.h>
 
-namespace lemlib {
 /**
- * @brief Struct containing all the sensors used for odometry
+ * @brief The variables are pointers so that they can be set to nullptr if they
+ * are not used Otherwise the chassis class would have to have a constructor for
+ * each possible combination of sensors
+ *
+ * @param vertical1 pointer to the first vertical tracking wheel
+ * @param vertical2 pointer to the second vertical tracking wheel
+ * @param horizontal1 pointer to the first horizontal tracking wheel
+ * @param horizontal2 pointer to the second horizontal tracking wheel
+ * @param imu pointer to the IMU
+ */
+lemlib::OdomSensors::OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
+                                 TrackingWheel* horizontal2, pros::Imu* imu)
+    : vertical1(vertical1), vertical2(vertical2), horizontal1(horizontal1), horizontal2(horizontal2), imu(imu) {}
+
+/**
+ * @brief The constants are stored in a struct so that they can be easily passed
+ * to the chassis class Set a constant to 0 and it will be ignored
+ *
+ * @param leftMotors pointer to the left motors
+ * @param rightMotors pointer to the right motors
+ * @param trackWidth the track width of the robot
+ * @param wheelDiameter the diameter of the wheel used on the drivetrain
+ * @param rpm the rpm of the wheels
+ * @param chasePower higher values make the robot move faster but causes more
+ * overshoot on turns
+ */
+lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth,
+                               float wheelDiameter, float rpm, float chasePower)
+    : leftMotors(leftMotors), rightMotors(rightMotors), trackWidth(trackWidth), wheelDiameter(wheelDiameter), rpm(rpm),
+      chasePower(chasePower) {}
+
+/**
+ * @brief Construct a new Chassis
+ *
+ * @param drivetrain drivetrain to be used for the chassis
+ * @param lateralSettings settings for the lateral controller
+ * @param angularSettings settings for the angular controller
+ * @param sensors sensors to be used for odometry
+ * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
+ */
+lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings lateralSettings, ControllerSettings angularSettings,
+                         OdomSensors sensors, DriveCurveFunction_t driveCurve)
+    : drivetrain(drivetrain), lateralSettings(lateralSettings), angularSettings(angularSettings), sensors(sensors),
+      driveCurve(driveCurve),
+      lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD, lateralSettings.windupRange, true),
+      angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
+      lateralLargeExit(lateralSettings.largeError, lateralSettings.largeErrorTimeout),
+      lateralSmallExit(lateralSettings.smallError, lateralSettings.smallErrorTimeout),
+      angularLargeExit(angularSettings.largeError, angularSettings.largeErrorTimeout),
+      angularSmallExit(angularSettings.smallError, angularSettings.smallErrorTimeout) {}
+
+/**
+ * @brief Calibrate the chassis sensors
+ *
+ * @param calibrateIMU whether the IMU should be calibrated. true by default
+ */
+void lemlib::Chassis::calibrate(bool calibrateIMU) {
+    // calibrate the IMU if it exists and the user doesn't specify otherwise
+    if (sensors.imu != nullptr && calibrateIMU) {
+        int attempt = 1;
+        // calibrate inertial, and if calibration fails, then repeat 5 times or
+        // until successful
+        while (sensors.imu->reset(true) != 1 && (errno == PROS_ERR || errno == ENODEV || errno == ENXIO) &&
+               attempt < 5) {
+            pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, "---");
+            pros::delay(10);
+            attempt++;
+        }
+        if (attempt == 5)
+            sensors.imu = nullptr;
+    }
+    // initialize odom
+    if (sensors.vertical1 == nullptr)
+        sensors.vertical1 = new lemlib::TrackingWheel(drivetrain.leftMotors, drivetrain.wheelDiameter,
+                                                      -(drivetrain.trackWidth / 2), drivetrain.rpm);
+    if (sensors.vertical2 == nullptr)
+        sensors.vertical2 = new lemlib::TrackingWheel(drivetrain.rightMotors, drivetrain.wheelDiameter,
+                                                      drivetrain.trackWidth / 2, drivetrain.rpm);
+    sensors.vertical1->reset();
+    sensors.vertical2->reset();
+    if (sensors.horizontal1 != nullptr)
+        sensors.horizontal1->reset();
+    if (sensors.horizontal2 != nullptr)
+        sensors.horizontal2->reset();
+    lemlib::setSensors(sensors, drivetrain);
+    lemlib::init();
+    // rumble to controller to indicate success
+    pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, ".");
+}
+
+/**
+ * @brief Set the Pose object
+ *
+ * @param x new x value
+ * @param y new y value
+ * @param theta new theta value
+ * @param radians true if theta is in radians, false if not. False by default
+ */
+void lemlib::Chassis::setPose(float x, float y, float theta, bool radians) {
+    lemlib::setPose(lemlib::Pose(x, y, theta), radians);
+}
+
+/**
+ * @brief Set the pose of the chassis
+ *
+ * @param Pose the new pose
+ * @param radians whether pose theta is in radians (true) or not (false). false
+ * by default
+ */
+void lemlib::Chassis::setPose(Pose pose, bool radians) { lemlib::setPose(pose, radians); }
+
+/**
+ * @brief Get the pose of the chassis
+ *
+ * @param radians whether theta should be in radians (true) or degrees (false).
+ * false by default
+ * @return Pose
+ */
+lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
+    Pose pose = lemlib::getPose(true);
+    if (standardPos)
+        pose.theta = M_PI_2 - pose.theta;
+    if (!radians)
+        pose.theta = radToDeg(pose.theta);
+    return pose;
+}
+
+/**
+ * @brief Wait until the robot has traveled a certain distance along the path
+ *
+ * @note Units are in inches if current motion is moveTo or follow, degrees if
+ * using turnTo
+ *
+ * @param dist the distance the robot needs to travel before returning
+ */
+void lemlib::Chassis::waitUntil(float dist) {
+    // do while to give the thread time to start
+    do
+        pros::delay(10);
+    while (distTravelled <= dist && distTravelled != -1);
+}
+
+/**
+ * @brief Wait until the robot has completed the path
  *
  */
-struct OdomSensors {
-        /**
-         * The sensors are stored in a struct so that they can be easily passed to the
-         * chassis class The variables are pointers so that they can be set to nullptr
-         * if they are not used Otherwise the chassis class would have to have a
-         * constructor for each possible combination of sensors
-         *
-         * @param vertical1 pointer to the first vertical tracking wheel
-         * @param vertical2 pointer to the second vertical tracking wheel
-         * @param horizontal1 pointer to the first horizontal tracking wheel
-         * @param horizontal2 pointer to the second horizontal tracking wheel
-         * @param imu pointer to the IMU
-         */
-        OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
-                    TrackingWheel* horizontal2, pros::Imu* imu);
-        TrackingWheel* vertical1;
-        TrackingWheel* vertical2;
-        TrackingWheel* horizontal1;
-        TrackingWheel* horizontal2;
-        pros::Imu* imu;
-};
+void lemlib::Chassis::waitUntilDone() {
+    do
+        pros::delay(10);
+    while (distTravelled != -1);
+}
+
+void lemlib::Chassis::requestMotionStart() {
+    if (this->isInMotion())
+        this->motionQueued = true; // indicate a motion is queued
+    else
+        this->motionRunning = true; // indicate a motion is running
+
+    // wait until this motion is at front of "queue"
+    this->mutex.take(TIMEOUT_MAX);
+
+    // this->motionRunning should be true
+    // and this->motionQueued should be false
+    // indicating this motion is running
+}
+
+void lemlib::Chassis::endMotion() {
+    // move the "queue" forward 1
+    this->motionRunning = this->motionQueued;
+    this->motionQueued = false;
+
+    // permit queued motion to run
+    this->mutex.give();
+}
+
+void lemlib::Chassis::cancelMotion() {
+    this->motionRunning = false;
+    pros::delay(10); // give time for motion to stop
+}
+
+void lemlib::Chassis::cancelAllMotions() {
+    this->motionRunning = false;
+    this->motionQueued = false;
+    pros::delay(10); // give time for motion to stop
+}
+
+bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
 
 /**
- * @brief Struct containing constants for a chassis controller
+ * @brief Turn the chassis so it is facing the target point
  *
- */
-struct ControllerSettings {
-        /**
-         * The constants are stored in a struct so that they can be easily passed to
-         * the chassis class Set a constant to 0 and it will be ignored
-         *
-         * @param kP proportional constant for the chassis controller
-         * @param kI integral constant for the chassis controller
-         * @param kD derivative constant for the chassis controller
-         * @param antiWindup
-         * @param smallError the error at which the chassis controller will switch to
-         * a slower control loop
-         * @param smallErrorTimeout the time the chassis controller will wait before
-         * switching to a slower control loop
-         * @param largeError the error at which the chassis controller will switch to
-         * a faster control loop
-         * @param largeErrorTimeout the time the chassis controller will wait before
-         * switching to a faster control loop
-         * @param slew the maximum acceleration of the chassis controller
-         */
-        ControllerSettings(float kP, float kI, float kD, float windupRange, float smallError, float smallErrorTimeout,
-                           float largeError, float largeErrorTimeout, float slew)
-            : kP(kP),
-              kI(kI),
-              kD(kD),
-              windupRange(windupRange),
-              smallError(smallError),
-              smallErrorTimeout(smallErrorTimeout),
-              largeError(largeError),
-              largeErrorTimeout(largeErrorTimeout),
-              slew(slew) {}
-
-        float kP;
-        float kI;
-        float kD;
-        float windupRange;
-        float smallError;
-        float smallErrorTimeout;
-        float largeError;
-        float largeErrorTimeout;
-        float slew;
-};
-
-/**
- * @brief Struct containing constants for a drivetrain
+ * The PID logging id is "angularPID"
  *
- */
-struct Drivetrain {
-        /**
-         * The constants are stored in a struct so that they can be easily passed to
-         * the chassis class Set a constant to 0 and it will be ignored
-         *
-         * @param leftMotors pointer to the left motors
-         * @param rightMotors pointer to the right motors
-         * @param trackWidth the track width of the robot
-         * @param wheelDiameter the diameter of the wheel used on the drivetrain
-         * @param rpm the rpm of the wheels
-         * @param chasePower higher values make the robot move faster but causes more
-         * overshoot on turns
-         */
-        Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth, float wheelDiameter,
-                   float rpm, float chasePower);
-        pros::Motor_Group* leftMotors;
-        pros::Motor_Group* rightMotors;
-        float trackWidth;
-        float wheelDiameter;
-        float rpm;
-        float chasePower;
-};
-
-/**
- * @brief Targets for Chassis::moveToPose
- *
- * We use a struct to simplify customization. Chassis::moveToPose has many
- * parameters and specifying them all just to set one optional param ruins
- * readability. By passing a struct to the function, we can have named
- * parameters, overcoming the c/c++ limitation
- *
- * @param dist whether the robot should move forwards or backwards. True by
+ * @param x x location
+ * @param y y location
+ * @param timeout longest time the robot can spend moving
+ * @param forwards whether the robot should turn to face the point with the
+ * front of the robot. true by default
+ * @param maxSpeed the maximum speed the robot can turn at. Default is 127
+ * @param async whether the function should be run asynchronously. true by
  * default
- * @param x how fast the robot will move around corners. Recommended value 2-15.
- *  0 means use chasePower set in chassis class. 0 by default.
- * @param y carrot point multiplier. value between 0 and 1. Higher values result
- * in curvier movements. 0.6 by default
- * @param theta the maximum speed the robot can travel at. Value between 0-127.
- *  127 by default
  */
-struct MoveToPoseTarget {
-        float dist = std::numeric_limits<float>::quiet_NaN();
-        float x = std::numeric_limits<float>::quiet_NaN();
-        float y = std::numeric_limits<float>::quiet_NaN();
-        float theta = std::numeric_limits<float>::quiet_NaN();
-};
+void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
+    this->requestMotionStart();
+    // were all motions cancelled?
+    if (!this->motionRunning)
+        return;
+    // if the function is async, run it in a new task
+    if (async) {
+        pros::Task task([&]() { turnTo(x, y, timeout, forwards, maxSpeed, false); });
+        this->endMotion();
+        pros::delay(10); // delay to give the task time to start
+        return;
+    }
+    float targetTheta;
+    float deltaX, deltaY, deltaTheta;
+    float motorPower;
+    float startTheta = getPose().theta;
+    std::uint8_t compState = pros::competition::get_status();
+    distTravelled = 0;
+    Timer timer(timeout);
+    angularLargeExit.reset();
+    angularSmallExit.reset();
+    angularPID.reset();
 
-// Enum to represent different movement types
-enum MovementType {
-    RelativeWithoutAngle,
-    RelativeWithAngle,
-    ClassicMovement
-    // Add more movement types as needed
-};
+    // main loop
+    while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
+        // update variables
+        Pose pose = getPose();
+        pose.theta = (forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
 
+        // update completion vars
+        distTravelled = fabs(angleError(pose.theta, startTheta));
+
+        deltaX = x - pose.x;
+        deltaY = y - pose.y;
+        targetTheta = fmod(radToDeg(M_PI_2 - atan2(deltaY, deltaX)), 360);
+
+        // calculate deltaTheta
+        deltaTheta = angleError(targetTheta, pose.theta, false);
+
+        // calculate the speed
+        motorPower = angularPID.update(deltaTheta);
+        angularLargeExit.update(deltaTheta);
+        angularSmallExit.update(deltaTheta);
+
+        // cap the speed
+        if (motorPower > maxSpeed)
+            motorPower = maxSpeed;
+        else if (motorPower < -maxSpeed)
+            motorPower = -maxSpeed;
+
+        // move the drivetrain
+        drivetrain.leftMotors->move(motorPower);
+        drivetrain.rightMotors->move(-motorPower);
+
+        pros::delay(10);
+    }
+
+    // stop the drivetrain
+    drivetrain.leftMotors->move(0);
+    drivetrain.rightMotors->move(0);
+    // set distTraveled to -1 to indicate that the function has finished
+    distTravelled = -1;
+    this->endMotion();
+}
 /**
- * @brief Flags for Chassis::moveToPose
+ * @brief Move the chassis towards the target pose
  *
- * We use a struct to simplify customization. Chassis::moveToPose has many
- * parameters and specifying them all just to set one optional param ruins
- * readability. By passing a struct to the function, we can have named
- * parameters, overcoming the c/c++ limitation
+ * Uses the boomerang controller
  *
- * @param forwards whether the robot should move forwards or backwards. True by
+ * @param x x location
+ * @param y y location
+ * @param theta target heading in degrees.
+ * @param timeout longest time the robot can spend moving
+ *
+ * @param maxSpeed the maximum speed the robot can move at. 127 at default
+ * @param async whether the function should be run asynchronously. true by
  * default
- * @param chasePower how fast the robot will move around corners. Recommended
- * value 2-15. 0 means use chasePower set in chassis class. 0 by default.
- * @param lead carrot point multiplier. value between 0 and 1. Higher values
- * result in curvier movements. 0.6 by default
- * @param maxSpeed the maximum speed the robot can travel at. Value between
- * 0-127. 127 by default
- * @param minSpeed the minimum speed the robot can travel at. If set to a
- * non-zero value, the exit conditions will switch to less accurate but smoother
- * ones. Value between 0-127. 0 by default
- * @param earlyExitRange distance between the robot and target point where the
- * movement will exit. Only has an effect if minSpeed is non-zero.
  */
-struct MoveToPoseFlags {
-        bool forwards = true;
-        float chasePower = 0;
-        float lead = 0.6;
-        float maxSpeed = 127;
-        float minSpeed = 0;
-        float earlyExitRange = 0;
-};
+void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params, bool async) {
+    // take the mutex
+    this->requestMotionStart();
+    // were all motions cancelled?
+    if (!this->motionRunning)
+        return;
+    // if the function is async, run it in a new task
+    if (async) {
+        pros::Task task([&]() { moveToPose(targetPose, timeout, params, false); });
+        this->endMotion();
+        pros::delay(10); // delay to give the task time to start
+        return;
+    }
+
+    // reset PIDs and exit conditions
+    lateralPID.reset();
+    lateralLargeExit.reset();
+    lateralSmallExit.reset();
+    angularPID.reset();
+    angularLargeExit.reset();
+    angularSmallExit.reset();
+
+    // figure out movement type
+    MovementType mType;
+    if (!isnan(targetPose.dist)) {
+        mType = RelativeWithoutAngle;
+    } else if (!isnan(targetPose.dist) && !isnan(targetPose.theta)) {
+        mType = RelativeWithAngle;
+    } else if (!isnan(targetPose.x) || !isnan(targetPose.y) || !isnan(targetPose.theta)) {
+        mType = ClassicMovement;
+    } else {
+        // Handle unknown movement type
+        // Maybe log error
+        mType = ClassicMovement; // Default to classic movement for unknown
+                                 // input
+    }
+
+    const Pose pose_t = getPose(true, true);
+    // Recalculate target based on user input
+    Pose target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+    switch (mType) {
+    case RelativeWithoutAngle:
+        target = Pose(pose_t.x + targetPose.dist * std::cos(pose_t.theta),
+                      pose_t.y + targetPose.dist * std::sin(pose_t.theta), pose_t.theta);
+        break;
+    case RelativeWithAngle:
+        target = Pose(pose_t.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
+                      pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
+        break;
+    case ClassicMovement:
+        // calculate target pose in standard form
+        target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+        break;
+
+    default:
+        // Handle unknown movement type
+        // Log error maybe
+        // calculate target pose in standard form
+        target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+        break;
+    }
+
+    if (!params.forwards)
+        target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
+
+    // use global chasePower is chasePower is 0
+    if (params.chasePower == 0)
+        params.chasePower = drivetrain.chasePower;
+
+    // initialize vars used between iterations
+    Pose lastPose = getPose();
+    distTravelled = 0;
+    Timer timer(timeout);
+    bool close = false;
+    bool lateralSettled = false;
+    bool prevSameSide = false;
+    float prevLateralOut = 0; // previous lateral power
+    float prevAngularOut = 0; // previous angular power
+    const int compState = pros::competition::get_status();
+
+    // main loop
+    while (!timer.isDone() &&
+           ((!lateralSettled || (!angularLargeExit.getExit() && !angularSmallExit.getExit())) || !close) &&
+           this->motionRunning) {
+        // update position
+        const Pose pose = getPose(true, true);
+
+        // update distance travelled
+        distTravelled += pose.distance(lastPose);
+        lastPose = pose;
+
+        // calculate distance to the target point
+        const float distTarget = pose.distance(target);
+
+        // check if the robot is close enough to the target to start settling
+        if (distTarget < 7.5 && close == false) {
+            close = true;
+            params.maxSpeed = fmax(fabs(prevLateralOut), 60);
+        }
+
+        // check if the lateral controller has settled
+        if (lateralLargeExit.getExit() && lateralSmallExit.getExit())
+            lateralSettled = true;
+
+        // calculate the carrot point
+        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget;
+        if (close)
+            carrot = target; // settling behavior
+
+        // calculate if the robot is on the same side as the carrot point
+        const bool robotSide =
+            (pose.y - target.y) * -sin(target.theta) <= (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
+        const bool carrotSide = (carrot.y - target.y) * -sin(target.theta) <=
+                                (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
+        const bool sameSide = robotSide == carrotSide;
+        // exit if close
+        if (!sameSide && prevSameSide && close && params.minSpeed != 0)
+            break;
+        prevSameSide = sameSide;
+
+        // calculate error
+        const float adjustedRobotTheta = params.forwards ? pose.theta : pose.theta + M_PI;
+        const float angularError =
+            close ? angleError(adjustedRobotTheta, target.theta) : angleError(adjustedRobotTheta, pose.angle(carrot));
+        float lateralError = pose.distance(carrot);
+        // only use cos when settling
+        // otherwise just multiply by the sign of cos
+        // maxSlipSpeed takes care of lateralOut
+        if (close)
+            lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
+        else
+            lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
+
+        // update exit conditions
+        lateralSmallExit.update(lateralError);
+        lateralLargeExit.update(lateralError);
+        angularSmallExit.update(radToDeg(angularError));
+        angularLargeExit.update(radToDeg(angularError));
+
+        // get output from PIDs
+        float lateralOut = lateralPID.update(lateralError);
+        float angularOut = angularPID.update(radToDeg(angularError));
+
+        // apply restrictions on angular speed
+        angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
+        angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
+
+        // apply restrictions on lateral speed
+        lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
+
+        // constrain lateral output by max accel
+        // but not for decelerating, since that would interfere with settling
+        if (params.forwards && lateralOut > prevLateralOut)
+            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+        if (!params.forwards && lateralOut < prevLateralOut)
+            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+
+        // constrain lateral output by the max speed it can travel at without
+        // slipping
+        const float radius = 1 / fabs(getCurvature(pose, carrot));
+        const float maxSlipSpeed(sqrt(params.chasePower * radius * 9.8));
+        lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
+        // prioritize angular movement over lateral movement
+        const float overturn = fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
+        if (overturn > 0)
+            lateralOut -= lateralOut > 0 ? overturn : -overturn;
+
+        // prevent moving in the wrong direction
+        if (params.forwards && !close)
+            lateralOut = std::fmax(lateralOut, 0);
+        else if (!params.forwards && !close)
+            lateralOut = std::fmin(lateralOut, 0);
+
+        // constrain lateral output by the minimum speed
+        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
+            lateralOut = fabs(params.minSpeed);
+        if (!params.forwards && -lateralOut < fabs(params.minSpeed) && lateralOut < 0)
+            lateralOut = -fabs(params.minSpeed);
+
+        // update previous output
+        prevAngularOut = angularOut;
+        prevLateralOut = lateralOut;
+
+        // ratio the speeds to respect the max speed
+        float leftPower = lateralOut + angularOut;
+        float rightPower = lateralOut - angularOut;
+        const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
+        if (ratio > 1) {
+            leftPower /= ratio;
+            rightPower /= ratio;
+        }
+
+        // move the drivetrain
+        drivetrain.leftMotors->move(leftPower);
+        drivetrain.rightMotors->move(rightPower);
+
+        // delay to save resources
+        pros::delay(10);
+    }
+
+    // stop the drivetrain
+    drivetrain.leftMotors->move(0);
+    drivetrain.rightMotors->move(0);
+    // set distTraveled to -1 to indicate that the function has finished
+    distTravelled = -1;
+    this->endMotion();
+}
 
 /**
- * @brief Function pointer type for drive curve functions.
- * @param input The control input in the range [-127, 127].
- * @param scale The scaling factor, which can be optionally ignored.
- * @return The new value to be used.
- */
-typedef std::function<float(float, float)> DriveCurveFunction_t;
-/**
- * @brief  Default drive curve. Modifies  the input with an exponential curve.
- * If the input is 127, the function will always output 127, no matter the value
- * of scale, likewise for -127. This curve was inspired by team 5225, the
- * Pilons. A Desmos graph of this curve can be found here:
- * https://www.desmos.com/calculator/rcfjjg83zx
- * @param input value from -127 to 127
- * @param scale how steep the curve should be.
- * @return The new value to be used.
- */
-float defaultDriveCurve(float input, float scale);
-
-/**
- * @brief Chassis class
+ * @brief Move the chassis towards a target point
  *
+ * @param x x location
+ * @param y y location
+ * @param timeout longest time the robot can spend moving
+ * @param maxSpeed the maximum speed the robot can move at. 127 by default
+ * @param async whether the function should be run asynchronously. true by
+ * default
  */
-class Chassis {
-    public:
-        /**
-         * @brief Construct a new Chassis
-         *
-         * @param drivetrain drivetrain to be used for the chassis
-         * @param lateralSettings settings for the lateral controller
-         * @param angularSettings settings for the angular controller
-         * @param sensors sensors to be used for odometry
-         * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
-         */
-        Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
-                OdomSensors sensors, DriveCurveFunction_t driveCurve = &defaultDriveCurve);
-        /**
-         * @brief Calibrate the chassis sensors
-         *
-         * @param calibrateIMU whether the IMU should be calibrated. true by default
-         */
-        void calibrate(bool calibrateIMU = true);
-        /**
-         * @brief Set the pose of the chassis
-         *
-         * @param x new x value
-         * @param y new y value
-         * @param theta new theta value
-         * @param radians true if theta is in radians, false if not. False by default
-         */
-        void setPose(float x, float y, float theta, bool radians = false);
-        /**
-         * @brief Set the pose of the chassis
-         *
-         * @param pose the new pose
-         * @param radians whether pose theta is in radians (true) or not (false).
-         * false by default
-         */
-        void setPose(Pose pose, bool radians = false);
-        /**
-         * @brief Get the pose of the chassis
-         *
-         * @param radians whether theta should be in radians (true) or degrees
-         * (false). false by default
-         * @return Pose
-         */
-        Pose getPose(bool radians = false, bool standardPos = false);
-        /**
-         * @brief Wait until the robot has traveled a certain distance along the path
-         *
-         * @note Units are in inches if current motion is moveTo or follow, degrees if
-         * using turnTo
-         *
-         * @param dist the distance the robot needs to travel before returning
-         */
-        void waitUntil(float dist);
-        /**
-         * @brief Wait until the robot has completed the path
-         *
-         */
-        void waitUntilDone();
-        /**
-         * @brief Turn the chassis so it is facing the target point
-         *
-         * The PID logging id is "angularPID"
-         *
-         * @param x x location
-         * @param y y location
-         * @param timeout longest time the robot can spend moving
-         * @param forwards whether the robot should turn to face the point with the
-         * front of the robot. true by default
-         * @param maxSpeed the maximum speed the robot can turn at. Default is 127
-         * @param async whether the function should be run asynchronously. true by
-         * default
-         */
-        void turnTo(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-        /**
-         * @brief Move the chassis towards the target pose
-         *
-         * Uses the boomerang controller
-         *
-         * @param x x location
-         * @param y y location
-         * @param theta target heading in degrees.
-         * @param timeout longest time the robot can spend moving
-         * @param params struct to simulate named parameters
-         * @param async whether the function should be run asynchronously. true by
-         * default
-         */
-        void moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params = {}, bool async = true);
-        /**
-         * @brief Move the chassis towards a target point
-         *
-         * @param x x location
-         * @param y y location
-         * @param timeout longest time the robot can spend moving
-         * @param maxSpeed the maximum speed the robot can move at. 127 by default
-         * @param async whether the function should be run asynchronously. true by
-         * default
-         */
-        void moveToPoint(float x, float y, int timeout, bool forwards = true, float maxSpeed = 127, bool async = true);
-        /**
-         * @brief Move the chassis along a path
-         *
-         * @param path the path asset to follow
-         * @param lookahead the lookahead distance. Units in inches. Larger values
-         * will make the robot move faster but will follow the path less accurately
-         * @param timeout the maximum time the robot can spend moving
-         * @param forwards whether the robot should follow the path going forwards.
-         * true by default
-         * @param async whether the function should be run asynchronously. true by
-         * default
-         */
-        void follow(const asset& path, float lookahead, int timeout, bool forwards = true, bool async = true);
-        /**
-         * @brief Control the robot during the driver control period using the tank
-         * drive control scheme. In this control scheme one joystick axis controls one
-         * half of the robot, and another joystick axis controls another.
-         * @param left speed of the left side of the drivetrain. Takes an input from
-         * -127 to 127.
-         * @param right speed of the right side of the drivetrain. Takes an input from
-         * -127 to 127.
-         * @param curveGain control how steep the drive curve is. The larger the
-         * number, the steeper the curve. A value of 0 disables the curve entirely.
-         */
-        void tank(int left, int right, float curveGain = 0.0);
-        /**
-         * @brief Control the robot during the driver using the arcade drive control
-         * scheme. In this control scheme one joystick axis controls the forwards and
-         * backwards movement of the robot, while the other joystick axis controls the
-         * robot's turning
-         * @param throttle speed to move forward or backward. Takes an input from -127
-         * to 127.
-         * @param turn speed to turn. Takes an input from -127 to 127.
-         * @param curveGain the scale inputted into the drive curve function. If you
-         * are using the default drive curve, refer to the `defaultDriveCurve`
-         * documentation.
-         */
-        void arcade(int throttle, int turn, float curveGain = 0.0);
-        /**
-         * @brief Control the robot during the driver using the curvature drive
-         * control scheme. This control scheme is very similar to arcade drive, except
-         * the second joystick axis controls the radius of the curve that the
-         * drivetrain makes, rather than the speed. This means that the driver can
-         * accelerate in a turn without changing the radius of that turn. This control
-         * scheme defaults to arcade when forward is zero.
-         * @param throttle speed to move forward or backward. Takes an input from -127
-         * to 127.
-         * @param turn speed to turn. Takes an input from -127 to 127.
-         * @param curveGain the scale inputted into the drive curve function. If you
-         * are using the default drive curve, refer to the `defaultDriveCurve`
-         * documentation.
-         */
-        void curvature(int throttle, int turn, float cureGain = 0.0);
-        /**
-         * @brief Cancels the currently running motion.
-         * If there is a queued motion, then that queued motion will run.
-         */
-        void cancelMotion();
-        /**
-         * @brief Cancels all motions, even those that are queued.
-         * After this, the chassis will not be in motion.
-         */
-        void cancelAllMotions();
-        /**
-         * @return whether a motion is currently running
-         */
-        bool isInMotion() const;
-    protected:
-        /**
-         * @brief Indicates that this motion is queued and blocks current task until
-         * this motion reaches front of queue
-         */
-        void requestMotionStart();
-        /**
-         * @brief Dequeues this motion and permits queued task to run
-         */
-        void endMotion();
-    private:
-        bool motionRunning = false;
-        bool motionQueued = false;
-        pros::Mutex mutex;
-        float distTravelled = 0;
-        ControllerSettings lateralSettings;
-        ControllerSettings angularSettings;
-        Drivetrain drivetrain;
-        OdomSensors sensors;
-        DriveCurveFunction_t driveCurve;
-        PID lateralPID;
-        PID angularPID;
-        ExitCondition lateralLargeExit;
-        ExitCondition lateralSmallExit;
-        ExitCondition angularLargeExit;
-        ExitCondition angularSmallExit;
-        MovementType getMovementType(const MoveToPoseTarget& params_t);
-};
-} // namespace lemlib
+void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
+    this->requestMotionStart();
+    // were all motions cancelled?
+    if (!this->motionRunning)
+        return;
+    // if the function is async, run it in a new task
+    if (async) {
+        pros::Task task([&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
+        this->endMotion();
+        pros::delay(10); // delay to give the task time to start
+        return;
+    }
+
+    // reset PIDs and exit conditions
+    lateralPID.reset();
+    lateralLargeExit.reset();
+    lateralSmallExit.reset();
+    angularPID.reset();
+
+    // calculate target pose in standard form
+    const Pose target(x, y);
+
+    // initialize vars used between iterations
+    Pose lastPose = getPose();
+    distTravelled = 0;
+    Timer timer(timeout);
+    bool close = false;
+    float prevLateralOut = 0; // previous lateral power
+    float prevAngularOut = 0; // previous angular power
+    const int compState = pros::competition::get_status();
+
+    // main loop
+    while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close) &&
+           this->motionRunning) {
+        // update position
+        const Pose pose = getPose(true, true);
+
+        // update distance travelled
+        distTravelled += pose.distance(lastPose);
+        lastPose = pose;
+
+        // calculate distance to the target point
+        const float distTarget = pose.distance(target);
+
+        // check if the robot is close enough to the target to start settling
+        if (distTarget < 7.5 && close == false) {
+            close = true;
+            maxSpeed = fmax(fabs(prevLateralOut), 60);
+        }
+
+        // calculate error
+        const float adjustedRobotTheta = forwards ? pose.theta : pose.theta + M_PI;
+        const float angularError = angleError(adjustedRobotTheta, pose.angle(target));
+        float lateralError = pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
+
+        // update exit conditions
+        lateralSmallExit.update(lateralError);
+        lateralLargeExit.update(lateralError);
+
+        // get output from PIDs
+        float lateralOut = lateralPID.update(lateralError);
+        float angularOut = angularPID.update(radToDeg(angularError));
+        if (close)
+            angularOut = 0;
+
+        // apply restrictions on angular speed
+        angularOut = std::clamp(angularOut, -maxSpeed, maxSpeed);
+        angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
+
+        // apply restrictions on lateral speed
+        lateralOut = std::clamp(lateralOut, -maxSpeed, maxSpeed);
+        // constrain lateral output by max accel
+        // but not for decelerating, since that would interfere with settling
+        if (forwards && lateralOut > prevLateralOut)
+            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+        if (!forwards && lateralOut < prevLateralOut)
+            lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+
+        // prevent moving in the wrong direction
+        if (forwards && !close)
+            lateralOut = std::fmax(lateralOut, 0);
+        else if (!forwards && !close)
+            lateralOut = std::fmin(lateralOut, 0);
+
+        // update previous output
+        prevAngularOut = angularOut;
+        prevLateralOut = lateralOut;
+
+        // ratio the speeds to respect the max speed
+        float leftPower = lateralOut + angularOut;
+        float rightPower = lateralOut - angularOut;
+        const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / maxSpeed;
+        if (ratio > 1) {
+            leftPower /= ratio;
+            rightPower /= ratio;
+        }
+
+        // move the drivetrain
+        drivetrain.leftMotors->move(leftPower);
+        drivetrain.rightMotors->move(rightPower);
+
+        // delay to save resources
+        pros::delay(10);
+    }
+
+    // stop the drivetrain
+    drivetrain.leftMotors->move(0);
+    drivetrain.rightMotors->move(0);
+    // set distTraveled to -1 to indicate that the function has finished
+    distTravelled = -1;
+    this->endMotion();
+}

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -328,7 +328,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
 
     const Pose pose = getPose(true, true);
     // Recalculate target based on user input
-    Pose target = (targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+    Pose target = (targetPose.x, targetPose.y, targetPose.theta);
     switch (getMovementType(targetPose)) {
     case RelativeWithoutAngle:
         target = (pose.x + targetPose.dist * std::cos(pose.theta), pose.y + targetPose.dist * std::sin(pose.theta),

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -339,7 +339,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         break;
     case ClassicMovement:
         // calculate target pose in standard form
-        Pose target(x, y, M_PI_2 - degToRad(theta));
+        Pose target(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
 
     default:

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -312,7 +312,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         return;
     // if the function is async, run it in a new task
     if (async) {
-        pros::Task task([&]() { moveToPose(MoveToPoseTarget targetPose, timeout, params, false); });
+        pros::Task task([&]() { moveToPose(targetPose, timeout, params, false); });
         this->endMotion();
         pros::delay(10); // delay to give the task time to start
         return;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -351,15 +351,6 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         break;
     }
 
-    private:
-    // Enum to represent different movement types
-    enum MovementType {
-        RelativeWithoutAngle,
-        RelativeWithAngle,
-        ClassicMovement
-        // Add more movement types as needed
-    };
-
     // Function to determine the movement type based on user input
     MovementType getMovementType(const MovementParams& params) {
         if (!isnan(params.distance)) {

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -293,7 +293,7 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
 /*
  * @brief Get the movement type for boomerang so we can run calculations for the target
  */
-MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
+lemlib::MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
     MovementType mType;
     // count number of values in the vector that were used
     uint16_t count = 0;
@@ -301,18 +301,17 @@ MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) 
         if (!isnan(v)) count++;
     // figure out movement type
     if (count = 1) {
-        mType = ClassicMovement;
+        return ClassicMovement;
     } else if (count = 2) {
-        mType = RelativeWithAngle;
+        return RelativeWithAngle;
     } else if (count = 3) {
-        mType = RelativeWithoutAngle;
+        return RelativeWithoutAngle;
     } else {
         // Handle unknown movement type
         // Maybe log error
-        mType = ClassicMovement; // Default to classic movement for unknown
+        return ClassicMovement; // Default to classic movement for unknown
                                 // input
     }
-    return mType;
 }
 
 /*

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -18,6 +18,8 @@
 #include "pros/rtos.h"
 #include "pros/rtos.hpp"
 #include <algorithm>
+#include <functional>
+#include <limits>
 #include <math.h>
 
 /**

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -8,7 +8,6 @@
  * @copyright Copyright (c) 2023
  *
  */
-#pragma once
 #include "lemlib/asset.hpp"
 #include "lemlib/chassis/trackingWheel.hpp"
 #include "lemlib/exitcondition.hpp"

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -342,26 +342,26 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
   
     const Pose pose_t = getPose(true, true);
     // Recalculate target based on user input
-    Pose target(targetPose.x, targetPose.y,  M_PI_2 - degToRad(targetPose.theta));
+    Pose target = Pose(targetPose.x, targetPose.y,  M_PI_2 - degToRad(targetPose.theta));
     switch (mType) {
     case RelativeWithoutAngle:
-        target = (pose_t.x + targetPose.dist * std::cos(pose_t.theta), pose_t.y + targetPose.dist * std::sin(pose_t.theta),
+        target = Pose(pose_t.x + targetPose.dist * std::cos(pose_t.theta), pose_t.y + targetPose.dist * std::sin(pose_t.theta),
                        pose_t.theta);
         break;
     case RelativeWithAngle:
-        target = (pose_t.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
+        target = Pose(pose_t.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
                        pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
         break;
     case ClassicMovement:
         // calculate target pose in standard form
-        target = (targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+        target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
 
     default:
         // Handle unknown movement type
         // Log error maybe
         // calculate target pose in standard form
-        target = (targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+        target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
     }
   

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -35,11 +35,7 @@
  */
 lemlib::OdomSensors::OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
                                  TrackingWheel* horizontal2, pros::Imu* imu)
-    : vertical1(vertical1),
-      vertical2(vertical2),
-      horizontal1(horizontal1),
-      horizontal2(horizontal2),
-      imu(imu) {}
+    : vertical1(vertical1), vertical2(vertical2), horizontal1(horizontal1), horizontal2(horizontal2), imu(imu) {}
 
 /**
  * @brief The constants are stored in a struct so that they can be easily passed
@@ -55,11 +51,7 @@ lemlib::OdomSensors::OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertic
  */
 lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth,
                                float wheelDiameter, float rpm, float chasePower)
-    : leftMotors(leftMotors),
-      rightMotors(rightMotors),
-      trackWidth(trackWidth),
-      wheelDiameter(wheelDiameter),
-      rpm(rpm),
+    : leftMotors(leftMotors), rightMotors(rightMotors), trackWidth(trackWidth), wheelDiameter(wheelDiameter), rpm(rpm),
       chasePower(chasePower) {}
 
 /**
@@ -73,10 +65,7 @@ lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* r
  */
 lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings lateralSettings, ControllerSettings angularSettings,
                          OdomSensors sensors, DriveCurveFunction_t driveCurve)
-    : drivetrain(drivetrain),
-      lateralSettings(lateralSettings),
-      angularSettings(angularSettings),
-      sensors(sensors),
+    : drivetrain(drivetrain), lateralSettings(lateralSettings), angularSettings(angularSettings), sensors(sensors),
       driveCurve(driveCurve),
       lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD, lateralSettings.windupRange, true),
       angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
@@ -102,7 +91,8 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
             pros::delay(10);
             attempt++;
         }
-        if (attempt == 5) sensors.imu = nullptr;
+        if (attempt == 5)
+            sensors.imu = nullptr;
     }
     // initialize odom
     if (sensors.vertical1 == nullptr)
@@ -113,8 +103,10 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
                                                       drivetrain.trackWidth / 2, drivetrain.rpm);
     sensors.vertical1->reset();
     sensors.vertical2->reset();
-    if (sensors.horizontal1 != nullptr) sensors.horizontal1->reset();
-    if (sensors.horizontal2 != nullptr) sensors.horizontal2->reset();
+    if (sensors.horizontal1 != nullptr)
+        sensors.horizontal1->reset();
+    if (sensors.horizontal2 != nullptr)
+        sensors.horizontal2->reset();
     lemlib::setSensors(sensors, drivetrain);
     lemlib::init();
     // rumble to controller to indicate success
@@ -151,8 +143,10 @@ void lemlib::Chassis::setPose(Pose pose, bool radians) { lemlib::setPose(pose, r
  */
 lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
     Pose pose = lemlib::getPose(true);
-    if (standardPos) pose.theta = M_PI_2 - pose.theta;
-    if (!radians) pose.theta = radToDeg(pose.theta);
+    if (standardPos)
+        pose.theta = M_PI_2 - pose.theta;
+    if (!radians)
+        pose.theta = radToDeg(pose.theta);
     return pose;
 }
 
@@ -166,7 +160,8 @@ lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
  */
 void lemlib::Chassis::waitUntil(float dist) {
     // do while to give the thread time to start
-    do pros::delay(10);
+    do
+        pros::delay(10);
     while (distTravelled <= dist && distTravelled != -1);
 }
 
@@ -175,13 +170,16 @@ void lemlib::Chassis::waitUntil(float dist) {
  *
  */
 void lemlib::Chassis::waitUntilDone() {
-    do pros::delay(10);
+    do
+        pros::delay(10);
     while (distTravelled != -1);
 }
 
 void lemlib::Chassis::requestMotionStart() {
-    if (this->isInMotion()) this->motionQueued = true; // indicate a motion is queued
-    else this->motionRunning = true; // indicate a motion is running
+    if (this->isInMotion())
+        this->motionQueued = true; // indicate a motion is queued
+    else
+        this->motionRunning = true; // indicate a motion is running
 
     // wait until this motion is at front of "queue"
     this->mutex.take(TIMEOUT_MAX);
@@ -230,7 +228,8 @@ bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
 void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
     this->requestMotionStart();
     // were all motions cancelled?
-    if (!this->motionRunning) return;
+    if (!this->motionRunning)
+        return;
     // if the function is async, run it in a new task
     if (async) {
         pros::Task task([&]() { turnTo(x, y, timeout, forwards, maxSpeed, false); });
@@ -271,8 +270,10 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
         angularSmallExit.update(deltaTheta);
 
         // cap the speed
-        if (motorPower > maxSpeed) motorPower = maxSpeed;
-        else if (motorPower < -maxSpeed) motorPower = -maxSpeed;
+        if (motorPower > maxSpeed)
+            motorPower = maxSpeed;
+        else if (motorPower < -maxSpeed)
+            motorPower = -maxSpeed;
 
         // move the drivetrain
         drivetrain.leftMotors->move(motorPower);
@@ -307,7 +308,8 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
     // take the mutex
     this->requestMotionStart();
     // were all motions cancelled?
-    if (!this->motionRunning) return;
+    if (!this->motionRunning)
+        return;
     // if the function is async, run it in a new task
     if (async) {
         pros::Task task([&]() { moveToPose(x, y, theta, timeout, params, false); });
@@ -327,25 +329,26 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
     const Pose pose = getPose(true, true);
     // Recalculate target based on user input
     switch (getMovementType(targetPose)) {
-        case RelativeWithoutAngle:
-            Pose target = (pose.x + targetPose.dist * std::cos(pose.theta),
-                           pose.y + targetPose.dist * std::sin(pose.theta), pose.theta);
-            break;
-        case RelativeWithAngle:
-            Pose target = (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
-                           pose.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
-            break;
-        case ClassicMovement:
-            // calculate target pose in standard form
-            Pose target(x, y, M_PI_2 - degToRad(theta));
-            break;
+    case RelativeWithoutAngle:
+        Pose target = (pose.x + targetPose.dist * std::cos(pose.theta), pose.y + targetPose.dist * std::sin(pose.theta),
+                       pose.theta);
+        break;
+    case RelativeWithAngle:
+        Pose target = (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
+                       pose.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
+        break;
+    case ClassicMovement:
+        // calculate target pose in standard form
+        Pose target(x, y, M_PI_2 - degToRad(theta));
+        break;
 
-        default:
-            // Handle unknown movement type
-            // Log error maybe
-            break;
+    default:
+        // Handle unknown movement type
+        // Log error maybe
+        break;
     }
-private:
+
+    private:
     // Enum to represent different movement types
     enum MovementType {
         RelativeWithoutAngle,
@@ -373,10 +376,12 @@ private:
 
         // calculate target pose in standard form
         Pose target(x, y, M_PI_2 - degToRad(theta));
-    if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
+    if (!params.forwards)
+        target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 
     // use global chasePower is chasePower is 0
-    if (params.chasePower == 0) params.chasePower = drivetrain.chasePower;
+    if (params.chasePower == 0)
+        params.chasePower = drivetrain.chasePower;
 
     // initialize vars used between iterations
     Pose lastPose = getPose();
@@ -410,11 +415,13 @@ private:
         }
 
         // check if the lateral controller has settled
-        if (lateralLargeExit.getExit() && lateralSmallExit.getExit()) lateralSettled = true;
+        if (lateralLargeExit.getExit() && lateralSmallExit.getExit())
+            lateralSettled = true;
 
         // calculate the carrot point
         Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget;
-        if (close) carrot = target; // settling behavior
+        if (close)
+            carrot = target; // settling behavior
 
         // calculate if the robot is on the same side as the carrot point
         const bool robotSide =
@@ -423,7 +430,8 @@ private:
                                 (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
         const bool sameSide = robotSide == carrotSide;
         // exit if close
-        if (!sameSide && prevSameSide && close && params.minSpeed != 0) break;
+        if (!sameSide && prevSameSide && close && params.minSpeed != 0)
+            break;
         prevSameSide = sameSide;
 
         // calculate error
@@ -434,8 +442,10 @@ private:
         // only use cos when settling
         // otherwise just multiply by the sign of cos
         // maxSlipSpeed takes care of lateralOut
-        if (close) lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
-        else lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
+        if (close)
+            lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
+        else
+            lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
 
         // update exit conditions
         lateralSmallExit.update(lateralError);
@@ -468,14 +478,18 @@ private:
         lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
         // prioritize angular movement over lateral movement
         const float overturn = fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
-        if (overturn > 0) lateralOut -= lateralOut > 0 ? overturn : -overturn;
+        if (overturn > 0)
+            lateralOut -= lateralOut > 0 ? overturn : -overturn;
 
         // prevent moving in the wrong direction
-        if (params.forwards && !close) lateralOut = std::fmax(lateralOut, 0);
-        else if (!params.forwards && !close) lateralOut = std::fmin(lateralOut, 0);
+        if (params.forwards && !close)
+            lateralOut = std::fmax(lateralOut, 0);
+        else if (!params.forwards && !close)
+            lateralOut = std::fmin(lateralOut, 0);
 
         // constrain lateral output by the minimum speed
-        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0) lateralOut = fabs(params.minSpeed);
+        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
+            lateralOut = fabs(params.minSpeed);
         if (!params.forwards && -lateralOut < fabs(params.minSpeed) && lateralOut < 0)
             lateralOut = -fabs(params.minSpeed);
 
@@ -521,7 +535,8 @@ private:
 void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
     this->requestMotionStart();
     // were all motions cancelled?
-    if (!this->motionRunning) return;
+    if (!this->motionRunning)
+        return;
     // if the function is async, run it in a new task
     if (async) {
         pros::Task task([&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
@@ -579,7 +594,8 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, 
         // get output from PIDs
         float lateralOut = lateralPID.update(lateralError);
         float angularOut = angularPID.update(radToDeg(angularError));
-        if (close) angularOut = 0;
+        if (close)
+            angularOut = 0;
 
         // apply restrictions on angular speed
         angularOut = std::clamp(angularOut, -maxSpeed, maxSpeed);
@@ -595,8 +611,10 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, 
             lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
 
         // prevent moving in the wrong direction
-        if (forwards && !close) lateralOut = std::fmax(lateralOut, 0);
-        else if (!forwards && !close) lateralOut = std::fmin(lateralOut, 0);
+        if (forwards && !close)
+            lateralOut = std::fmax(lateralOut, 0);
+        else if (!forwards && !close)
+            lateralOut = std::fmin(lateralOut, 0);
 
         // update previous output
         prevAngularOut = angularOut;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -312,7 +312,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         return;
     // if the function is async, run it in a new task
     if (async) {
-        pros::Task task([&]() { moveToPose(x, y, theta, timeout, params, false); });
+        pros::Task task([&]() { moveToPose(MoveToPoseTarget targetPose, timeout, params, false); });
         this->endMotion();
         pros::delay(10); // delay to give the task time to start
         return;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -290,7 +290,6 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
     distTravelled = -1;
     this->endMotion();
 }
-, const MoveToPoseTarget& params_t
 /*
  * @brief Get the movement type for boomerang so we can run calculations for the target
  */
@@ -317,7 +316,7 @@ MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) 
 /*
  * @brief get the target for the boomerang
  */
-void lemlib::Chassis::getTarget(MovementType mType, const MoveToPoseTarget& params_t) {
+Pose lemlib::Chassis::getTarget(MovementType mType, const MoveToPoseTarget& params_t) {
     struct Target { // structure for readability
         float x;
         float y;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -318,27 +318,39 @@ MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) 
  * @brief get the target for the boomerang
  */
 void lemlib::Chassis::getTarget(MovementType mType, const MoveToPoseTarget& params_t) {
+    struct Target { // structure for readability
+        float x;
+        float y;
+        float theta;
+        float dist;
+    }; Target targetPose;
     const Pose pose_t = getPose(true, true);
     // Recalculate target based on user input
     switch (mType) {
         case RelativeWithoutAngle:
-            return Pose(params_t[0] + params_t[3] * std::cos(pose_t.theta),
-                        params_t[1] + params_t[3] * std::sin(pose_t.theta), params_t[2]);
+            targetPose.dist=params_t.params[0];
+            return Pose(pose_t.x + targetPose.dist * std::cos(pose_t.theta),
+                          pose_t.y + targetPose.dist * std::sin(pose_t.theta), pose_t.theta);
             break;
         case RelativeWithAngle:
-            return Pose(params_t[0] + params_t[3] * std::cos(degToRad(params_t[2])),
-                        params_t[1] + params_t[3] * std::sin(degToRad(params_t[2])), params_t[2]);
+            targetPose.dist=params_t.params[0];
+            targetPose.theta=params_t.params[1];
+            return Pose(pose_t.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
+                          pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
             break;
         case ClassicMovement:
+            targetPose.x=params_t.params[0];
+            targetPose.y=params_t.params[1];
+            targetPose.theta=params_t.params[2];
             // calculate target pose in standard form
-            return Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(params_t[2]));
+            return Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
             break;
 
         default:
             // Handle unknown movement type
             // Log error maybe
             // calculate target pose in standard form
-            return Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(params_t[2]));
+            return Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
             break;
     }
 }

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -35,7 +35,11 @@
  */
 lemlib::OdomSensors::OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
                                  TrackingWheel* horizontal2, pros::Imu* imu)
-    : vertical1(vertical1), vertical2(vertical2), horizontal1(horizontal1), horizontal2(horizontal2), imu(imu) {}
+    : vertical1(vertical1),
+      vertical2(vertical2),
+      horizontal1(horizontal1),
+      horizontal2(horizontal2),
+      imu(imu) {}
 
 /**
  * @brief The constants are stored in a struct so that they can be easily passed
@@ -51,7 +55,11 @@ lemlib::OdomSensors::OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertic
  */
 lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth,
                                float wheelDiameter, float rpm, float chasePower)
-    : leftMotors(leftMotors), rightMotors(rightMotors), trackWidth(trackWidth), wheelDiameter(wheelDiameter), rpm(rpm),
+    : leftMotors(leftMotors),
+      rightMotors(rightMotors),
+      trackWidth(trackWidth),
+      wheelDiameter(wheelDiameter),
+      rpm(rpm),
       chasePower(chasePower) {}
 
 /**
@@ -65,7 +73,10 @@ lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* r
  */
 lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings lateralSettings, ControllerSettings angularSettings,
                          OdomSensors sensors, DriveCurveFunction_t driveCurve)
-    : drivetrain(drivetrain), lateralSettings(lateralSettings), angularSettings(angularSettings), sensors(sensors),
+    : drivetrain(drivetrain),
+      lateralSettings(lateralSettings),
+      angularSettings(angularSettings),
+      sensors(sensors),
       driveCurve(driveCurve),
       lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD, lateralSettings.windupRange, true),
       angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
@@ -91,8 +102,7 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
             pros::delay(10);
             attempt++;
         }
-        if (attempt == 5)
-            sensors.imu = nullptr;
+        if (attempt == 5) sensors.imu = nullptr;
     }
     // initialize odom
     if (sensors.vertical1 == nullptr)
@@ -103,10 +113,8 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
                                                       drivetrain.trackWidth / 2, drivetrain.rpm);
     sensors.vertical1->reset();
     sensors.vertical2->reset();
-    if (sensors.horizontal1 != nullptr)
-        sensors.horizontal1->reset();
-    if (sensors.horizontal2 != nullptr)
-        sensors.horizontal2->reset();
+    if (sensors.horizontal1 != nullptr) sensors.horizontal1->reset();
+    if (sensors.horizontal2 != nullptr) sensors.horizontal2->reset();
     lemlib::setSensors(sensors, drivetrain);
     lemlib::init();
     // rumble to controller to indicate success
@@ -143,10 +151,8 @@ void lemlib::Chassis::setPose(Pose pose, bool radians) { lemlib::setPose(pose, r
  */
 lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
     Pose pose = lemlib::getPose(true);
-    if (standardPos)
-        pose.theta = M_PI_2 - pose.theta;
-    if (!radians)
-        pose.theta = radToDeg(pose.theta);
+    if (standardPos) pose.theta = M_PI_2 - pose.theta;
+    if (!radians) pose.theta = radToDeg(pose.theta);
     return pose;
 }
 
@@ -160,8 +166,7 @@ lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
  */
 void lemlib::Chassis::waitUntil(float dist) {
     // do while to give the thread time to start
-    do
-        pros::delay(10);
+    do pros::delay(10);
     while (distTravelled <= dist && distTravelled != -1);
 }
 
@@ -170,16 +175,13 @@ void lemlib::Chassis::waitUntil(float dist) {
  *
  */
 void lemlib::Chassis::waitUntilDone() {
-    do
-        pros::delay(10);
+    do pros::delay(10);
     while (distTravelled != -1);
 }
 
 void lemlib::Chassis::requestMotionStart() {
-    if (this->isInMotion())
-        this->motionQueued = true; // indicate a motion is queued
-    else
-        this->motionRunning = true; // indicate a motion is running
+    if (this->isInMotion()) this->motionQueued = true; // indicate a motion is queued
+    else this->motionRunning = true; // indicate a motion is running
 
     // wait until this motion is at front of "queue"
     this->mutex.take(TIMEOUT_MAX);
@@ -228,8 +230,7 @@ bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
 void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
     this->requestMotionStart();
     // were all motions cancelled?
-    if (!this->motionRunning)
-        return;
+    if (!this->motionRunning) return;
     // if the function is async, run it in a new task
     if (async) {
         pros::Task task([&]() { turnTo(x, y, timeout, forwards, maxSpeed, false); });
@@ -270,10 +271,8 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
         angularSmallExit.update(deltaTheta);
 
         // cap the speed
-        if (motorPower > maxSpeed)
-            motorPower = maxSpeed;
-        else if (motorPower < -maxSpeed)
-            motorPower = -maxSpeed;
+        if (motorPower > maxSpeed) motorPower = maxSpeed;
+        else if (motorPower < -maxSpeed) motorPower = -maxSpeed;
 
         // move the drivetrain
         drivetrain.leftMotors->move(motorPower);
@@ -289,6 +288,7 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
     distTravelled = -1;
     this->endMotion();
 }
+
 /**
  * @brief Move the chassis towards the target pose
  *
@@ -307,8 +307,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
     // take the mutex
     this->requestMotionStart();
     // were all motions cancelled?
-    if (!this->motionRunning)
-        return;
+    if (!this->motionRunning) return;
     // if the function is async, run it in a new task
     if (async) {
         pros::Task task([&]() { moveToPose(targetPose, timeout, params, false); });
@@ -344,33 +343,31 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
     // Recalculate target based on user input
     Pose target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
     switch (mType) {
-    case RelativeWithoutAngle:
-        target = Pose(pose_t.x + targetPose.dist * std::cos(pose_t.theta),
-                      pose_t.y + targetPose.dist * std::sin(pose_t.theta), pose_t.theta);
-        break;
-    case RelativeWithAngle:
-        target = Pose(pose_t.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
-                      pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
-        break;
-    case ClassicMovement:
-        // calculate target pose in standard form
-        target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
-        break;
+        case RelativeWithoutAngle:
+            target = Pose(pose_t.x + targetPose.dist * std::cos(pose_t.theta),
+                          pose_t.y + targetPose.dist * std::sin(pose_t.theta), pose_t.theta);
+            break;
+        case RelativeWithAngle:
+            target = Pose(pose_t.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
+                          pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
+            break;
+        case ClassicMovement:
+            // calculate target pose in standard form
+            target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+            break;
 
-    default:
-        // Handle unknown movement type
-        // Log error maybe
-        // calculate target pose in standard form
-        target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
-        break;
+        default:
+            // Handle unknown movement type
+            // Log error maybe
+            // calculate target pose in standard form
+            target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+            break;
     }
 
-    if (!params.forwards)
-        target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
+    if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 
     // use global chasePower is chasePower is 0
-    if (params.chasePower == 0)
-        params.chasePower = drivetrain.chasePower;
+    if (params.chasePower == 0) params.chasePower = drivetrain.chasePower;
 
     // initialize vars used between iterations
     Pose lastPose = getPose();
@@ -404,13 +401,11 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         }
 
         // check if the lateral controller has settled
-        if (lateralLargeExit.getExit() && lateralSmallExit.getExit())
-            lateralSettled = true;
+        if (lateralLargeExit.getExit() && lateralSmallExit.getExit()) lateralSettled = true;
 
         // calculate the carrot point
         Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget;
-        if (close)
-            carrot = target; // settling behavior
+        if (close) carrot = target; // settling behavior
 
         // calculate if the robot is on the same side as the carrot point
         const bool robotSide =
@@ -419,8 +414,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
                                 (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
         const bool sameSide = robotSide == carrotSide;
         // exit if close
-        if (!sameSide && prevSameSide && close && params.minSpeed != 0)
-            break;
+        if (!sameSide && prevSameSide && close && params.minSpeed != 0) break;
         prevSameSide = sameSide;
 
         // calculate error
@@ -431,10 +425,8 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         // only use cos when settling
         // otherwise just multiply by the sign of cos
         // maxSlipSpeed takes care of lateralOut
-        if (close)
-            lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
-        else
-            lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
+        if (close) lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
+        else lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
 
         // update exit conditions
         lateralSmallExit.update(lateralError);
@@ -467,18 +459,14 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
         // prioritize angular movement over lateral movement
         const float overturn = fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
-        if (overturn > 0)
-            lateralOut -= lateralOut > 0 ? overturn : -overturn;
+        if (overturn > 0) lateralOut -= lateralOut > 0 ? overturn : -overturn;
 
         // prevent moving in the wrong direction
-        if (params.forwards && !close)
-            lateralOut = std::fmax(lateralOut, 0);
-        else if (!params.forwards && !close)
-            lateralOut = std::fmin(lateralOut, 0);
+        if (params.forwards && !close) lateralOut = std::fmax(lateralOut, 0);
+        else if (!params.forwards && !close) lateralOut = std::fmin(lateralOut, 0);
 
         // constrain lateral output by the minimum speed
-        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
-            lateralOut = fabs(params.minSpeed);
+        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0) lateralOut = fabs(params.minSpeed);
         if (!params.forwards && -lateralOut < fabs(params.minSpeed) && lateralOut < 0)
             lateralOut = -fabs(params.minSpeed);
 
@@ -524,8 +512,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
 void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
     this->requestMotionStart();
     // were all motions cancelled?
-    if (!this->motionRunning)
-        return;
+    if (!this->motionRunning) return;
     // if the function is async, run it in a new task
     if (async) {
         pros::Task task([&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
@@ -583,8 +570,7 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, 
         // get output from PIDs
         float lateralOut = lateralPID.update(lateralError);
         float angularOut = angularPID.update(radToDeg(angularError));
-        if (close)
-            angularOut = 0;
+        if (close) angularOut = 0;
 
         // apply restrictions on angular speed
         angularOut = std::clamp(angularOut, -maxSpeed, maxSpeed);
@@ -600,10 +586,8 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, 
             lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
 
         // prevent moving in the wrong direction
-        if (forwards && !close)
-            lateralOut = std::fmax(lateralOut, 0);
-        else if (!forwards && !close)
-            lateralOut = std::fmin(lateralOut, 0);
+        if (forwards && !close) lateralOut = std::fmax(lateralOut, 0);
+        else if (!forwards && !close) lateralOut = std::fmin(lateralOut, 0);
 
         // update previous output
         prevAngularOut = angularOut;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -345,6 +345,8 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
     default:
         // Handle unknown movement type
         // Log error maybe
+        // calculate target pose in standard form
+        Pose target(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
     }
 

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -293,30 +293,32 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
 /*
  * @brief Get the movement type for boomerang so we can run calculations for the target
  */
-MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
+void lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
+    MovementType mType;
     // count number of values in the vector that were used
     uint16_t count = 0;
     for (auto v : params_t.params)
         if (!isnan(v)) count++;
     // figure out movement type
     if (count = 1) {
-        return ClassicMovement;
+        mType = ClassicMovement;
     } else if (count = 2) {
-        return RelativeWithAngle;
+        mType = RelativeWithAngle;
     } else if (count = 3) {
-        returnRelativeWithoutAngle;
+        mType = RelativeWithoutAngle;
     } else {
         // Handle unknown movement type
         // Maybe log error
-        return ClassicMovement; // Default to classic movement for unknown
+        mType = ClassicMovement; // Default to classic movement for unknown
                                 // input
     }
+    return mType;
 }
 
 /*
  * @brief get the target for the boomerang
  */
-Pose lemlib::Chassis::getTarget(MovementType mType, const MoveToPoseTarget& params_t) {
+void lemlib::Chassis::getTarget(MovementType mType, const MoveToPoseTarget& params_t) {
     struct Target { // structure for readability
         float x;
         float y;
@@ -389,7 +391,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
     angularLargeExit.reset();
     angularSmallExit.reset();
 
-    Pose target = getTarget(getMovementType(targetPose));
+    Pose target = getTarget(getMovementType(targetPose),targetPose);
 
     if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -294,7 +294,7 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
 /*
  * @brief Get the movement type for boomerang so we can run calculations for the target
  */
-void lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
+MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
     // count number of values in the vector that were used
     uint16_t count = 0;
     for (auto v : params_t)

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -330,7 +330,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         mType = RelativeWithoutAngle;
     } else if (!isnan(targetPose.dist) && !isnan(targetPose.theta)) {
         mType = RelativeWithAngle;
-    } else if (!isnan(targetPose.x) || !isnan(targetPose.y) || !isnan(targetPose.theta)) {
+    } else if (!isnan(targetPose.x) && !isnan(targetPose.y) && !isnan(targetPose.theta)) {
         mType = ClassicMovement;
     } else {
         // Handle unknown movement type

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -33,12 +33,13 @@
  * @param horizontal2 pointer to the second horizontal tracking wheel
  * @param imu pointer to the IMU
  */
-lemlib::OdomSensors::OdomSensors(TrackingWheel *vertical1,
-                                                                 TrackingWheel *vertical2,
-                                                                 TrackingWheel *horizontal1,
-                                                                 TrackingWheel *horizontal2, pros::Imu *imu)
-        : vertical1(vertical1), vertical2(vertical2), horizontal1(horizontal1),
-            horizontal2(horizontal2), imu(imu) {}
+lemlib::OdomSensors::OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertical2, TrackingWheel* horizontal1,
+                                 TrackingWheel* horizontal2, pros::Imu* imu)
+    : vertical1(vertical1),
+      vertical2(vertical2),
+      horizontal1(horizontal1),
+      horizontal2(horizontal2),
+      imu(imu) {}
 
 /**
  * @brief The constants are stored in a struct so that they can be easily passed
@@ -52,11 +53,14 @@ lemlib::OdomSensors::OdomSensors(TrackingWheel *vertical1,
  * @param chasePower higher values make the robot move faster but causes more
  * overshoot on turns
  */
-lemlib::Drivetrain::Drivetrain(pros::MotorGroup *leftMotors,
-                                                             pros::MotorGroup *rightMotors, float trackWidth,
-                                                             float wheelDiameter, float rpm, float chasePower)
-        : leftMotors(leftMotors), rightMotors(rightMotors), trackWidth(trackWidth),
-            wheelDiameter(wheelDiameter), rpm(rpm), chasePower(chasePower) {}
+lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth,
+                               float wheelDiameter, float rpm, float chasePower)
+    : leftMotors(leftMotors),
+      rightMotors(rightMotors),
+      trackWidth(trackWidth),
+      wheelDiameter(wheelDiameter),
+      rpm(rpm),
+      chasePower(chasePower) {}
 
 /**
  * @brief Construct a new Chassis
@@ -67,25 +71,19 @@ lemlib::Drivetrain::Drivetrain(pros::MotorGroup *leftMotors,
  * @param sensors sensors to be used for odometry
  * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
  */
-lemlib::Chassis::Chassis(Drivetrain drivetrain,
-                                                 ControllerSettings lateralSettings,
-                                                 ControllerSettings angularSettings,
-                                                 OdomSensors sensors, DriveCurveFunction_t driveCurve)
-        : drivetrain(drivetrain), lateralSettings(lateralSettings),
-            angularSettings(angularSettings), sensors(sensors),
-            driveCurve(driveCurve),
-            lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD,
-                                 lateralSettings.windupRange, true),
-            angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD,
-                                 angularSettings.windupRange, true),
-            lateralLargeExit(lateralSettings.largeError,
-                                             lateralSettings.largeErrorTimeout),
-            lateralSmallExit(lateralSettings.smallError,
-                                             lateralSettings.smallErrorTimeout),
-            angularLargeExit(angularSettings.largeError,
-                                             angularSettings.largeErrorTimeout),
-            angularSmallExit(angularSettings.smallError,
-                                             angularSettings.smallErrorTimeout) {}
+lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings lateralSettings, ControllerSettings angularSettings,
+                         OdomSensors sensors, DriveCurveFunction_t driveCurve)
+    : drivetrain(drivetrain),
+      lateralSettings(lateralSettings),
+      angularSettings(angularSettings),
+      sensors(sensors),
+      driveCurve(driveCurve),
+      lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD, lateralSettings.windupRange, true),
+      angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
+      lateralLargeExit(lateralSettings.largeError, lateralSettings.largeErrorTimeout),
+      lateralSmallExit(lateralSettings.smallError, lateralSettings.smallErrorTimeout),
+      angularLargeExit(angularSettings.largeError, angularSettings.largeErrorTimeout),
+      angularSmallExit(angularSettings.smallError, angularSettings.smallErrorTimeout) {}
 
 /**
  * @brief Calibrate the chassis sensors
@@ -98,31 +96,25 @@ void lemlib::Chassis::calibrate(bool calibrateIMU) {
         int attempt = 1;
         // calibrate inertial, and if calibration fails, then repeat 5 times or
         // until successful
-        while (sensors.imu->reset(true) != 1 &&
-                     (errno == PROS_ERR || errno == ENODEV || errno == ENXIO) &&
-                     attempt < 5) {
+        while (sensors.imu->reset(true) != 1 && (errno == PROS_ERR || errno == ENODEV || errno == ENXIO) &&
+               attempt < 5) {
             pros::c::controller_rumble(pros::E_CONTROLLER_MASTER, "---");
             pros::delay(10);
             attempt++;
         }
-        if (attempt == 5)
-            sensors.imu = nullptr;
+        if (attempt == 5) sensors.imu = nullptr;
     }
     // initialize odom
     if (sensors.vertical1 == nullptr)
-        sensors.vertical1 = new lemlib::TrackingWheel(
-                drivetrain.leftMotors, drivetrain.wheelDiameter,
-                -(drivetrain.trackWidth / 2), drivetrain.rpm);
+        sensors.vertical1 = new lemlib::TrackingWheel(drivetrain.leftMotors, drivetrain.wheelDiameter,
+                                                      -(drivetrain.trackWidth / 2), drivetrain.rpm);
     if (sensors.vertical2 == nullptr)
-        sensors.vertical2 = new lemlib::TrackingWheel(
-                drivetrain.rightMotors, drivetrain.wheelDiameter,
-                drivetrain.trackWidth / 2, drivetrain.rpm);
+        sensors.vertical2 = new lemlib::TrackingWheel(drivetrain.rightMotors, drivetrain.wheelDiameter,
+                                                      drivetrain.trackWidth / 2, drivetrain.rpm);
     sensors.vertical1->reset();
     sensors.vertical2->reset();
-    if (sensors.horizontal1 != nullptr)
-        sensors.horizontal1->reset();
-    if (sensors.horizontal2 != nullptr)
-        sensors.horizontal2->reset();
+    if (sensors.horizontal1 != nullptr) sensors.horizontal1->reset();
+    if (sensors.horizontal2 != nullptr) sensors.horizontal2->reset();
     lemlib::setSensors(sensors, drivetrain);
     lemlib::init();
     // rumble to controller to indicate success
@@ -148,9 +140,7 @@ void lemlib::Chassis::setPose(float x, float y, float theta, bool radians) {
  * @param radians whether pose theta is in radians (true) or not (false). false
  * by default
  */
-void lemlib::Chassis::setPose(Pose pose, bool radians) {
-    lemlib::setPose(pose, radians);
-}
+void lemlib::Chassis::setPose(Pose pose, bool radians) { lemlib::setPose(pose, radians); }
 
 /**
  * @brief Get the pose of the chassis
@@ -161,10 +151,8 @@ void lemlib::Chassis::setPose(Pose pose, bool radians) {
  */
 lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
     Pose pose = lemlib::getPose(true);
-    if (standardPos)
-        pose.theta = M_PI_2 - pose.theta;
-    if (!radians)
-        pose.theta = radToDeg(pose.theta);
+    if (standardPos) pose.theta = M_PI_2 - pose.theta;
+    if (!radians) pose.theta = radToDeg(pose.theta);
     return pose;
 }
 
@@ -178,8 +166,7 @@ lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
  */
 void lemlib::Chassis::waitUntil(float dist) {
     // do while to give the thread time to start
-    do
-        pros::delay(10);
+    do pros::delay(10);
     while (distTravelled <= dist && distTravelled != -1);
 }
 
@@ -188,16 +175,13 @@ void lemlib::Chassis::waitUntil(float dist) {
  *
  */
 void lemlib::Chassis::waitUntilDone() {
-    do
-        pros::delay(10);
+    do pros::delay(10);
     while (distTravelled != -1);
 }
 
 void lemlib::Chassis::requestMotionStart() {
-    if (this->isInMotion())
-        this->motionQueued = true; // indicate a motion is queued
-    else
-        this->motionRunning = true; // indicate a motion is running
+    if (this->isInMotion()) this->motionQueued = true; // indicate a motion is queued
+    else this->motionRunning = true; // indicate a motion is running
 
     // wait until this motion is at front of "queue"
     this->mutex.take(TIMEOUT_MAX);
@@ -243,16 +227,13 @@ bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
  * @param async whether the function should be run asynchronously. true by
  * default
  */
-void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards,
-                                                         float maxSpeed, bool async) {
+void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
     this->requestMotionStart();
     // were all motions cancelled?
-    if (!this->motionRunning)
-        return;
+    if (!this->motionRunning) return;
     // if the function is async, run it in a new task
     if (async) {
-        pros::Task task(
-                [&]() { turnTo(x, y, timeout, forwards, maxSpeed, false); });
+        pros::Task task([&]() { turnTo(x, y, timeout, forwards, maxSpeed, false); });
         this->endMotion();
         pros::delay(10); // delay to give the task time to start
         return;
@@ -269,12 +250,10 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards,
     angularPID.reset();
 
     // main loop
-    while (!timer.isDone() && !angularLargeExit.getExit() &&
-                 !angularSmallExit.getExit() && this->motionRunning) {
+    while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
         // update variables
         Pose pose = getPose();
-        pose.theta =
-                (forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
+        pose.theta = (forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
 
         // update completion vars
         distTravelled = fabs(angleError(pose.theta, startTheta));
@@ -292,10 +271,8 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards,
         angularSmallExit.update(deltaTheta);
 
         // cap the speed
-        if (motorPower > maxSpeed)
-            motorPower = maxSpeed;
-        else if (motorPower < -maxSpeed)
-            motorPower = -maxSpeed;
+        if (motorPower > maxSpeed) motorPower = maxSpeed;
+        else if (motorPower < -maxSpeed) motorPower = -maxSpeed;
 
         // move the drivetrain
         drivetrain.leftMotors->move(motorPower);
@@ -326,13 +303,11 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards,
  * @param async whether the function should be run asynchronously. true by
  * default
  */
-void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout,
-                                                                 MoveToPoseFlags params, bool async) {
+void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveToPoseFlags params, bool async) {
     // take the mutex
     this->requestMotionStart();
     // were all motions cancelled?
-    if (!this->motionRunning)
-        return;
+    if (!this->motionRunning) return;
     // if the function is async, run it in a new task
     if (async) {
         pros::Task task([&]() { moveToPose(x, y, theta, timeout, params, false); });
@@ -352,27 +327,24 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout,
     const Pose pose = getPose(true, true);
     // Recalculate target based on user input
     switch (getMovementType(targetPose)) {
-    case RelativeWithoutAngle:
-        Pose target = (pose.x + targetPose.dist * std::cos(pose.theta),
-                                     pose.y + targetPose.dist * std::sin(pose.theta), pose.theta);
-        break;
-    case RelativeWithAngle:
-        Pose target =
-                (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
-                 pose.y + targetPose.dist * std::sin(degToRad(targetPose.theta)),
-                 targetPose.theta);
-        break;
-    case ClassicMovement:
-        // calculate target pose in standard form
-        Pose target(x, y, M_PI_2 - degToRad(theta));
-        break;
+        case RelativeWithoutAngle:
+            Pose target = (pose.x + targetPose.dist * std::cos(pose.theta),
+                           pose.y + targetPose.dist * std::sin(pose.theta), pose.theta);
+            break;
+        case RelativeWithAngle:
+            Pose target = (pose.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
+                           pose.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
+            break;
+        case ClassicMovement:
+            // calculate target pose in standard form
+            Pose target(x, y, M_PI_2 - degToRad(theta));
+            break;
 
-    default:
-        // Handle unknown movement type
-        // Log error maybe
-        break;
+        default:
+            // Handle unknown movement type
+            // Log error maybe
+            break;
     }
-
 private:
     // Enum to represent different movement types
     enum MovementType {
@@ -383,7 +355,7 @@ private:
     };
 
     // Function to determine the movement type based on user input
-    MovementType getMovementType(const MovementParams &params) {
+    MovementType getMovementType(const MovementParams& params) {
         if (!isnan(params.distance)) {
             return RelativeWithoutAngle;
         } else if (!isnan(params.distance) && !isnan(params.angle)) {
@@ -394,19 +366,17 @@ private:
             // Handle unknown movement type
             // Maybe log error
             return ClassicMovement; // Default to classic movement for unknown
-                                                            // input
+                                    // input
         }
     }
     ...
 
-            // calculate target pose in standard form
-            Pose target(x, y, M_PI_2 - degToRad(theta));
-    if (!params.forwards)
-        target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
+        // calculate target pose in standard form
+        Pose target(x, y, M_PI_2 - degToRad(theta));
+    if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 
     // use global chasePower is chasePower is 0
-    if (params.chasePower == 0)
-        params.chasePower = drivetrain.chasePower;
+    if (params.chasePower == 0) params.chasePower = drivetrain.chasePower;
 
     // initialize vars used between iterations
     Pose lastPose = getPose();
@@ -421,10 +391,8 @@ private:
 
     // main loop
     while (!timer.isDone() &&
-                 ((!lateralSettled ||
-                     (!angularLargeExit.getExit() && !angularSmallExit.getExit())) ||
-                    !close) &&
-                 this->motionRunning) {
+           ((!lateralSettled || (!angularLargeExit.getExit() && !angularSmallExit.getExit())) || !close) &&
+           this->motionRunning) {
         // update position
         const Pose pose = getPose(true, true);
 
@@ -442,42 +410,32 @@ private:
         }
 
         // check if the lateral controller has settled
-        if (lateralLargeExit.getExit() && lateralSmallExit.getExit())
-            lateralSettled = true;
+        if (lateralLargeExit.getExit() && lateralSmallExit.getExit()) lateralSettled = true;
 
         // calculate the carrot point
-        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) *
-                                                             params.lead * distTarget;
-        if (close)
-            carrot = target; // settling behavior
+        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget;
+        if (close) carrot = target; // settling behavior
 
         // calculate if the robot is on the same side as the carrot point
         const bool robotSide =
-                (pose.y - target.y) * -sin(target.theta) <=
-                (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
-        const bool carrotSide =
-                (carrot.y - target.y) * -sin(target.theta) <=
-                (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
+            (pose.y - target.y) * -sin(target.theta) <= (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
+        const bool carrotSide = (carrot.y - target.y) * -sin(target.theta) <=
+                                (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
         const bool sameSide = robotSide == carrotSide;
         // exit if close
-        if (!sameSide && prevSameSide && close && params.minSpeed != 0)
-            break;
+        if (!sameSide && prevSameSide && close && params.minSpeed != 0) break;
         prevSameSide = sameSide;
 
         // calculate error
-        const float adjustedRobotTheta =
-                params.forwards ? pose.theta : pose.theta + M_PI;
+        const float adjustedRobotTheta = params.forwards ? pose.theta : pose.theta + M_PI;
         const float angularError =
-                close ? angleError(adjustedRobotTheta, target.theta)
-                            : angleError(adjustedRobotTheta, pose.angle(carrot));
+            close ? angleError(adjustedRobotTheta, target.theta) : angleError(adjustedRobotTheta, pose.angle(carrot));
         float lateralError = pose.distance(carrot);
         // only use cos when settling
         // otherwise just multiply by the sign of cos
         // maxSlipSpeed takes care of lateralOut
-        if (close)
-            lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
-        else
-            lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
+        if (close) lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
+        else lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
 
         // update exit conditions
         lateralSmallExit.update(lateralError);
@@ -509,22 +467,16 @@ private:
         const float maxSlipSpeed(sqrt(params.chasePower * radius * 9.8));
         lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
         // prioritize angular movement over lateral movement
-        const float overturn =
-                fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
-        if (overturn > 0)
-            lateralOut -= lateralOut > 0 ? overturn : -overturn;
+        const float overturn = fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
+        if (overturn > 0) lateralOut -= lateralOut > 0 ? overturn : -overturn;
 
         // prevent moving in the wrong direction
-        if (params.forwards && !close)
-            lateralOut = std::fmax(lateralOut, 0);
-        else if (!params.forwards && !close)
-            lateralOut = std::fmin(lateralOut, 0);
+        if (params.forwards && !close) lateralOut = std::fmax(lateralOut, 0);
+        else if (!params.forwards && !close) lateralOut = std::fmin(lateralOut, 0);
 
         // constrain lateral output by the minimum speed
-        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
-            lateralOut = fabs(params.minSpeed);
-        if (!params.forwards && -lateralOut < fabs(params.minSpeed) &&
-                lateralOut < 0)
+        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0) lateralOut = fabs(params.minSpeed);
+        if (!params.forwards && -lateralOut < fabs(params.minSpeed) && lateralOut < 0)
             lateralOut = -fabs(params.minSpeed);
 
         // update previous output
@@ -534,8 +486,7 @@ private:
         // ratio the speeds to respect the max speed
         float leftPower = lateralOut + angularOut;
         float rightPower = lateralOut - angularOut;
-        const float ratio =
-                std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
+        const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
         if (ratio > 1) {
             leftPower /= ratio;
             rightPower /= ratio;
@@ -567,16 +518,13 @@ private:
  * @param async whether the function should be run asynchronously. true by
  * default
  */
-void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards,
-                                                                    float maxSpeed, bool async) {
+void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards, float maxSpeed, bool async) {
     this->requestMotionStart();
     // were all motions cancelled?
-    if (!this->motionRunning)
-        return;
+    if (!this->motionRunning) return;
     // if the function is async, run it in a new task
     if (async) {
-        pros::Task task(
-                [&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
+        pros::Task task([&]() { moveToPoint(x, y, timeout, forwards, maxSpeed, false); });
         this->endMotion();
         pros::delay(10); // delay to give the task time to start
         return;
@@ -601,10 +549,8 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards,
     const int compState = pros::competition::get_status();
 
     // main loop
-    while (!timer.isDone() &&
-                 ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) ||
-                    !close) &&
-                 this->motionRunning) {
+    while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close) &&
+           this->motionRunning) {
         // update position
         const Pose pose = getPose(true, true);
 
@@ -623,10 +569,8 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards,
 
         // calculate error
         const float adjustedRobotTheta = forwards ? pose.theta : pose.theta + M_PI;
-        const float angularError =
-                angleError(adjustedRobotTheta, pose.angle(target));
-        float lateralError =
-                pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
+        const float angularError = angleError(adjustedRobotTheta, pose.angle(target));
+        float lateralError = pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
 
         // update exit conditions
         lateralSmallExit.update(lateralError);
@@ -635,8 +579,7 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards,
         // get output from PIDs
         float lateralOut = lateralPID.update(lateralError);
         float angularOut = angularPID.update(radToDeg(angularError));
-        if (close)
-            angularOut = 0;
+        if (close) angularOut = 0;
 
         // apply restrictions on angular speed
         angularOut = std::clamp(angularOut, -maxSpeed, maxSpeed);
@@ -652,10 +595,8 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards,
             lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
 
         // prevent moving in the wrong direction
-        if (forwards && !close)
-            lateralOut = std::fmax(lateralOut, 0);
-        else if (!forwards && !close)
-            lateralOut = std::fmin(lateralOut, 0);
+        if (forwards && !close) lateralOut = std::fmax(lateralOut, 0);
+        else if (!forwards && !close) lateralOut = std::fmin(lateralOut, 0);
 
         // update previous output
         prevAngularOut = angularOut;
@@ -664,8 +605,7 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, bool forwards,
         // ratio the speeds to respect the max speed
         float leftPower = lateralOut + angularOut;
         float rightPower = lateralOut - angularOut;
-        const float ratio =
-                std::max(std::fabs(leftPower), std::fabs(rightPower)) / maxSpeed;
+        const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / maxSpeed;
         if (ratio > 1) {
             leftPower /= ratio;
             rightPower /= ratio;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -22,7 +22,7 @@
 #include <functional>
 #include <limits>
 #include <math.h>
-#include<vector>
+#include <vector>
 
 /**
  * @brief The variables are pointers so that they can be set to nullptr if they

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -294,7 +294,7 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
 /*
  * @brief Get the movement type for boomerang so we can run calculations for the target
  */
-MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
+void lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) {
     // count number of values in the vector that were used
     uint16_t count = 0;
     for (auto v : params_t)
@@ -317,7 +317,7 @@ MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& params_t) 
 /*
  * @brief get the target for the boomerang
  */
-Pose lemlib::Chassis::getTarget(MovementType mType) {
+void lemlib::Chassis::getTarget(MovementType mType) {
     const Pose pose_t = getPose(true, true);
     // Recalculate target based on user input
     switch (mType) {

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -328,7 +328,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
 
     const Pose pose = getPose(true, true);
     // Recalculate target based on user input
-    Pose target;
+    Pose target = (targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
     switch (getMovementType(targetPose)) {
     case RelativeWithoutAngle:
         target = (pose.x + targetPose.dist * std::cos(pose.theta), pose.y + targetPose.dist * std::sin(pose.theta),
@@ -340,7 +340,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         break;
     case ClassicMovement:
         // calculate target pose in standard form
-        target(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
+        target = (targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
 
     default:

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -289,6 +289,7 @@ void lemlib::Chassis::turnTo(float x, float y, int timeout, bool forwards, float
     distTravelled = -1;
     this->endMotion();
 }
+/**
  * @brief Figure Out The Movement Type For Boomerang Controller
  */
 // Function to determine the movement type based on user input

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -305,7 +305,7 @@ lemlib::MovementType lemlib::Chassis::getMovementType(const MoveToPoseTarget& pa
     } else if (count = 2) {
         return RelativeWithAngle;
     } else if (count = 3) {
-        return RelativeWithoutAngle;
+        return RelativeWithoutAngle; 
     } else {
         // Handle unknown movement type
         // Maybe log error

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -324,7 +324,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
     angularPID.reset();
     angularLargeExit.reset();
     angularSmallExit.reset();
-  
+
     // figure out movement type
     MovementType mType;
     if (!isnan(targetPose.dist)) {
@@ -337,20 +337,20 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         // Handle unknown movement type
         // Maybe log error
         mType = ClassicMovement; // Default to classic movement for unknown
-                                // input
+                                 // input
     }
-  
+
     const Pose pose_t = getPose(true, true);
     // Recalculate target based on user input
-    Pose target = Pose(targetPose.x, targetPose.y,  M_PI_2 - degToRad(targetPose.theta));
+    Pose target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
     switch (mType) {
     case RelativeWithoutAngle:
-        target = Pose(pose_t.x + targetPose.dist * std::cos(pose_t.theta), pose_t.y + targetPose.dist * std::sin(pose_t.theta),
-                       pose_t.theta);
+        target = Pose(pose_t.x + targetPose.dist * std::cos(pose_t.theta),
+                      pose_t.y + targetPose.dist * std::sin(pose_t.theta), pose_t.theta);
         break;
     case RelativeWithAngle:
         target = Pose(pose_t.x + targetPose.dist * std::cos(degToRad(targetPose.theta)),
-                       pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
+                      pose_t.y + targetPose.dist * std::sin(degToRad(targetPose.theta)), targetPose.theta);
         break;
     case ClassicMovement:
         // calculate target pose in standard form
@@ -364,7 +364,7 @@ void lemlib::Chassis::moveToPose(MoveToPoseTarget targetPose, int timeout, MoveT
         target = Pose(targetPose.x, targetPose.y, M_PI_2 - degToRad(targetPose.theta));
         break;
     }
-  
+
     if (!params.forwards)
         target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,11 +125,11 @@ ASSET(example_txt); // '.' replaced with "_" to make c++ happy
  */
 void autonomous() {
     // example movement: Move to x: 20 and y: 15, and face heading 90. Timeout set to 4000 ms
-    chassis.moveToPose({20,15,90}, 4000);
+    chassis.moveToPose({{20,15,90}}, 4000);
     // example movement: Move to x: 0 and y: 0 and face heading 270, going backwards. Timeout set to 4000ms
-    chassis.moveToPose({0,0,270}, 4000, {.forwards = false});
+    chassis.moveToPose({{0,0,270}}, 4000, {.forwards = false});
     // example movement: Move forward 10 inches face heading 90. Timeout set to 4000ms
-    chassis.moveToPose({10,90},4000);
+    chassis.moveToPose({{10,90}},4000);
     // cancel the movement after it has travelled 10 inches
     chassis.waitUntil(10);
     chassis.cancelMotion();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,11 +125,11 @@ ASSET(example_txt); // '.' replaced with "_" to make c++ happy
  */
 void autonomous() {
     // example movement: Move to x: 20 and y: 15, and face heading 90. Timeout set to 4000 ms
-    chassis.moveToPose({.x=20,.y=15,.theta=90}, 4000);
+    chassis.moveToPose({20,15,90}, 4000);
     // example movement: Move to x: 0 and y: 0 and face heading 270, going backwards. Timeout set to 4000ms
-    chassis.moveToPose({.x=0,.y=0,.theta=270}, 4000, {.forwards = false});
+    chassis.moveToPose({0,0,270}, 4000, {.forwards = false});
     // example movement: Move forward 10 inches face heading 90. Timeout set to 4000ms
-    chassis.moveToPose({.dist=10,.theta=90},4000);
+    chassis.moveToPose({10,90},4000);
     // cancel the movement after it has travelled 10 inches
     chassis.waitUntil(10);
     chassis.cancelMotion();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,9 +125,11 @@ ASSET(example_txt); // '.' replaced with "_" to make c++ happy
  */
 void autonomous() {
     // example movement: Move to x: 20 and y: 15, and face heading 90. Timeout set to 4000 ms
-    chassis.moveToPose(20, 15, 90, 4000);
+    chassis.moveToPose({.x=20,.y=15,.theta=90}, 4000);
     // example movement: Move to x: 0 and y: 0 and face heading 270, going backwards. Timeout set to 4000ms
-    chassis.moveToPose(0, 0, 270, 4000, {.forwards = false});
+    chassis.moveToPose({{.x=0,.y=0,.theta=270}}, 4000, {.forwards = false});
+    // example movement: Move forward 10 inches face heading 90. Timeout set to 4000ms
+    chassis.moveToPose({.dist=10,.theta=90},4000);
     // cancel the movement after it has travelled 10 inches
     chassis.waitUntil(10);
     chassis.cancelMotion();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,11 +125,11 @@ ASSET(example_txt); // '.' replaced with "_" to make c++ happy
  */
 void autonomous() {
     // example movement: Move to x: 20 and y: 15, and face heading 90. Timeout set to 4000 ms
-    chassis.moveToPose({{20,15,90}}, 4000);
+    chassis.moveToPose({{20, 15, 90}}, 4000);
     // example movement: Move to x: 0 and y: 0 and face heading 270, going backwards. Timeout set to 4000ms
-    chassis.moveToPose({{0,0,270}}, 4000, {.forwards = false});
+    chassis.moveToPose({{0, 0, 270}}, 4000, {.forwards = false});
     // example movement: Move forward 10 inches face heading 90. Timeout set to 4000ms
-    chassis.moveToPose({{10,90}},4000);
+    chassis.moveToPose({{10, 90}}, 4000);
     // cancel the movement after it has travelled 10 inches
     chassis.waitUntil(10);
     chassis.cancelMotion();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -127,7 +127,7 @@ void autonomous() {
     // example movement: Move to x: 20 and y: 15, and face heading 90. Timeout set to 4000 ms
     chassis.moveToPose({.x=20,.y=15,.theta=90}, 4000);
     // example movement: Move to x: 0 and y: 0 and face heading 270, going backwards. Timeout set to 4000ms
-    chassis.moveToPose({{.x=0,.y=0,.theta=270}}, 4000, {.forwards = false});
+    chassis.moveToPose({.x=0,.y=0,.theta=270}, 4000, {.forwards = false});
     // example movement: Move forward 10 inches face heading 90. Timeout set to 4000ms
     chassis.moveToPose({.dist=10,.theta=90},4000);
     // cancel the movement after it has travelled 10 inches


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
users can now use boomerang to go x inches forward, x inches forward and turn, or the classic coordinates and theta
#### Motivation
<!-- Why are you making this pull request? -->
This would help a lot of teams also since it is difficult to visualize coordinates sometimes.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 12b706b2d0353eb3c7124a0c4df8b89b170e3730 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7379297533)
- via manual download: [LemLib@0.5.0-rc.5+12b706.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1142042448.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.5+12b706.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1142042448.zip;
pros c fetch LemLib@0.5.0-rc.5+12b706.zip;
pros c apply LemLib@0.5.0-rc.5+12b706;
rm LemLib@0.5.0-rc.5+12b706.zip;
```