### PR TITLE
:bug: Fix Sign-Flip-Reset Always Enabled

### DIFF
--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -27,7 +27,7 @@ PID::PID(float kP, float kI, float kD, float windupRange, bool signFlipReset)
 float PID::update(const float error) {
     // calculate integral
     integral += error;
-    if (sgn(error) != sgn((prevError))) integral = 0;
+    if (sgn(error) != sgn((prevError)) && signFlipReset) integral = 0;
     if (fabs(error) > windupRange) integral = 0;
 
     // calculate derivative

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -28,7 +28,7 @@ float PID::update(const float error) {
     // calculate integral
     integral += error;
     if (sgn(error) != sgn((prevError)) && signFlipReset) integral = 0;
-    if (fabs(error) > windupRange) integral = 0;
+    if (fabs(error) > windupRange && windupRange != 0) integral = 0;
 
     // calculate derivative
     const float derivative = error - prevError;


### PR DESCRIPTION
#### Summary
Fixes sign-flip-reset always being enabled. This happens because there is no check.

#### Motivation
Its a bug, it needs fixing. And its easy, just a one-liner

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 84df2482f5728cb9583618ae863771bcefaa88df -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8635733639)
- via manual download: [LemLib@0.5.0-rc.7+84df24.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1402496062.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+84df24.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1402496062.zip;
pros c fetch LemLib@0.5.0-rc.7+84df24.zip;
pros c apply LemLib@0.5.0-rc.7+84df24;
rm LemLib@0.5.0-rc.7+84df24.zip;
```