### PR TITLE
Rename chasePower to horizontalDrift

### DIFF
--- a/docs/tutorials/2_setting_up_the_chassis.md
+++ b/docs/tutorials/2_setting_up_the_chassis.md
@@ -38,7 +38,7 @@ lemlib::Drivetrain drivetrain(&left_side_motors, // left motor group
                               10, // 10 inch track width
                               lemlib::Omniwheel::NEW_325, // using new 3.25" omnis
                               360, // drivetrain rpm is 360
-                              2 // chase power is 2. If we had traction wheels, it would have been 8
+                              2 // horizontal drift is 2. If we had traction wheels, it would have been 8
 );
 ``` 
 
@@ -155,7 +155,7 @@ lemlib::Drivetrain drivetrain(&left_side_motors, // left motor group
                               10, // 10 inch track width
                               lemlib::Omniwheel::NEW_325, // using new 3.25" omnis
                               360, // drivetrain rpm is 360
-                              2 // chase power is 2. If we had traction wheels, it would have been 8
+                              2 // horizontal drift is 2. If we had traction wheels, it would have been 8
 );
 
 // left tracking wheel encoder

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -96,16 +96,16 @@ class Drivetrain {
          * @param trackWidth the track width of the robot
          * @param wheelDiameter the diameter of the wheel used on the drivetrain
          * @param rpm the rpm of the wheels
-         * @param chasePower higher values make the robot move faster but causes more overshoot on turns
+         * @param horizontalDrift higher values make the robot move faster but causes more overshoot on turns
          */
         Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth, float wheelDiameter,
-                   float rpm, float chasePower);
+                   float rpm, float horizontalDrift);
         pros::Motor_Group* leftMotors;
         pros::Motor_Group* rightMotors;
         float trackWidth;
         float wheelDiameter;
         float rpm;
-        float chasePower;
+        float horizontalDrift;
 };
 
 /**
@@ -238,8 +238,8 @@ struct SwingToHeadingParams {
  * parameters, overcoming the c/c++ limitation
  *
  * @param forwards whether the robot should move forwards or backwards. True by default
- * @param chasePower how fast the robot will move around corners. Recommended value 2-15.
- *  0 means use chasePower set in chassis class. 0 by default.
+ * @param horizontalDrift how fast the robot will move around corners. Recommended value 2-15.
+ *  0 means use horizontalDrift set in chassis class. 0 by default.
  * @param lead carrot point multiplier. value between 0 and 1. Higher values result in
  *  curvier movements. 0.6 by default
  * @param maxSpeed the maximum speed the robot can travel at. Value between 0-127.
@@ -252,7 +252,7 @@ struct SwingToHeadingParams {
  */
 struct MoveToPoseParams {
         bool forwards = true;
-        float chasePower = 0;
+        float horizontalDrift = 0;
         float lead = 0.6;
         float maxSpeed = 127;
         float minSpeed = 0;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -41,16 +41,16 @@ lemlib::OdomSensors::OdomSensors(TrackingWheel* vertical1, TrackingWheel* vertic
  * @param trackWidth the track width of the robot
  * @param wheelDiameter the diameter of the wheel used on the drivetrain
  * @param rpm the rpm of the wheels
- * @param chasePower higher values make the robot move faster but causes more overshoot on turns
+ * @param horizontalDrift higher values make the robot move faster but causes more overshoot on turns
  */
 lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* rightMotors, float trackWidth,
-                               float wheelDiameter, float rpm, float chasePower)
+                               float wheelDiameter, float rpm, float horizontalDrift)
     : leftMotors(leftMotors),
       rightMotors(rightMotors),
       trackWidth(trackWidth),
       wheelDiameter(wheelDiameter),
       rpm(rpm),
-      chasePower(chasePower) {}
+      horizontalDrift(horizontalDrift) {}
 
 /**
  * @brief Construct a new Chassis

--- a/src/lemlib/chassis/motions/moveToPose.cpp
+++ b/src/lemlib/chassis/motions/moveToPose.cpp
@@ -43,8 +43,8 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
     Pose target(x, y, M_PI_2 - degToRad(theta));
     if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 
-    // use global chasePower is chasePower is 0
-    if (params.chasePower == 0) params.chasePower = drivetrain.chasePower;
+    // use global horizontalDrift is horizontalDrift is 0
+    if (params.horizontalDrift == 0) params.horizontalDrift = drivetrain.horizontalDrift;
 
     // initialize vars used between iterations
     Pose lastPose = getPose();
@@ -127,7 +127,7 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
         // constrain lateral output by the max speed it can travel at without
         // slipping
         const float radius = 1 / fabs(getCurvature(pose, carrot));
-        const float maxSlipSpeed(sqrt(params.chasePower * radius * 9.8));
+        const float maxSlipSpeed(sqrt(params.horizontalDrift * radius * 9.8));
         lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
         // prioritize angular movement over lateral movement
         const float overturn = fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,7 @@ lemlib::Drivetrain drivetrain(&leftMotors, // left motor group
                               10, // 10 inch track width
                               lemlib::Omniwheel::NEW_4, // using new 3.25" omnis
                               343, // drivetrain rpm is 343
-                              2 // chase power is 2. If we had traction wheels, it would have been 8
+                              2 // horizontal drift is 2. If we had traction wheels, it would have been 8
 );
 
 // lateral motion controller


### PR DESCRIPTION
#### Summary
Renamed all instances of chasePower to horizontalDrift, and fixed comments in the documentation and the example main.cpp

#### Motivation
chasePower seems too vague a description of what this value represents. horizontalDrift is better.

#### Test Plan
Anyone with a robot can test this. I do not currently have one but it should be as trivial as using moveToPose and observing differences in movement as you change horizontalDrift.

#### Additional Notes
N/A

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 3a33218ec30c5530caf2d1037e634524ee4ca16c -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8778048138)
- via manual download: [LemLib@0.5.0-rc.7+3a3321.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1434074382.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+3a3321.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1434074382.zip;
pros c fetch LemLib@0.5.0-rc.7+3a3321.zip;
pros c apply LemLib@0.5.0-rc.7+3a3321;
rm LemLib@0.5.0-rc.7+3a3321.zip;
```