### PR TITLE
Implement resetLocalPosition

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -396,7 +396,7 @@ class Chassis {
          * @brief Resets the x and y position of the robot
          * without interfering with the heading.
          */
-         void resetLocalPosition();
+        void resetLocalPosition();
     protected:
         /**
          * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -392,6 +392,11 @@ class Chassis {
          * @return whether a motion is currently running
          */
         bool isInMotion() const;
+        /**
+         * @brief Resets the x and y position of the robot
+         * without interfering with the heading.
+         */
+         void resetLocalPosition();
     protected:
         /**
          * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -232,6 +232,15 @@ void lemlib::Chassis::cancelAllMotions() {
 bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
 
 /**
+ * @brief Resets the x and y position of the robot
+ * without interfering with the heading.
+ */
+void lemlib::Chassis::resetLocalPosition() { 
+    float theta = this->getPose().theta;
+    lemlib::setPose(lemlib::Pose(0, 0, theta), false);
+}
+
+/**
  * @brief Sets the brake mode of the drivetrain motors
  *
  */

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -235,7 +235,7 @@ bool lemlib::Chassis::isInMotion() const { return this->motionRunning; }
  * @brief Resets the x and y position of the robot
  * without interfering with the heading.
  */
-void lemlib::Chassis::resetLocalPosition() { 
+void lemlib::Chassis::resetLocalPosition() {
     float theta = this->getPose().theta;
     lemlib::setPose(lemlib::Pose(0, 0, theta), false);
 }


### PR DESCRIPTION
#### Summary
Implements `chassis.resetLocalPosition();`
Resets the x and y values of the robot without interfering with heading. Useful for quick resets, instead of having to write `chassis.setPose(0, 0, chassis.getPose().theta);` multiple times.

#### Motivation
Requested by Jamie

#### Test Plan
I don't have a working robot to test on right now. I don't think this needs testing, but if it does I can test it tomorrow.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 743c92e849db3424fc34dfa8ef75c209f4b02d55 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8043593639)
- via manual download: [LemLib@0.5.0-rc.6+743c92.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1273946506.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.6+743c92.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1273946506.zip;
pros c fetch LemLib@0.5.0-rc.6+743c92.zip;
pros c apply LemLib@0.5.0-rc.6+743c92;
rm LemLib@0.5.0-rc.6+743c92.zip;
```