### PR TITLE
Added TurnCurveGain from Refactor/PR#115

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -280,7 +280,9 @@ class Chassis {
          * @param curveGain control how steep the drive curve is. The larger the number, the steeper the curve.
          * A value of 0 disables the curve entirely.
          */
-        void tank(int left, int right, float curveGain = 0.0);
+        void tank(int left, int right, float leftCurveGain = 0.0, float rightCurveGain = 0.0,
+                  const DriveCurveFunction_t& leftCurve = defaultDriveCurve,
+                  const DriveCurveFunction_t& rightCurve = defaultDriveCurve);
         /**
          * @brief Control the robot during the driver using the arcade drive control scheme. In this control
          * scheme one joystick axis controls the forwards and backwards movement of the robot, while the other
@@ -290,7 +292,9 @@ class Chassis {
          * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
          * curve, refer to the `defaultDriveCurve` documentation.
          */
-        void arcade(int throttle, int turn, float curveGain = 0.0);
+        void arcade(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0.0,
+                    const DriveCurveFunction_t& leftCurve = defaultDriveCurve,
+                    const DriveCurveFunction_t& rightCurve = defaultDriveCurve);
         /**
          * @brief Control the robot during the driver using the curvature drive control scheme. This control
          * scheme is very similar to arcade drive, except the second joystick axis controls the radius of the
@@ -302,7 +306,9 @@ class Chassis {
          * @param curveGain the scale inputted into the drive curve function. If you are using the default drive
          * curve, refer to the `defaultDriveCurve` documentation.
          */
-        void curvature(int throttle, int turn, float cureGain = 0.0);
+        void curvature(int throttle, int turn, float linearCurveGain = 0.0, float turnCurveGain = 0.0,
+                       const DriveCurveFunction_t& driveCurve = defaultDriveCurve,
+                       const DriveCurveFunction_t& turnCurve = defaultDriveCurve);
         /**
          * @brief Cancels the currently running motion.
          * If there is a queued motion, then that queued motion will run.

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -32,8 +32,8 @@ float defaultDriveCurve(float input, float scale) {
  */
 void Chassis::tank(int left, int right, float leftCurveGain, float rightCurveGain,
                    const DriveCurveFunction_t& leftCurve, const DriveCurveFunction_t& rightCurve) {
-    this->drivetrain->leftMotors->move(leftCurve(left, leftCurveGain));
-    this->drivetrain->rightMotors->move(rightCurve(right, rightCurveGain));
+    drivetrain.leftMotors->move(leftCurve(left, leftCurveGain));
+    drivetrain.rightMotors->move(rightCurve(right, rightCurveGain));
 }
 
 /**
@@ -49,8 +49,8 @@ void Chassis::arcade(int throttle, int turn, float linearCurveGain, float turnCu
                      const DriveCurveFunction_t& driveCurve, const DriveCurveFunction_t& turnCurve) {
     int leftPower = driveCurve(throttle, linearCurveGain) + turnCurve(turn, linearCurveGain);
     int rightPower = driveCurve(throttle, linearCurveGain) - turnCurve(turn, linearCurveGain);
-    this->drivetrain->leftMotors->move(leftPower);
-    this->drivetrain->rightMotors->move(rightPower);
+    drivetrain.leftMotors->move(leftPower);
+    drivetrain.rightMotors->move(rightPower);
 }
 
 /**
@@ -79,7 +79,7 @@ void Chassis::curvature(int throttle, int turn, float linearCurveGain, float tur
     leftPower = driveCurve(leftPower, linearCurveGain);
     rightPower = turnCurve(rightPower, turnCurveGain);
 
-    this->drivetrain->leftMotors->move(leftPower);
-    this->drivetrain->rightMotors->move(rightPower);
+    drivetrain.leftMotors->move(leftPower);
+    drivetrain.rightMotors->move(rightPower);
 }
 } // namespace lemlib


### PR DESCRIPTION
From Refactor/PR#115:

####Summary
Added curves to the turn input in arcade and curvature drives. This helps users customize their driving a little bit more and get better control over their turning in opcontrol.

####Motivation
A lot of teams have their turning curve a little bit different from their linear speed curves.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 9befab3d4dd7cdac756a3a9791350aa1c5518767 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7381495425)
- via manual download: [LemLib@0.5.0-rc.5+9befab.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1142305591.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.5+9befab.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1142305591.zip;
pros c fetch LemLib@0.5.0-rc.5+9befab.zip;
pros c apply LemLib@0.5.0-rc.5+9befab;
rm LemLib@0.5.0-rc.5+9befab.zip;
```