### PR TITLE
✨ Driver Control Improvements

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -381,31 +381,39 @@ class Chassis {
          */
         void follow(const asset& path, float lookahead, int timeout, bool forwards = true, bool async = true);
         /**
-         * @brief Control the robot during the driver control period using the tank drive control scheme. In
-         * this control scheme one joystick axis controls one half of the robot, and another joystick axis
-         * controls another.
-         * @param left speed of the left side of the drivetrain. Takes an input from -127 to 127.
-         * @param right speed of the right side of the drivetrain. Takes an input from -127 to 127.
-         */
-        void tank(int left, int right);
-        /**
-         * @brief Control the robot during the driver using the arcade drive control scheme. In this control
-         * scheme one joystick axis controls the forwards and backwards movement of the robot, while the other
-         * joystick axis controls the robot's turning
+         * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
+         * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis
+
+         * controls  the robot's turning
          * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
          * @param turn speed to turn. Takes an input from -127 to 127.
+         * @param disableDriveCurve whether to disable the drive curve or not. If disabled, uses a linear curve with no
+         * deadzone or minimum power
          */
-        void arcade(int throttle, int turn);
+        void tank(int left, int right, bool disableDriveCurve = false);
         /**
-         * @brief Control the robot during the driver using the curvature drive control scheme. This control
-         * scheme is very similar to arcade drive, except the second joystick axis controls the radius of the
-         * curve that the drivetrain makes, rather than the speed. This means that the driver can accelerate in
-         * a turn without changing the radius of that turn. This control scheme defaults to arcade when forward
-         * is zero.
+         * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
+         * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis
+         * controls the robot's turning
+         *
          * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
          * @param turn speed to turn. Takes an input from -127 to 127.
+         * @param disableDriveCurve whether to disable the drive curve or not. If disabled, uses a linear curve with no
+         * deadzone or minimum power
          */
-        void curvature(int throttle, int turn);
+        void arcade(int throttle, int turn, bool disableDriveCurve = false);
+        /**
+         * @brief Control the robot during the driver using the curvature drive control scheme. This control scheme is
+         * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the
+         * drivetrain makes, rather than the speed. This means that the driver can accelerate in a turn without changing
+         * the radius of that turn. This control scheme defaults to arcade when forward is zero.
+         *
+         * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
+         * @param turn speed to turn. Takes an input from -127 to 127.
+         * @param disableDriveCurve whether to disable the drive curve or not. If disabled, uses a linear curve with no
+         * deadzone or minimum power
+         */
+        void curvature(int throttle, int turn, bool disableDriveCurve = false);
         /**
          * @brief Cancels the currently running motion.
          * If there is a queued motion, then that queued motion will run.

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -245,10 +245,14 @@ class Chassis {
          * @param lateralSettings settings for the lateral controller
          * @param angularSettings settings for the angular controller
          * @param sensors sensors to be used for odometry
-         * @param opcontrolSettings settings for driver control. defaultOpcontrolSettings by default
+         * @param throttleOpcontrolSettings settings for driver control when using throttle. defaultOpcontrolSettings by
+         * default
+         * @param turnOpcontrolSettings settings for driver control when using turn. defaultOpcontrolSettings by
+         * default
          */
         Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
-                OdomSensors sensors, OpcontrolSettings opcontrolSettings = defaultOpcontrolSettings);
+                OdomSensors sensors, OpcontrolSettings throttleOpcontrolSettings = defaultOpcontrolSettings,
+                OpcontrolSettings turnOpcontrolSettings = defaultOpcontrolSettings);
         /**
          * @brief Calibrate the chassis sensors
          *
@@ -440,7 +444,8 @@ class Chassis {
         ControllerSettings angularSettings;
         Drivetrain drivetrain;
         OdomSensors sensors;
-        OpcontrolSettings opcontrolSettings;
+        OpcontrolSettings throttleOpcontrolSettings;
+        OpcontrolSettings turnOpcontrolSettings;
 
         PID lateralPID;
         PID angularPID;

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -17,7 +17,7 @@ namespace lemlib {
  * @param input The control input in the range [-127, 127].
  * @param inputDeadband range where inputs will be ignored (outputs 0), which can be optionally ignored
  * @param minOutput the minimum output required to make the drivetrain move, which can be optionally ignored
- * @param scale The scaling factor, which can be optionally ignored.
+ * @param curve how curved the graph is, which can be optionally ignored.
  * @return The new value to be used.
  */
 typedef std::function<float(float, float, float, float)> DriveCurveFunction_t;
