### PR TITLE
Change members in Chassis and PID to protected instead of private

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -348,11 +348,10 @@ class Chassis {
          * @brief Dequeues this motion and permits queued task to run
          */
         void endMotion();
-    private:
+
         bool motionRunning = false;
         bool motionQueued = false;
 
-        pros::Mutex mutex;
         float distTravelled = 0;
 
         ControllerSettings lateralSettings;
@@ -367,5 +366,7 @@ class Chassis {
         ExitCondition lateralSmallExit;
         ExitCondition angularLargeExit;
         ExitCondition angularSmallExit;
+    private:
+        pros::Mutex mutex;
 };
 } // namespace lemlib

--- a/include/lemlib/exitcondition.hpp
+++ b/include/lemlib/exitcondition.hpp
@@ -33,7 +33,7 @@ class ExitCondition {
          *
          */
         void reset();
-    private:
+    protected:
         const float range;
         const int time;
         int startTime = -1;

--- a/include/lemlib/pid.hpp
+++ b/include/lemlib/pid.hpp
@@ -27,7 +27,7 @@ class PID {
          *
          */
         void reset();
-    private:
+    protected:
         // gains
         const float kP;
         const float kI;


### PR DESCRIPTION
#### Summary
Change all private members except `mutex` in to be protected in Chassis, change all private members to be protected in PID

#### Motivation
As it currently stands, it is almost impossible to extend the Chassis or PID classes by subclassing them because a large portion of their members are private rather than protected. This makes it impossible to implement any functionality which needs access to these internals.

#### Test Plan
N/A (no code functionality is changed)


<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 19d208a45688d59de80d7dd48061116edbfb6fdc -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7551089068)
- via manual download: [LemLib@0.5.0-rc.5+19d208.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1174175265.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.5+19d208.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1174175265.zip;
pros c fetch LemLib@0.5.0-rc.5+19d208.zip;
pros c apply LemLib@0.5.0-rc.5+19d208;
rm LemLib@0.5.0-rc.5+19d208.zip;
```