### PR TITLE
Added 2" Omni

### DIFF
--- a/include/lemlib/chassis/trackingWheel.hpp
+++ b/include/lemlib/chassis/trackingWheel.hpp
@@ -10,6 +10,7 @@ namespace lemlib {
  * @brief A namespace representing the size of omniwheels.
  */
 namespace Omniwheel {
+constexpr float NEW_2 = 2.125;
 constexpr float NEW_275 = 2.75;
 constexpr float OLD_275 = 2.75;
 constexpr float NEW_275_HALF = 2.744;


### PR DESCRIPTION
#### Summary
Added new 2" omni wheel to omni wheel namespace 

#### Motivation
Easy to do, and helpful to users having issues with using new 2" omni wheels for tracking

#### Test Plan
2.125" for the 2" omni wheel size is around 1"-2" more accurate over a 24" movement

#### Additional Notes
Done while screensharing with Liam

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: abd24513d159226ed6239854e5988f7272c48ac8 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8732008448)
- via manual download: [LemLib@0.5.0-rc.7+abd245.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1424398258.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+abd245.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1424398258.zip;
pros c fetch LemLib@0.5.0-rc.7+abd245.zip;
pros c apply LemLib@0.5.0-rc.7+abd245;
rm LemLib@0.5.0-rc.7+abd245.zip;
```