@@ -30,10 +30,10 @@ typedef std::function<float(float, float, float, float)> DriveCurveFunction_t;
  * @param input value from -127 to 127
  * @param inputDeadband range where inputs will be ignored (outputs 0), which can be optionally ignored
  * @param minOutput the minimum output required to make the drivetrain move, which can be optionally ignored
- * @param scale how steep the curve should be.
+ * @param curve how steep the curve should be.
  * @return The new value to be used.
  */
-float expoDriveCurve(float input, float inputDeadband = 0, float minOutput = 0, float scale = 0);
+float expoDriveCurve(float input, float inputDeadband = 0, float minOutput = 0, float curve = 0);
 
 /**
  * @brief Struct containing all the sensors used for odometry
@@ -130,19 +130,20 @@ struct Drivetrain {
 
 /**
  * @brief Struct containing settings for driver control
- * 
+ *
  */
 struct OpcontrolSettings {
         /**
          * @brief These settings are used to optimize drivetrain control during Operator control.
          *
          * https://www.desmos.com/calculator/umicbymbnl
-         * 
+         *
          * @param deadband range where inputs will be ignored
          * @param minOutput minimum output required to make the drivetrain move
          * @param curve how curved the graph is. Set to 0 for linear
          */
-        OpcontrolSettings(float deadband, float minOutput, float curve, DriveCurveFunction_t driveCurve = &expoDriveCurve);
+        OpcontrolSettings(float deadband, float minOutput, float curve,
+                          DriveCurveFunction_t driveCurve = &expoDriveCurve);
         float deadband;
         float minOutput;
         float curve;

--- a/include/lemlib/driveCurve.hpp
+++ b/include/lemlib/driveCurve.hpp
@@ -1,0 +1,32 @@
+namespace lemlib {
+
+class DriveCurve {
+    public:
+        virtual float curve(float input) = 0;
+};
+
+class ExpoDriveCurve : public DriveCurve {
+    public:
+        /**
+         * @brief Construct a new Expo Drive Curve object
+         *
+         * see https://www.desmos.com/calculator/umicbymbnl for interactive graph
+         *
+         * @param deadband range where input is considered to be input
+         * @param minOutput the minimum output that can be returned
+         * @param curve how "curved" the graph is
+         */
+        ExpoDriveCurve(float deadband, float minOutput, float curve);
+        /**
+         * @brief curve an input
+         *
+         * @param input the input to curve
+         * @return float the curved output
+         */
+        float curve(float input);
+    private:
+        const float deadband = 0;
+        const float minOutput = 0;
+        const float curveGain = 1;
+};
+} // namespace lemlib

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -58,20 +58,17 @@ lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* r
  * @param lateralSettings settings for the lateral controller
  * @param angularSettings settings for the angular controller
  * @param sensors sensors to be used for odometry
- * @param throttleOpcontrolSettings settings for driver control when using throttle. defaultOpcontrolSettings by
- * default
- * @param turnOpcontrolSettings settings for driver control when using turn. defaultOpcontrolSettings by
- * default
+ * @param throttleCurve curve applied to throttle input during driver control
+ * @param turnCurve curve applied to steer input during driver control
  */
 lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
-                         OdomSensors sensors, OpcontrolSettings throttleOpcontrolSettings,
-                         OpcontrolSettings turnOpcontrolSettings)
+                         OdomSensors sensors, DriveCurve* throttleCurve, DriveCurve* steerCurve)
     : drivetrain(drivetrain),
       lateralSettings(linearSettings),
       angularSettings(angularSettings),
       sensors(sensors),
-      throttleOpcontrolSettings(throttleOpcontrolSettings),
-      turnOpcontrolSettings(turnOpcontrolSettings),
+      throttleCurve(throttleCurve),
+      steerCurve(steerCurve),
       lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD, lateralSettings.windupRange, true),
       angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
       lateralLargeExit(lateralSettings.largeError, lateralSettings.largeErrorTimeout),

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <math.h>
 #include <optional>
-#include "lemlib/logger/baseSink.hpp"
 #include "pros/motors.hpp"
 #include "pros/misc.hpp"
 #include "pros/rtos.h"
@@ -59,15 +58,15 @@ lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* r
  * @param lateralSettings settings for the lateral controller
  * @param angularSettings settings for the angular controller
  * @param sensors sensors to be used for odometry
- * @param driveCurve drive curve to be used. defaults to `defaultDriveCurve`
+ * @param opcontrolSettings settings for driver control. defaultOpcontrolSettings by default
  */
-lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings lateralSettings, ControllerSettings angularSettings,
-                         OdomSensors sensors, DriveCurveFunction_t driveCurve)
+lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
+                         OdomSensors sensors, OpcontrolSettings opcontrolSettings)
     : drivetrain(drivetrain),
