### PR TITLE
style: :art: remove newline at the top of some files

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <functional>

--- a/include/lemlib/chassis/odom.hpp
+++ b/include/lemlib/chassis/odom.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "lemlib/chassis/chassis.hpp"

--- a/include/lemlib/chassis/trackingWheel.hpp
+++ b/include/lemlib/chassis/trackingWheel.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "pros/motors.hpp"

--- a/include/lemlib/util.hpp
+++ b/include/lemlib/util.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <vector>

--- a/src/lemlib/chassis/odom.cpp
+++ b/src/lemlib/chassis/odom.cpp
@@ -1,4 +1,3 @@
-
 // The implementation below is mostly based off of
 // the document written by 5225A (Pilons)
 // Here is a link to the original document

--- a/src/lemlib/chassis/pursuit.cpp
+++ b/src/lemlib/chassis/pursuit.cpp
@@ -1,4 +1,3 @@
-
 // The implementation below is mostly based off of
 // the document written by Dawgma
 // Here is a link to the original document

--- a/src/lemlib/chassis/trackingWheel.cpp
+++ b/src/lemlib/chassis/trackingWheel.cpp
@@ -1,4 +1,3 @@
-
 #include <math.h>
 #include "lemlib/chassis/trackingWheel.hpp"
 #include "lemlib/util.hpp"

--- a/src/lemlib/pose.cpp
+++ b/src/lemlib/pose.cpp
@@ -1,4 +1,3 @@
-
 #define FMT_HEADER_ONLY
 #include "fmt/core.h"
 


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Cleans up annoying newlines at the top of some of the files

used this command:
```
find | grep -v "^\./\." | grep -Ev "^./include/[^l][^e][^m][^l][^i][^b]" | grep -v "bin" | grep -v "firmware" | xargs -I {} perl -0777 -i -pe 's/^\x0D?\x0A?//s' {}
```

#### Motivation
<!-- Why are you making this pull request? -->

It bugs me.

#### Test Plan
<!-- How did you test / plan to test this pull request? -->
N/A
#### Additional Notes
<!-- Add any other information you think is relevant -->

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 566a19310c9d6f5f8c334bcddb7ccfbe57d962df -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7485190536)
- via manual download: [LemLib@0.5.0-rc.5+566a19.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1161613244.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.5+566a19.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1161613244.zip;
pros c fetch LemLib@0.5.0-rc.5+566a19.zip;
pros c apply LemLib@0.5.0-rc.5+566a19;
rm LemLib@0.5.0-rc.5+566a19.zip;
```