### PR TITLE
Add methods to set the lateral and angular PID gains to Chassis

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -363,20 +363,16 @@ class Chassis {
         /**
          * @brief Set the lateral PID gains
          *
-         * @param kP proportional gain
-         * @param kI integral gain
-         * @param kD derivative gain
+         * @param gains the new PID gains
          */
-        void setLateralGains(float kP, float kI, float kD);
+        void setLateralGains(GainOptions gains);
 
         /**
          * @brief Set angular PID gains
          *
-         * @param kP proportional gain
-         * @param kI integral gain
-         * @param kD derivative gain
+         * @param gains the new PID gains
          */
-        void setAngularGains(float kP, float kI, float kD);
+        void setAngularGains(GainOptions gains);
     protected:
         /**
          * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -361,6 +361,20 @@ class Chassis {
         bool isInMotion() const;
 
         /**
+         * @brief Get the lateral PID gains
+         *
+         * @return gains the current PID gains
+         */
+        Gains getLateralGains();
+
+        /**
+         * @brief Get the angular PID gains
+         *
+         * @return gains the current PID gains
+         */
+        Gains getAngularGains();
+
+        /**
          * @brief Set the lateral PID gains
          *
          * @param gains the new PID gains

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -359,6 +359,9 @@ class Chassis {
          * @return whether a motion is currently running
          */
         bool isInMotion() const;
+
+        void setLateralGains(float kP, float kI, float kD);
+        void setAngularGains(float kP, float kI, float kD);
     protected:
         /**
          * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -360,7 +360,22 @@ class Chassis {
          */
         bool isInMotion() const;
 
+        /**
+         * @brief Set the lateral PID gains
+         *
+         * @param kP proportional gain
+         * @param kI integral gain
+         * @param kD derivative gain
+         */
         void setLateralGains(float kP, float kI, float kD);
+
+        /**
+         * @brief Set angular PID gains
+         *
+         * @param kP proportional gain
+         * @param kI integral gain
+         * @param kD derivative gain
+         */
         void setAngularGains(float kP, float kI, float kD);
     protected:
         /**

--- a/include/lemlib/pid.hpp
+++ b/include/lemlib/pid.hpp
@@ -48,8 +48,8 @@ class PID {
          *
          * @return the current PID gains
          */
-
         Gains getGains();
+
         /**
          * @brief Set the PID gains
          *

--- a/include/lemlib/pid.hpp
+++ b/include/lemlib/pid.hpp
@@ -28,6 +28,13 @@ class PID {
          */
         void reset();
 
+        /**
+         * @brief Set the PID gains
+         *
+         * @param kP proportional gain
+         * @param kI integral gain
+         * @param kD derivative gain
+         */
         void setGains(float kP, float kI, float kD);
     protected:
         // gains

--- a/include/lemlib/pid.hpp
+++ b/include/lemlib/pid.hpp
@@ -1,6 +1,20 @@
 #pragma once
+#include <optional>
 
 namespace lemlib {
+struct GainOptions {
+        std::optional<float> kP = std::nullopt;
+        std::optional<float> kI = std::nullopt;
+        std::optional<float> kD = std::nullopt;
+};
+
+struct Gains {
+        float kP;
+        float kI;
+        float kD;
+        Gains() = delete;
+};
+
 class PID {
     public:
         /**
@@ -14,6 +28,7 @@ class PID {
          */
         PID(float kP, float kI, float kD, float windupRange = 0, bool signFlipReset = false);
 
+        PID(Gains gains, float winupRange = 0, bool signFlipReset = false);
         /**
          * @brief Update the PID
          *
@@ -29,18 +44,21 @@ class PID {
         void reset();
 
         /**
+         * @brief Get the PID gains
+         *
+         * @return the current PID gains
+         */
+
+        Gains getGains();
+        /**
          * @brief Set the PID gains
          *
-         * @param kP proportional gain
-         * @param kI integral gain
-         * @param kD derivative gain
+         * @param gains the new PID gains
          */
-        void setGains(float kP, float kI, float kD);
+        void setGains(GainOptions gains);
     protected:
         // gains
-        float kP;
-        float kI;
-        float kD;
+        Gains gains;
 
         // optimizations
         const float windupRange;

--- a/include/lemlib/pid.hpp
+++ b/include/lemlib/pid.hpp
@@ -27,11 +27,13 @@ class PID {
          *
          */
         void reset();
+
+        void setGains(float kP, float kI, float kD);
     protected:
         // gains
-        const float kP;
-        const float kI;
-        const float kD;
+        float kP;
+        float kI;
+        float kD;
 
         // optimizations
         const float windupRange;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -585,3 +585,11 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
     distTravelled = -1;
     this->endMotion();
 }
+
+void lemlib::Chassis::setLateralGains(float kP, float kI, float kD) {
+    this->lateralPID.setGains(kP, kI, kD);
+}
+
+void lemlib::Chassis::setAngularGains(float kP, float kI, float kD) {
+    this->angularPID.setGains(kP, kI, kD);
+}

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <math.h>
 #include <optional>
+#include "lemlib/pid.hpp"
 #include "pros/motors.hpp"
 #include "pros/misc.hpp"
 #include "pros/rtos.h"
@@ -589,17 +590,13 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
 /**
  * @brief Set the lateral PID gains
  *
- * @param kP proportional gain
- * @param kI integral gain
- * @param kD derivative gain
+ * @param gains the new PID gains
  */
-void lemlib::Chassis::setLateralGains(float kP, float kI, float kD) { this->lateralPID.setGains(kP, kI, kD); }
+void lemlib::Chassis::setLateralGains(lemlib::GainOptions gains) { this->lateralPID.setGains(gains); }
 
 /**
  * @brief Set the angular PID gains
  *
- * @param kP proportional gain
- * @param kI integral gain
- * @param kD derivative gain
+ * @param gains the new PID gains
  */
-void lemlib::Chassis::setAngularGains(float kP, float kI, float kD) { this->angularPID.setGains(kP, kI, kD); }
+void lemlib::Chassis::setAngularGains(lemlib::GainOptions gains) { this->angularPID.setGains(gains); }

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -586,10 +586,20 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
     this->endMotion();
 }
 
-void lemlib::Chassis::setLateralGains(float kP, float kI, float kD) {
-    this->lateralPID.setGains(kP, kI, kD);
-}
+/**
+ * @brief Set the lateral PID gains
+ *
+ * @param kP proportional gain
+ * @param kI integral gain
+ * @param kD derivative gain
+ */
+void lemlib::Chassis::setLateralGains(float kP, float kI, float kD) { this->lateralPID.setGains(kP, kI, kD); }
 
-void lemlib::Chassis::setAngularGains(float kP, float kI, float kD) {
-    this->angularPID.setGains(kP, kI, kD);
-}
+/**
+ * @brief Set the angular PID gains
+ *
+ * @param kP proportional gain
+ * @param kI integral gain
+ * @param kD derivative gain
+ */
+void lemlib::Chassis::setAngularGains(float kP, float kI, float kD) { this->angularPID.setGains(kP, kI, kD); }

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -588,6 +588,20 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
 }
 
 /**
+ * @brief Get the lateral PID gains
+ *
+ * @return gains the current PID gains
+ */
+lemlib::Gains lemlib::Chassis::getLateralGains() { return this->lateralPID.getGains(); }
+
+/**
+ * @brief Get the angular PID gains
+ *
+ * @return gains the current PID gains
+ */
+lemlib::Gains lemlib::Chassis::getAngularGains() { return this->angularPID.getGains(); }
+
+/**
  * @brief Set the lateral PID gains
  *
  * @param gains the new PID gains

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -26,16 +26,16 @@ PID::PID(float kP, float kI, float kD, float windupRange, bool signFlipReset)
  */
 float PID::update(const float error) {
     // calculate integral
-    integral += error;
-    if (sgn(error) != sgn((prevError))) integral = 0;
-    if (fabs(error) > windupRange) integral = 0;
+    this->integral += error;
+    if (sgn(error) != sgn((this->prevError))) this->integral = 0;
+    if (fabs(error) > this->windupRange) this->integral = 0;
 
     // calculate derivative
-    const float derivative = error - prevError;
-    prevError = error;
+    const float derivative = error - this->prevError;
+    this->prevError = error;
 
     // calculate output
-    return error * kP + integral * kI + derivative * kD;
+    return error * this->kP + integral * this->kI + derivative * this->kD;
 }
 
 /**
@@ -43,7 +43,13 @@ float PID::update(const float error) {
  *
  */
 void PID::reset() {
-    integral = 0;
-    prevError = 0;
+    this->integral = 0;
+    this->prevError = 0;
+}
+
+void PID::setGains(float kP, float kI, float kD) {
+    this->kP = kP;
+    this->kI = kI;
+    this->kD = kD;
 }
 } // namespace lemlib

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -47,6 +47,13 @@ void PID::reset() {
     this->prevError = 0;
 }
 
