### PR TITLE
fix: :bug: Pure Pursuit Motion Cancellation 

### DIFF
--- a/src/lemlib/chassis/pursuit.cpp
+++ b/src/lemlib/chassis/pursuit.cpp
@@ -198,12 +198,13 @@ float findLookaheadCurvature(lemlib::Pose pose, float heading, lemlib::Pose look
  * @param async whether the function should be run asynchronously. true by default
  */
 void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bool forwards, bool async) {
-    // take the mutex
-    mutex.take(TIMEOUT_MAX);
+    this->requestMotionStart();
+    // were all motions cancelled?
+    if (!this->motionRunning) return;
     // if the function is async, run it in a new task
     if (async) {
         pros::Task task([&]() { follow(path, lookahead, timeout, forwards, false); });
-        mutex.give();
+        this->endMotion();
         pros::delay(10); // delay to give the task time to start
         return;
     }
@@ -226,7 +227,7 @@ void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bo
     distTravelled = 0;
 
     // loop until the robot is within the end tolerance
-    for (int i = 0; i < timeout / 10 && pros::competition::get_status() == compState; i++) {
+    for (int i = 0; i < timeout / 10 && pros::competition::get_status() == compState && this->motionRunning; i++) {
         // get the current position of the robot
         pose = this->getPose(true);
         if (!forwards) pose.theta -= M_PI;
@@ -286,5 +287,5 @@ void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bo
     // set distTravelled to -1 to indicate that the function has finished
     distTravelled = -1;
     // give the mutex back
-    mutex.give();
+    this->endMotion();
 }


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Adds support for motion cancellation to pure pursuit.
#### Motivation
<!-- Why are you making this pull request? -->
I forgot to modify pure pursuit to support motion cancellation in #122.
#### Test Plan
<!-- How did you test / plan to test this pull request? -->
should be fine 🤞, but test it for good measure
#### Additional Notes
<!-- Add any other information you think is relevant -->
Should I rename the motion cancellation methods like so:
- `isInMotion()` -> `isInMovement()`
- `cancelMotion()` -> `cancelMovement()`
- etc.

I noticed that `isInMotion()` could be confusing for new users.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: b9f8e03eac9be8b6b9017add74aa64335f6f6f85 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7435662916)
- via manual download: [LemLib@0.5.0-rc.5+b9f8e0.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1152154455.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.5+b9f8e0.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1152154455.zip;
pros c fetch LemLib@0.5.0-rc.5+b9f8e0.zip;
pros c apply LemLib@0.5.0-rc.5+b9f8e0;
rm LemLib@0.5.0-rc.5+b9f8e0.zip;
```