### PR TITLE
fix: :adhesive_bandage: ignore commit/pr author

### DIFF
--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -42,14 +42,13 @@ jobs:
             const run_id = ${{github.event.workflow_run.id}};
             
             const pull_head_sha = '${{github.event.workflow_run.head_sha}}';
-            const pull_user_id = ${{github.event.sender.id}};
             
             /** @type {{old_body: string}} */
             const {issue_number, old_body} = await (async () => {
               const pulls = await github.rest.pulls.list({owner, repo});
               for await (const {data} of github.paginate.iterator(pulls)) {
                 for (const pull of data) {
-                  if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
+                  if (pull.head.sha === pull_head_sha) {
                     return {issue_number: pull.number, old_body: pull.body};
                   }
                 }


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Removes the check for matching PR author and commit author.

#### Motivation
<!-- Why are you making this pull request? -->
Currently the pr-comment workflow will only work if the commit author and pr author match. This is done to handle the edge case where multiple pr's share the same head branch. In this edge case, only one of the pr's will be updated.

By matching the pr author we can reduce the chance of this edge case, but it also breaks other functionality. 

By ignoring the author, this edge case will be more possible, but it will ensure it still functions when multiple authors contribute to a pr.

More research is needed to eliminate this edge case.

#### Test Plan
<!-- How did you test / plan to test this pull request? -->
- Research solution to edge case
- Test in my fork
#### Additional Notes
<!-- Add any other information you think is relevant -->
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: ebcfb9292a76fe31f0b793824a6981a182a24b3d -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7579137683)
- via manual download: [LemLib@0.5.0-rc.5+ebcfb9.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1179995259.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.5+ebcfb9.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1179995259.zip;
pros c fetch LemLib@0.5.0-rc.5+ebcfb9.zip;
pros c apply LemLib@0.5.0-rc.5+ebcfb9;
rm LemLib@0.5.0-rc.5+ebcfb9.zip;
```