+/**
+ * @brief Set the PID gains
+ *
+ * @param kP proportional gain
+ * @param kI integral gain
+ * @param kD derivative gain
+ */
 void PID::setGains(float kP, float kI, float kD) {
     this->kP = kP;
     this->kI = kI;

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -2,6 +2,7 @@
 #include "util.hpp"
 
 namespace lemlib {
+
 /**
  * @brief Construct a new PID
  *
@@ -12,9 +13,19 @@ namespace lemlib {
  * @param signFlipReset whether to reset integral when sign of error flips
  */
 PID::PID(float kP, float kI, float kD, float windupRange, bool signFlipReset)
-    : kP(kP),
-      kI(kI),
-      kD(kD),
+    : gains(Gains {kP, kI, kD}),
+      windupRange(windupRange),
+      signFlipReset(signFlipReset) {}
+
+/**
+ * @brief Construct a new PID
+ *
+ * @param gains The PID gains
+ * @param windupRange integral anti windup range
+ * @param signFlipReset whether to reset integral when sign of error flips
+ */
+PID::PID(Gains gains, float windupRange, bool signFlipReset)
+    : gains(gains),
       windupRange(windupRange),
       signFlipReset(signFlipReset) {}
 
@@ -35,7 +46,7 @@ float PID::update(const float error) {
     this->prevError = error;
 
     // calculate output
-    return error * this->kP + integral * this->kI + derivative * this->kD;
+    return error * this->gains.kP + integral * this->gains.kI + derivative * this->gains.kD;
 }
 
 /**
@@ -47,17 +58,20 @@ void PID::reset() {
     this->prevError = 0;
 }
 
+Gains PID::getGains() { return this->gains; }
+
 /**
  * @brief Set the PID gains
  *
- * @param kP proportional gain
- * @param kI integral gain
- * @param kD derivative gain
+ * @param gains The new PID gains
  */
-void PID::setGains(float kP, float kI, float kD) {
-    this->kP = kP;
-    this->kI = kI;
-    this->kD = kD;
+void PID::setGains(GainOptions gains) {
+    if (this->gains.kP) { this->gains.kP = *gains.kP; }
+
+    if (this->gains.kI) { this->gains.kI = *gains.kI; }
+
+    if (this->gains.kD) { this->gains.kD = *gains.kD; }
+
     this->reset();
 }
 } // namespace lemlib

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -58,5 +58,6 @@ void PID::setGains(float kP, float kI, float kD) {
     this->kP = kP;
     this->kI = kI;
     this->kD = kD;
+    this->reset();
 }
 } // namespace lemlib


### PR DESCRIPTION
#### Summary
Adds a `setGains` method to the PID class which updates the kP, kI, and kD gains as well as a `setLateralGains` and `setAngularGains` to the chassis which set the gains for the lateral and angular PID respectively.

#### Motivation
It is occasionally useful to be able to change the PID gains at runtime, especially for implementing things like gain scheduling.



<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 3cd4fc1b76e91b8fde059d6c45a24b82a9e498b5 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/7578261072)
- via manual download: [LemLib@0.5.0-rc.5+3cd4fc.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1179844958.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.5+3cd4fc.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1179844958.zip;
pros c fetch LemLib@0.5.0-rc.5+3cd4fc.zip;
pros c apply LemLib@0.5.0-rc.5+3cd4fc;
rm LemLib@0.5.0-rc.5+3cd4fc.zip;
```