-      lateralSettings(lateralSettings),
+      lateralSettings(linearSettings),
       angularSettings(angularSettings),
       sensors(sensors),
-      driveCurve(driveCurve),
+      opcontrolSettings(opcontrolSettings),
       lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD, lateralSettings.windupRange, true),
       angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
       lateralLargeExit(lateralSettings.largeError, lateralSettings.largeErrorTimeout),

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -58,15 +58,20 @@ lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* r
  * @param lateralSettings settings for the lateral controller
  * @param angularSettings settings for the angular controller
  * @param sensors sensors to be used for odometry
- * @param opcontrolSettings settings for driver control. defaultOpcontrolSettings by default
+ * @param throttleOpcontrolSettings settings for driver control when using throttle. defaultOpcontrolSettings by
+ * default
+ * @param turnOpcontrolSettings settings for driver control when using turn. defaultOpcontrolSettings by
+ * default
  */
 lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
-                         OdomSensors sensors, OpcontrolSettings opcontrolSettings)
+                         OdomSensors sensors, OpcontrolSettings throttleOpcontrolSettings,
+                         OpcontrolSettings turnOpcontrolSettings)
     : drivetrain(drivetrain),
       lateralSettings(linearSettings),
       angularSettings(angularSettings),
       sensors(sensors),
