### PR TITLE
Add method for relative movement to chassis

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -281,6 +281,9 @@ class Chassis {
          * @param async whether the function should be run asynchronously. true by default
          */
         void moveToPoint(float x, float y, int timeout, MoveToPointParams params = {}, bool async = true);
+        
+        void moveDistance(float inches, int timeout, MoveToPointParams params = {}, bool async = true);
+
         /**
          * @brief Move the chassis along a path
          *

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -281,7 +281,15 @@ class Chassis {
          * @param async whether the function should be run asynchronously. true by default
          */
         void moveToPoint(float x, float y, int timeout, MoveToPointParams params = {}, bool async = true);
-        
+
+        /**
+         * @brief Move the chassis forward for some number of inches
+         *
+         * @param inches the number of inches to move
+         * @param timeout longest time the robot can spend moving
+         * @param params struct to simulate named parameters
+         * @param async whether the function should be run asynchronously. true by default
+         */
         void moveDistance(float inches, int timeout, MoveToPointParams params = {}, bool async = true);
 
         /**

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -577,6 +577,14 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
     this->endMotion();
 }
 
+/**
+ * @brief Move the chassis forward for some number of inches
+ *
+ * @param inches the number of inches to move
+ * @param timeout longest time the robot can spend moving
+ * @param params struct to simulate named parameters
+ * @param async whether the function should be run asynchronously. true by default
+ */
 void lemlib::Chassis::moveDistance(float inches, int timeout, MoveToPointParams params, bool async) {
     // Compute the target pose by
     // 1. create a pose at (0, inches), equivalent to n inches forward at 0 degrees from (0, 0),

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -576,3 +576,17 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
     distTravelled = -1;
     this->endMotion();
 }
+
+void lemlib::Chassis::moveDistance(float inches, int timeout, MoveToPointParams params, bool async) {
+    // Compute the target pose by
+    // 1. create a pose at (0, inches), equivalent to n inches forward at 0 degrees from (0, 0),
+    // 2. rotating it by the current heading so it is n inches forward at the robot heading, and
+    // 3. adding it to the current pose
+    Pose start = getPose(true, true);
+    Pose offset = Pose(0, inches).rotate(start.theta);
+    Pose target = start + offset;
+
+    // Delegate to moveToPoint now that we have a target pose
+    // moveToPoint is used over moveToPose here because there should not be any need for turning
+    this->moveToPoint(target.x, target.y, timeout, params, async);
+}


### PR DESCRIPTION
#### Summary
Adds a thin wrapper `moveDistance` around `moveToPoint` for relative movement. 

#### Motivation
Relative movements are a highly requested feature, especially for small or short movements where using coordinates is overkill and often error prone.

#### Test Plan
I have checked the math, but someone other than me should review it to make sure it looks okay. The function just delegates to `moveToPoint` so there is no new implementation in need of testing.

#### Additional Notes
This PR does not include a `turnToHeading` function because it already exists in PR #127 

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 2ef8ae8a478507c7b682d10ac11e757babbeb5dd -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7565126648)
- via manual download: [LemLib@0.5.0-rc.5+2ef8ae.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1177105670.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.5+2ef8ae.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1177105670.zip;
pros c fetch LemLib@0.5.0-rc.5+2ef8ae.zip;
pros c apply LemLib@0.5.0-rc.5+2ef8ae;
rm LemLib@0.5.0-rc.5+2ef8ae.zip;
```