### PR TITLE
🐛 Fix Debug messages being printed to the terminal by default

### DIFF
--- a/include/lemlib/logger/baseSink.hpp
+++ b/include/lemlib/logger/baseSink.hpp
@@ -201,7 +201,7 @@ class BaseSink {
          */
         virtual fmt::dynamic_format_arg_store<fmt::format_context> getExtraFormattingArgs(const Message& messageInfo);
     private:
-        Level lowestLevel = Level::DEBUG;
+        Level lowestLevel = Level::WARN;
         std::string logFormat;
 
         std::vector<std::shared_ptr<BaseSink>> sinks {};


### PR DESCRIPTION
#### Summary
Debug messages are no longer printed to the terminal by default.

#### Motivation
Terminal gets spammed, most of the time you don't want debug messages. Only when you "debug"

#### Test Plan
- [X] debug messages are printed when lowest level is DEBUG
- [X] debug messages are not printed when lowest level is higher than DEBUG (e.g WARN)
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: d0f1802ade34cf5fcaec006886ea26a53cc1dfb6 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8516230195)
- via manual download: [LemLib@0.5.0-rc.7+d0f180.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1376043952.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+d0f180.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1376043952.zip;
pros c fetch LemLib@0.5.0-rc.7+d0f180.zip;
pros c apply LemLib@0.5.0-rc.7+d0f180;
rm LemLib@0.5.0-rc.7+d0f180.zip;
```