-      opcontrolSettings(opcontrolSettings),
+      throttleOpcontrolSettings(throttleOpcontrolSettings),
+      turnOpcontrolSettings(turnOpcontrolSettings),
       lateralPID(lateralSettings.kP, lateralSettings.kI, lateralSettings.kD, lateralSettings.windupRange, true),
       angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
       lateralLargeExit(lateralSettings.largeError, lateralSettings.largeErrorTimeout),

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -33,7 +33,7 @@ OpcontrolSettings defaultOpcontrolSettings = OpcontrolSettings(0, 0, 0);
  * @return The new value to be used.
  */
 float expoDriveCurve(float input, float inputDeadband, float minOutput, float curve) {
-    if (fabs(input) < inputDeadband) return 0;
+    if (fabs(input) <= inputDeadband) return 0;
     if (curve < 1) curve = 1;
     // g is the output of g(x) as defined in the Desmos graph
     const float g = fabs(input) - inputDeadband;

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -4,47 +4,7 @@
 
 namespace lemlib {
 
-/**
- * @brief These settings are used to optimize drivetrain control during Operator control.
- *
- * https://www.desmos.com/calculator/umicbymbnl
- *
- * @param deadband range where inputs will be ignored
- * @param minOutput minimum output required to make the drivetrain move
- * @param curve how curved the graph is. Set to 0 for linear
- */
-OpcontrolSettings::OpcontrolSettings(float deadband, float minOutput, float curve, DriveCurveFunction_t driveCurve)
-    : deadband(deadband),
-      minOutput(minOutput),
-      curve(curve),
-      driveCurve(driveCurve) {}
-
-OpcontrolSettings defaultOpcontrolSettings = OpcontrolSettings(0, 0, 0);
-
-/**
- * @brief Exponential drive curve. Allows for fine control at low speeds while maintaining the same maximum speed.
- *
- * Interactive Graph: https://www.desmos.com/calculator/umicbymbnl
- *
- * @param input value from -127 to 127
- * @param inputDeadband range where inputs will be ignored (outputs 0), which can be optionally ignored
- * @param minOutput the minimum output required to make the drivetrain move, which can be optionally ignored
- * @param curve how steep the curve should be.
- * @return The new value to be used.
- */
-float expoDriveCurve(float input, float inputDeadband, float minOutput, float curve) {
-    if (fabs(input) <= inputDeadband) return 0;
-    if (curve < 1) curve = 1;
-    // g is the output of g(x) as defined in the Desmos graph
-    const float g = fabs(input) - inputDeadband;
-    // g127 is the output of g(127) as defined in the Desmos graph
-    const float g127 = 127 - inputDeadband;
-    // i is the output of i(x) as defined in the Desmos graph
-    const float i = pow(curve, g - 127) * g * sgn(input);
-    // i127 is the output of i(127) as defined in the Desmos graph
-    const float i127 = pow(curve, g127 - 127) * g127;
-    return (127.0 - minOutput) / (127) * i * 127 / i127 + minOutput * sgn(input);
-}
+ExpoDriveCurve defaultDriveCurve = ExpoDriveCurve(0, 0, 1);
 
 /**
  * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
@@ -61,12 +21,8 @@ void Chassis::tank(int left, int right, bool disableDriveCurve) {
         drivetrain.leftMotors->move(left);
         drivetrain.rightMotors->move(right);
     } else {
-        drivetrain.leftMotors->move(throttleOpcontrolSettings.driveCurve(left, throttleOpcontrolSettings.deadband,
-                                                                         throttleOpcontrolSettings.minOutput,
-                                                                         throttleOpcontrolSettings.curve));
-        drivetrain.rightMotors->move(throttleOpcontrolSettings.driveCurve(right, throttleOpcontrolSettings.deadband,
-                                                                          throttleOpcontrolSettings.minOutput,
-                                                                          throttleOpcontrolSettings.curve));
+        drivetrain.leftMotors->move(throttleCurve->curve(left));
+        drivetrain.rightMotors->move(throttleCurve->curve(right));
     }
 }
 
@@ -83,11 +39,8 @@ void Chassis::tank(int left, int right, bool disableDriveCurve) {
 void Chassis::arcade(int throttle, int turn, bool disableDriveCurve) {
     // use drive curves if they have not been disabled
     if (!disableDriveCurve) {
-        throttle =
-            throttleOpcontrolSettings.driveCurve(throttle, throttleOpcontrolSettings.deadband,
-                                                 throttleOpcontrolSettings.minOutput, throttleOpcontrolSettings.curve);
-        turn = turnOpcontrolSettings.driveCurve(turn, turnOpcontrolSettings.deadband, turnOpcontrolSettings.minOutput,
-                                                turnOpcontrolSettings.curve);
+        throttle = throttleCurve->curve(throttle);
+        turn = throttleCurve->curve(turn);
     }
     int leftPower = throttle + turn;
     int rightPower = throttle - turn;
@@ -122,11 +75,8 @@ void Chassis::curvature(int throttle, int turn, bool disableDriveCurve) {
 
     // use drive curves if they have not been disabled
     if (!disableDriveCurve) {
-        throttle =
-            throttleOpcontrolSettings.driveCurve(throttle, throttleOpcontrolSettings.deadband,
-                                                 throttleOpcontrolSettings.minOutput, throttleOpcontrolSettings.curve);
-        turn = turnOpcontrolSettings.driveCurve(turn, turnOpcontrolSettings.deadband, turnOpcontrolSettings.minOutput,
-                                                turnOpcontrolSettings.curve);
+        throttle = throttleCurve->curve(throttle);
+        turn = throttleCurve->curve(turn);
     }
 
     float leftPower = throttle + (std::fabs(throttle) * turn / 127.0);

--- a/src/lemlib/chassis/opcontrol.cpp
+++ b/src/lemlib/chassis/opcontrol.cpp
@@ -50,31 +50,45 @@ float expoDriveCurve(float input, float inputDeadband, float minOutput, float cu
  * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
  * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis
  * controls  the robot's turning
+ *
  * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
  * @param turn speed to turn. Takes an input from -127 to 127.
+ * @param disableDriveCurve whether to disable the drive curve or not. If disabled, uses a linear curve with no
+ * deadzone or minimum power
  */
-void Chassis::tank(int left, int right) {
-    drivetrain.leftMotors->move(throttleOpcontrolSettings.driveCurve(left, throttleOpcontrolSettings.deadband,
-                                                                     throttleOpcontrolSettings.minOutput,
-                                                                     throttleOpcontrolSettings.curve));
-    drivetrain.rightMotors->move(throttleOpcontrolSettings.driveCurve(right, throttleOpcontrolSettings.deadband,
-                                                                      throttleOpcontrolSettings.minOutput,
-                                                                      throttleOpcontrolSettings.curve));
+void Chassis::tank(int left, int right, bool disableDriveCurve) {
+    if (disableDriveCurve) {
+        drivetrain.leftMotors->move(left);
+        drivetrain.rightMotors->move(right);
+    } else {
+        drivetrain.leftMotors->move(throttleOpcontrolSettings.driveCurve(left, throttleOpcontrolSettings.deadband,
+                                                                         throttleOpcontrolSettings.minOutput,
+                                                                         throttleOpcontrolSettings.curve));
+        drivetrain.rightMotors->move(throttleOpcontrolSettings.driveCurve(right, throttleOpcontrolSettings.deadband,
+                                                                          throttleOpcontrolSettings.minOutput,
+                                                                          throttleOpcontrolSettings.curve));
+    }
 }
 
 /**
  * @brief Control the robot during the driver using the arcade drive control scheme. In this control scheme one
  * joystick axis controls the forwards and backwards movement of the robot, while the other joystick axis
  * controls the robot's turning
+ *
  * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
  * @param turn speed to turn. Takes an input from -127 to 127.
+ * @param disableDriveCurve whether to disable the drive curve or not. If disabled, uses a linear curve with no
+ * deadzone or minimum power
  */
-void Chassis::arcade(int throttle, int turn) {
-    throttle =
-        throttleOpcontrolSettings.driveCurve(throttle, throttleOpcontrolSettings.deadband,
-                                             throttleOpcontrolSettings.minOutput, throttleOpcontrolSettings.curve);
-    turn = turnOpcontrolSettings.driveCurve(turn, turnOpcontrolSettings.deadband, turnOpcontrolSettings.minOutput,
-                                            turnOpcontrolSettings.curve);
+void Chassis::arcade(int throttle, int turn, bool disableDriveCurve) {
+    // use drive curves if they have not been disabled
+    if (!disableDriveCurve) {
+        throttle =
+            throttleOpcontrolSettings.driveCurve(throttle, throttleOpcontrolSettings.deadband,
+                                                 throttleOpcontrolSettings.minOutput, throttleOpcontrolSettings.curve);
+        turn = turnOpcontrolSettings.driveCurve(turn, turnOpcontrolSettings.deadband, turnOpcontrolSettings.minOutput,
+                                                turnOpcontrolSettings.curve);
+    }
     int leftPower = throttle + turn;
     int rightPower = throttle - turn;
     // desaturate output
@@ -93,21 +107,27 @@ void Chassis::arcade(int throttle, int turn) {
  * very similar to arcade drive, except the second joystick axis controls the radius of the curve that the
  * drivetrain makes, rather than the speed. This means that the driver can accelerate in a turn without changing
  * the radius of that turn. This control scheme defaults to arcade when forward is zero.
+ *
  * @param throttle speed to move forward or backward. Takes an input from -127 to 127.
  * @param turn speed to turn. Takes an input from -127 to 127.
+ * @param disableDriveCurve whether to disable the drive curve or not. If disabled, uses a linear curve with no
+ * deadzone or minimum power
  */
-void Chassis::curvature(int throttle, int turn) {
+void Chassis::curvature(int throttle, int turn, bool disableDriveCurve) {
     // If we're not moving forwards change to arcade drive
     if (throttle == 0) {
-        arcade(throttle, turn);
+        arcade(throttle, turn, disableDriveCurve);
         return;
     }
 
-    throttle =
-        throttleOpcontrolSettings.driveCurve(throttle, throttleOpcontrolSettings.deadband,
-                                             throttleOpcontrolSettings.minOutput, throttleOpcontrolSettings.curve);
-    turn = turnOpcontrolSettings.driveCurve(turn, turnOpcontrolSettings.deadband, turnOpcontrolSettings.minOutput,
-                                            turnOpcontrolSettings.curve);
+    // use drive curves if they have not been disabled
+    if (!disableDriveCurve) {
+        throttle =
+            throttleOpcontrolSettings.driveCurve(throttle, throttleOpcontrolSettings.deadband,
+                                                 throttleOpcontrolSettings.minOutput, throttleOpcontrolSettings.curve);
+        turn = turnOpcontrolSettings.driveCurve(turn, turnOpcontrolSettings.deadband, turnOpcontrolSettings.minOutput,
+                                                turnOpcontrolSettings.curve);
+    }
 
     float leftPower = throttle + (std::fabs(throttle) * turn / 127.0);
     float rightPower = throttle - (std::fabs(throttle) * turn / 127.0);

--- a/src/lemlib/driveCurve.cpp
+++ b/src/lemlib/driveCurve.cpp
@@ -11,8 +11,6 @@ ExpoDriveCurve::ExpoDriveCurve(float deadband, float minOutput, float curve)
 /**
  * @brief Exponential drive curve. Allows for fine control at low speeds while maintaining the same maximum speed.
  *
- * Interactive Graph: https://www.desmos.com/calculator/umicbymbnl
- *
  * @param input value from -127 to 127
  * @param inputDeadband range where inputs will be ignored (outputs 0), which can be optionally ignored
  * @param minOutput the minimum output required to make the drivetrain move, which can be optionally ignored

--- a/src/lemlib/driveCurve.cpp
+++ b/src/lemlib/driveCurve.cpp
@@ -1,0 +1,35 @@
+#include "lemlib/driveCurve.hpp"
+#include "lemlib/util.hpp"
+#include <cmath>
+
+namespace lemlib {
+ExpoDriveCurve::ExpoDriveCurve(float deadband, float minOutput, float curve)
+    : deadband(deadband),
+      minOutput(minOutput),
+      curveGain(curve) {}
+
+/**
+ * @brief Exponential drive curve. Allows for fine control at low speeds while maintaining the same maximum speed.
+ *
+ * Interactive Graph: https://www.desmos.com/calculator/umicbymbnl
+ *
+ * @param input value from -127 to 127
+ * @param inputDeadband range where inputs will be ignored (outputs 0), which can be optionally ignored
+ * @param minOutput the minimum output required to make the drivetrain move, which can be optionally ignored
+ * @param curve how steep the curve should be.
+ * @return The new value to be used.
+ */
+float ExpoDriveCurve::curve(float input) {
+    // return 0 if input is within deadzone
+    if (fabs(input) <= deadband) return 0;
+    // g is the output of g(x) as defined in the Desmos graph
+    const float g = fabs(input) - deadband;
+    // g127 is the output of g(127) as defined in the Desmos graph
+    const float g127 = 127 - deadband;
+    // i is the output of i(x) as defined in the Desmos graph
+    const float i = pow(curveGain, g - 127) * g * sgn(input);
+    // i127 is the output of i(127) as defined in the Desmos graph
+    const float i127 = pow(curveGain, g127 - 127) * g127;
+    return (127.0 - minOutput) / (127) * i * 127 / i127 + minOutput * sgn(input);
+}
+} // namespace lemlib

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,7 +75,7 @@ lemlib::OpcontrolSettings opcontrolSettings(3, // joystick deadband out of 127
 );
 
 // create the chassis
-lemlib::Chassis chassis(drivetrain, linearController, angularController, sensors);
+lemlib::Chassis chassis(drivetrain, linearController, angularController, sensors, opcontrolSettings);
 
 /**
  * Runs initialization code. This occurs as soon as the program is started.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,9 +22,9 @@ pros::MotorGroup rightMotors({rF, rM, rB}); // right motor group
 pros::Imu imu(10);
 
 // tracking wheels
-// horizontal tracking wheel encoder. Rotation sensor, port 15, reversed (negative signs don't work due to a pros bug)
+// horizontal tracking wheel encoder. Rotation sensor, port 20, reversed (negative signs don't work due to a pros bug)
 pros::Rotation horizontalEnc(20, true);
-// vertical tracking wheel encoder. Rotation sensor, port 15, reversed (negative signs don't work due to a pros bug)
+// vertical tracking wheel encoder. Rotation sensor, port 11, reversed (negative signs don't work due to a pros bug)
 pros::Rotation verticalEnc(11, true);
 // horizontal tracking wheel. 2.75" diameter, 5.75" offset, back of the robot (negative)
 lemlib::TrackingWheel horizontal(&horizontalEnc, lemlib::Omniwheel::NEW_275, -5.75);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,14 +74,12 @@ lemlib::OdomSensors sensors(&vertical, // vertical tracking wheel 1, set to null
 );
 
 // input curve for throttle input during driver control
-// see https://www.desmos.com/calculator/umicbymbnl for a visualization
 lemlib::ExpoDriveCurve throttleCurve(3, // joystick deadband out of 127
                                      10, // minimum output where drivetrain will move out of 127
                                      1.019 // expo curve gain
 );
 
 // input curve for steer input during driver control
-// see https://www.desmos.com/calculator/umicbymbnl for a visualization
 lemlib::ExpoDriveCurve steerCurve(3, // joystick deadband out of 127
                                   10, // minimum output where drivetrain will move out of 127
                                   1.019 // expo curve gain

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,13 @@ lemlib::OdomSensors sensors(nullptr, // vertical tracking wheel 1, set to null
                             &imu // inertial sensor
 );
 
+// opcontrol settings
+// see https://www.desmos.com/calculator/umicbymbnl for a visualization
+lemlib::OpcontrolSettings opcontrolSettings(3, // joystick deadband out of 127
+10, // minimum output where drivetrain will move out of 127
+1.019 // expo curve gain
+);
+
 // create the chassis
 lemlib::Chassis chassis(drivetrain, linearController, angularController, sensors);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,8 +70,8 @@ lemlib::OdomSensors sensors(nullptr, // vertical tracking wheel 1, set to null
 // opcontrol settings
 // see https://www.desmos.com/calculator/umicbymbnl for a visualization
 lemlib::OpcontrolSettings opcontrolSettings(3, // joystick deadband out of 127
-10, // minimum output where drivetrain will move out of 127
-1.019 // expo curve gain
+                                            10, // minimum output where drivetrain will move out of 127
+                                            1.019 // expo curve gain
 );
 
 // create the chassis

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,23 +73,22 @@ lemlib::OdomSensors sensors(&vertical, // vertical tracking wheel 1, set to null
                             &imu // inertial sensor
 );
 
-// opcontrol settings for throttle
+// input curve for throttle input during driver control
 // see https://www.desmos.com/calculator/umicbymbnl for a visualization
-lemlib::OpcontrolSettings throttleOpcontrolSettings(3, // joystick deadband out of 127
-                                                    10, // minimum output where drivetrain will move out of 127
-                                                    1.019 // expo curve gain
+lemlib::ExpoDriveCurve throttleCurve(3, // joystick deadband out of 127
+                                     10, // minimum output where drivetrain will move out of 127
+                                     1.019 // expo curve gain
 );
 
-// opcontrol settings for turn
+// input curve for steer input during driver control
 // see https://www.desmos.com/calculator/umicbymbnl for a visualization
-lemlib::OpcontrolSettings turnOpcontrolSettings(3, // joystick deadband out of 127
-                                                10, // minimum output where drivetrain will move out of 127
-                                                1.019 // expo curve gain
+lemlib::ExpoDriveCurve steerCurve(3, // joystick deadband out of 127
+                                  10, // minimum output where drivetrain will move out of 127
+                                  1.019 // expo curve gain
 );
 
 // create the chassis
-lemlib::Chassis chassis(drivetrain, linearController, angularController, sensors, throttleOpcontrolSettings,
-                        turnOpcontrolSettings);
+lemlib::Chassis chassis(drivetrain, linearController, angularController, sensors, &throttleCurve, &steerCurve);
 
 /**
  * Runs initialization code. This occurs as soon as the program is started.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,36 +1,42 @@
 #include "main.h"
 #include "lemlib/api.hpp"
+#include "lemlib/chassis/chassis.hpp"
+#include "pros/misc.h"
 
 // controller
 pros::Controller controller(pros::E_CONTROLLER_MASTER);
 
 // drive motors
-pros::Motor lF(-12, pros::E_MOTOR_GEARSET_06); // left front motor. port 12, reversed
-pros::Motor lM(-11, pros::E_MOTOR_GEARSET_06); // left middle motor. port 11, reversed
-pros::Motor lB(-1, pros::E_MOTOR_GEARSET_06); // left back motor. port 1, reversed
-pros::Motor rF(19, pros::E_MOTOR_GEARSET_06); // right front motor. port 2
-pros::Motor rM(20, pros::E_MOTOR_GEARSET_06); // right middle motor. port 11
-pros::Motor rB(9, pros::E_MOTOR_GEARSET_06); // right back motor. port 13
+pros::Motor lF(-5, pros::E_MOTOR_GEARSET_06); // left front motor. port 5, reversed
+pros::Motor lM(4, pros::E_MOTOR_GEARSET_06); // left middle motor. port 4
+pros::Motor lB(-3, pros::E_MOTOR_GEARSET_06); // left back motor. port 3, reversed
+pros::Motor rF(6, pros::E_MOTOR_GEARSET_06); // right front motor. port 6
+pros::Motor rM(-9, pros::E_MOTOR_GEARSET_06); // right middle motor. port 9, reversed
+pros::Motor rB(7, pros::E_MOTOR_GEARSET_06); // right back motor. port 7
 
 // motor groups
 pros::MotorGroup leftMotors({lF, lM, lB}); // left motor group
 pros::MotorGroup rightMotors({rF, rM, rB}); // right motor group
 
 // Inertial Sensor on port 2
-pros::Imu imu(2);
+pros::Imu imu(10);
 
 // tracking wheels
 // horizontal tracking wheel encoder. Rotation sensor, port 15, reversed (negative signs don't work due to a pros bug)
-pros::Rotation horizontalEnc(15, true);
-// horizontal tracking wheel. 2.75" diameter, 3.7" offset, back of the robot (negative)
-lemlib::TrackingWheel horizontal(&horizontalEnc, lemlib::Omniwheel::NEW_275, -3.7);
+pros::Rotation horizontalEnc(20, true);
+// vertical tracking wheel encoder. Rotation sensor, port 15, reversed (negative signs don't work due to a pros bug)
+pros::Rotation verticalEnc(11, true);
+// horizontal tracking wheel. 2.75" diameter, 5.75" offset, back of the robot (negative)
+lemlib::TrackingWheel horizontal(&horizontalEnc, lemlib::Omniwheel::NEW_275, -5.75);
+// vertical tracking wheel. 2.75" diameter, 2.5" offset, left of the robot (negative)
+lemlib::TrackingWheel vertical(&verticalEnc, lemlib::Omniwheel::NEW_275, -2.5);
 
 // drivetrain settings
 lemlib::Drivetrain drivetrain(&leftMotors, // left motor group
                               &rightMotors, // right motor group
                               10, // 10 inch track width
-                              lemlib::Omniwheel::NEW_325, // using new 3.25" omnis
-                              360, // drivetrain rpm is 360
+                              lemlib::Omniwheel::NEW_4, // using new 3.25" omnis
+                              343, // drivetrain rpm is 343
                               2 // chase power is 2. If we had traction wheels, it would have been 8
 );
 
@@ -60,22 +66,30 @@ lemlib::ControllerSettings angularController(2, // proportional gain (kP)
 
 // sensors for odometry
 // note that in this example we use internal motor encoders (IMEs), so we don't pass vertical tracking wheels
-lemlib::OdomSensors sensors(nullptr, // vertical tracking wheel 1, set to null
+lemlib::OdomSensors sensors(&vertical, // vertical tracking wheel 1, set to null
                             nullptr, // vertical tracking wheel 2, set to nullptr as we are using IMEs
                             &horizontal, // horizontal tracking wheel 1
                             nullptr, // horizontal tracking wheel 2, set to nullptr as we don't have a second one
                             &imu // inertial sensor
 );
 
-// opcontrol settings
+// opcontrol settings for throttle
 // see https://www.desmos.com/calculator/umicbymbnl for a visualization
-lemlib::OpcontrolSettings opcontrolSettings(3, // joystick deadband out of 127
-                                            10, // minimum output where drivetrain will move out of 127
-                                            1.019 // expo curve gain
+lemlib::OpcontrolSettings throttleOpcontrolSettings(3, // joystick deadband out of 127
+                                                    10, // minimum output where drivetrain will move out of 127
+                                                    1.019 // expo curve gain
+);
+
+// opcontrol settings for turn
+// see https://www.desmos.com/calculator/umicbymbnl for a visualization
+lemlib::OpcontrolSettings turnOpcontrolSettings(3, // joystick deadband out of 127
+                                                10, // minimum output where drivetrain will move out of 127
+                                                1.019 // expo curve gain
 );
 
 // create the chassis
-lemlib::Chassis chassis(drivetrain, linearController, angularController, sensors, opcontrolSettings);
+lemlib::Chassis chassis(drivetrain, linearController, angularController, sensors, throttleOpcontrolSettings,
+                        turnOpcontrolSettings);
 
 /**
  * Runs initialization code. This occurs as soon as the program is started.
@@ -169,7 +183,7 @@ void opcontrol() {
         int leftY = controller.get_analog(pros::E_CONTROLLER_ANALOG_LEFT_Y);
         int rightX = controller.get_analog(pros::E_CONTROLLER_ANALOG_RIGHT_X);
         // move the chassis with curvature drive
-        chassis.curvature(leftY, rightX);
+        chassis.arcade(leftY, rightX);
         // delay to save resources
         pros::delay(10);
     }


### PR DESCRIPTION
#### Summary
Improves various aspects of driver control

#### Motivation
The current driver control has some limitations:
1. no motor desaturation
2. throttle and turn drive curves are the same
3. no controller deadzone
4. no minimum output

## Implementation
1. Uses motor desaturation algorithm found [here](https://github.com/SizzinSeal/1010N-Spin-Up-Code/blob/1eddc047b13ebe666ae093c23c58564e1cb613c0/src/main.cpp#L70)
2. Added multiple gains that can be passed to the Chassis ctor
3. Added controller deadzone
4. Added drivetrain minimum output

#### Test Plan
- [X] verify alg works by running _a lot_ of test cases
- [X] Drive robot with Arcade
- [X] Drive robot with curvature
- [X] Drive robot with tank

#### Additional Notes
 * During curvature drive tests, turning was inconsistent. It would behave differently based on the initial input values. Tried earlier curvature drive implementations with the same effect. However, this is a bugfix and therefore outside the scope of this PR.
 
 * Interactive graph for drive curves: https://www.desmos.com/calculator/umicbymbnl
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: d205facb004054438c35156985e0c5cb43a083bd -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8485287135)
- via manual download: [LemLib@0.5.0-rc.7+d205fa.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1370517641.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+d205fa.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1370517641.zip;
pros c fetch LemLib@0.5.0-rc.7+d205fa.zip;
pros c apply LemLib@0.5.0-rc.7+d205fa;
rm LemLib@0.5.0-rc.7+d205fa.zip;
```