### PR TITLE
Fix spelling inconsistencies in traveled spelling

### DIFF
--- a/docs/tutorials/4_auto_and_tuning.md
+++ b/docs/tutorials/4_auto_and_tuning.md
@@ -107,7 +107,7 @@ The program waits. But what if we want to wait until the robot has moved a certa
 ```c++
 pros::millis(); // returns 0000
 chassis.moveToPose(0, 20, 0, 1000);
-chassis.waitUntil(10); // wait until the chassis has travelled 10 inches
+chassis.waitUntil(10); // wait until the chassis has traveled 10 inches
 pros::millis(); // outputs 500
 chassis.waitUntilDone(); // wait until the movement has been completed
 pros::millis(); // outputs 1000

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -476,7 +476,7 @@ class Chassis {
         bool motionRunning = false;
         bool motionQueued = false;
 
-        float distTravelled = 0;
+        float distTraveled = 0;
 
         ControllerSettings lateralSettings;
         ControllerSettings angularSettings;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -176,7 +176,7 @@ lemlib::Pose lemlib::Chassis::getPose(bool radians, bool standardPos) {
 void lemlib::Chassis::waitUntil(float dist) {
     // do while to give the thread time to start
     do pros::delay(10);
-    while (distTravelled <= dist && distTravelled != -1);
+    while (distTraveled <= dist && distTraveled != -1);
 }
 
 /**
@@ -185,7 +185,7 @@ void lemlib::Chassis::waitUntil(float dist) {
  */
 void lemlib::Chassis::waitUntilDone() {
     do pros::delay(10);
-    while (distTravelled != -1);
+    while (distTraveled != -1);
 }
 
 void lemlib::Chassis::requestMotionStart() {
@@ -270,7 +270,7 @@ void lemlib::Chassis::turnToPoint(float x, float y, int timeout, TurnToPointPara
     float startTheta = getPose().theta;
     std::optional<float> prevDeltaTheta = std::nullopt;
     std::uint8_t compState = pros::competition::get_status();
-    distTravelled = 0;
+    distTraveled = 0;
     Timer timer(timeout);
     angularLargeExit.reset();
     angularSmallExit.reset();
@@ -283,7 +283,7 @@ void lemlib::Chassis::turnToPoint(float x, float y, int timeout, TurnToPointPara
         pose.theta = (params.forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
 
         // update completion vars
-        distTravelled = fabs(angleError(pose.theta, startTheta, false));
+        distTraveled = fabs(angleError(pose.theta, startTheta, false));
 
         deltaX = x - pose.x;
         deltaY = y - pose.y;
@@ -323,7 +323,7 @@ void lemlib::Chassis::turnToPoint(float x, float y, int timeout, TurnToPointPara
     drivetrain.leftMotors->move(0);
     drivetrain.rightMotors->move(0);
     // set distTraveled to -1 to indicate that the function has finished
-    distTravelled = -1;
+    distTraveled = -1;
     this->endMotion();
 }
 
@@ -356,7 +356,7 @@ void lemlib::Chassis::turnToHeading(float theta, int timeout, TurnToHeadingParam
     float startTheta = getPose().theta;
     std::optional<float> prevDeltaTheta = std::nullopt;
     std::uint8_t compState = pros::competition::get_status();
-    distTravelled = 0;
+    distTraveled = 0;
     Timer timer(timeout);
     angularLargeExit.reset();
     angularSmallExit.reset();
@@ -368,7 +368,7 @@ void lemlib::Chassis::turnToHeading(float theta, int timeout, TurnToHeadingParam
         Pose pose = getPose();
 
         // update completion vars
-        distTravelled = fabs(angleError(pose.theta, startTheta, false));
+        distTraveled = fabs(angleError(pose.theta, startTheta, false));
 
         targetTheta = theta;
 
@@ -406,7 +406,7 @@ void lemlib::Chassis::turnToHeading(float theta, int timeout, TurnToHeadingParam
     drivetrain.leftMotors->move(0);
     drivetrain.rightMotors->move(0);
     // set distTraveled to -1 to indicate that the function has finished
-    distTravelled = -1;
+    distTraveled = -1;
     this->endMotion();
 }
 
@@ -440,7 +440,7 @@ void lemlib::Chassis::swingToPoint(float x, float y, DriveSide lockedSide, int t
     float startTheta = getPose().theta;
     std::optional<float> prevDeltaTheta = std::nullopt;
     std::uint8_t compState = pros::competition::get_status();
-    distTravelled = 0;
+    distTraveled = 0;
     Timer timer(timeout);
     angularLargeExit.reset();
     angularSmallExit.reset();
@@ -460,7 +460,7 @@ void lemlib::Chassis::swingToPoint(float x, float y, DriveSide lockedSide, int t
         pose.theta = (params.forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
 
         // update completion vars
-        distTravelled = fabs(angleError(pose.theta, startTheta, false));
+        distTraveled = fabs(angleError(pose.theta, startTheta, false));
 
         deltaX = x - pose.x;
         deltaY = y - pose.y;
@@ -509,7 +509,7 @@ void lemlib::Chassis::swingToPoint(float x, float y, DriveSide lockedSide, int t
     drivetrain.leftMotors->move(0);
     drivetrain.rightMotors->move(0);
     // set distTraveled to -1 to indicate that the function has finished
-    distTravelled = -1;
+    distTraveled = -1;
     this->endMotion();
 }
 
@@ -542,7 +542,7 @@ void lemlib::Chassis::swingToHeading(float theta, DriveSide lockedSide, int time
     float startTheta = getPose().theta;
     std::optional<float> prevDeltaTheta = std::nullopt;
     std::uint8_t compState = pros::competition::get_status();
-    distTravelled = 0;
+    distTraveled = 0;
     Timer timer(timeout);
     angularLargeExit.reset();
     angularSmallExit.reset();
@@ -562,7 +562,7 @@ void lemlib::Chassis::swingToHeading(float theta, DriveSide lockedSide, int time
         pose.theta = fmod(pose.theta, 360);
 
         // update completion vars
-        distTravelled = fabs(angleError(pose.theta, startTheta, false));
+        distTraveled = fabs(angleError(pose.theta, startTheta, false));
         targetTheta = theta;
 
         // calculate deltaTheta
@@ -609,7 +609,7 @@ void lemlib::Chassis::swingToHeading(float theta, DriveSide lockedSide, int time
     drivetrain.leftMotors->move(0);
     drivetrain.rightMotors->move(0);
     // set distTraveled to -1 to indicate that the function has finished
-    distTravelled = -1;
+    distTraveled = -1;
     this->endMotion();
 }
 
@@ -656,7 +656,7 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
 
     // initialize vars used between iterations
     Pose lastPose = getPose();
-    distTravelled = 0;
+    distTraveled = 0;
     Timer timer(timeout);
     bool close = false;
     bool lateralSettled = false;
@@ -673,7 +673,7 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
         const Pose pose = getPose(true, true);
 
         // update distance travelled
-        distTravelled += pose.distance(lastPose);
+        distTraveled += pose.distance(lastPose);
         lastPose = pose;
 
         // calculate distance to the target point
@@ -777,7 +777,7 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
     drivetrain.leftMotors->move(0);
     drivetrain.rightMotors->move(0);
     // set distTraveled to -1 to indicate that the function has finished
-    distTravelled = -1;
+    distTraveled = -1;
     this->endMotion();
 }
 
@@ -811,7 +811,7 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
 
     // initialize vars used between iterations
     Pose lastPose = getPose();
-    distTravelled = 0;
+    distTraveled = 0;
     Timer timer(timeout);
     bool close = false;
     float prevLateralOut = 0; // previous lateral power
@@ -830,7 +830,7 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
         const Pose pose = getPose(true, true);
 
         // update distance travelled
-        distTravelled += pose.distance(lastPose);
+        distTraveled += pose.distance(lastPose);
         lastPose = pose;
 
         // calculate distance to the target point
@@ -911,6 +911,6 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
     drivetrain.leftMotors->move(0);
     drivetrain.rightMotors->move(0);
     // set distTraveled to -1 to indicate that the function has finished
-    distTravelled = -1;
+    distTraveled = -1;
     this->endMotion();
 }

--- a/src/lemlib/chassis/pursuit.cpp
+++ b/src/lemlib/chassis/pursuit.cpp
@@ -226,8 +226,8 @@ void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bo
     std::vector<lemlib::Pose> pathPoints = getData(path); // get list of path points
     if (pathPoints.size() == 0) {
         infoSink()->error("No points in path! Do you have the right format? Skipping motion");
-        // set distTravelled to -1 to indicate that the function has finished
-        distTravelled = -1;
+        // set distTraveled to -1 to indicate that the function has finished
+        distTraveled = -1;
         // give the mutex back
         this->endMotion();
         return;
@@ -246,7 +246,7 @@ void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bo
     float rightInput = 0;
     float prevVel = 0;
     int compState = pros::competition::get_status();
-    distTravelled = 0;
+    distTraveled = 0;
 
     // loop until the robot is within the end tolerance
     for (int i = 0; i < timeout / 10 && pros::competition::get_status() == compState && this->motionRunning; i++) {
@@ -255,7 +255,7 @@ void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bo
         if (!forwards) pose.theta -= M_PI;
 
         // update completion vars
-        distTravelled += pose.distance(lastPose);
+        distTraveled += pose.distance(lastPose);
         lastPose = pose;
 
         // find the closest point on the path to the robot
@@ -306,8 +306,8 @@ void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bo
     // stop the robot
     drivetrain.leftMotors->move(0);
     drivetrain.rightMotors->move(0);
-    // set distTravelled to -1 to indicate that the function has finished
-    distTravelled = -1;
+    // set distTraveled to -1 to indicate that the function has finished
+    distTraveled = -1;
     // give the mutex back
     this->endMotion();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,7 +146,7 @@ void autonomous() {
     chassis.moveToPose(20, 15, 90, 4000);
     // example movement: Move to x: 0 and y: 0 and face heading 270, going backwards. Timeout set to 4000ms
     chassis.moveToPose(0, 0, 270, 4000, {.forwards = false});
-    // cancel the movement after it has travelled 10 inches
+    // cancel the movement after it has traveled 10 inches
     chassis.waitUntil(10);
     chassis.cancelMotion();
     // example movement: Turn to face the point x:45, y:-45. Timeout set to 1000
@@ -163,7 +163,7 @@ void autonomous() {
     // the movement will run immediately
     // Unless its another movement, in which case it will wait
     chassis.waitUntil(10);
-    pros::lcd::print(4, "Travelled 10 inches during pure pursuit!");
+    pros::lcd::print(4, "Traveled 10 inches during pure pursuit!");
     // wait until the movement is done
     chassis.waitUntilDone();
     pros::lcd::print(4, "pure pursuit finished!");


### PR DESCRIPTION
#### Summary
The ``distTravelled`` member of ``Chassis``, was renamed to ``distTraveled``. All uses in comments of the british english spelling (travelled) were renamed to the american english version (traveled).

#### Motivation
The spelling of the word traveled was very inconsistent as the ``distTravelled`` member of ``Chassis`` uses the british spelling but the ``getDistanceTraveled`` method of ``TrackingWheel`` uses the american spelling. In addition, comments used both spellings. This inconsistency can get a bit annoying to people using a search function in this project.

#### Test Plan
Building the project works fine. I doubt testing with an actual robot is necessary because it's just renaming a variable + comments.

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: a56e17c99ae88260d562cb48825a0840e96bd271 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8533224305)
- via manual download: [LemLib@0.5.0-rc.7+a56e17.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1379846832.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+a56e17.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1379846832.zip;
pros c fetch LemLib@0.5.0-rc.7+a56e17.zip;
pros c apply LemLib@0.5.0-rc.7+a56e17;
rm LemLib@0.5.0-rc.7+a56e17.zip;
```