### PR TITLE
feat: ✨ Expose PID, exits, and slew to be modified

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -482,14 +482,40 @@ class Chassis {
          * without interfering with the heading.
          */
         void resetLocalPosition();
+
         /**
-         * PIDs are exposed so advanced users can implement things like gain scheduling
-         * Changes are immediate and will affect a motion in progress
+         * @brief Modify the lateral PID gains object. This also contains the windupRange and signFlipReset settings.
+         * Intended for advanced users.
+         * @param newGains the new gains. May specify all the gains, none of them, or anywhere in between.
          *
-         * @warning Do not interact with these unless you know what you are doing
+         * @b Example
+         * @code {.cpp}
+         * chassis.setLateralPIDGains({.kP = 24});
          */
-        PID lateralPID;
-        PID angularPID;
+        void setLateralPIDGains(PID::OptionalGains newGains);
+        /**
+         * @brief Modify the angular PID gains object. This also contains the windupRange and signFlipReset settings.
+         * Intended for advanced users.
+         * @param newGains the new gains. May specify all the gains, none of them, or anywhere in between.
+         *
+         * @b Example
+         * @code {.cpp}
+         * chassis.setAngularPIDGains({.kP = 24});
+         */
+        void setAngularPIDGains(PID::OptionalGains newGains);
+
+        /**
+         * @brief Get the Lateral PID Gains object
+         *
+         * @return PID::Gains
+         */
+        PID::Gains getLateralPIDGains() const;
+        /**
+         * @brief Get the Angular PID Gains object
+         *
+         * @return PID::Gains
+         */
+        PID::Gains getAngularPIDGains() const;
     protected:
         /**
          * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue
@@ -516,6 +542,9 @@ class Chassis {
         ExitCondition lateralSmallExit;
         ExitCondition angularLargeExit;
         ExitCondition angularSmallExit;
+
+        PID lateralPID;
+        PID angularPID;
     private:
         pros::Mutex mutex;
 };

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -10,6 +10,7 @@
 #include "lemlib/exitcondition.hpp"
 #include "lemlib/driveCurve.hpp"
 #include <atomic>
+#include <vector>
 
 namespace lemlib {
 
@@ -523,9 +524,17 @@ class Chassis {
 
         float getLateralSlew() const;
         float getAngularSlew() const;
+
+        const ErrorExitConditionGroupFactory& getLateralExitConditionFactory() const;
+        ErrorExitConditionGroupFactory& getLateralExitConditionFactory();
+        const ErrorExitConditionGroupFactory& getAngularExitConditionFactory() const;
+        ErrorExitConditionGroupFactory& getAngularExitConditionFactory();
     protected:
+        ErrorExitConditionGroupFactory lateralExitConditionFactory;
+        ErrorExitConditionGroupFactory angularExitConditionFactory;
         /**
-         * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue
+         * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of
+         * queue
          */
         void requestMotionStart();
         /**
@@ -545,11 +554,6 @@ class Chassis {
         OdomSensors sensors;
         DriveCurve* throttleCurve;
         DriveCurve* steerCurve;
-
-        ExitCondition lateralLargeExit;
-        ExitCondition lateralSmallExit;
-        ExitCondition angularLargeExit;
-        ExitCondition angularSmallExit;
 
         PID lateralPID;
         PID angularPID;

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -9,6 +9,7 @@
 #include "lemlib/pid.hpp"
 #include "lemlib/exitcondition.hpp"
 #include "lemlib/driveCurve.hpp"
+#include <atomic>
 
 namespace lemlib {
 
@@ -516,6 +517,12 @@ class Chassis {
          * @return PID::Gains
          */
         PID::Gains getAngularPIDGains() const;
+
+        void setLateralSlew(float newSlew);
+        void setAngularSlew(float newSlew);
+
+        float getLateralSlew() const;
+        float getAngularSlew() const;
     protected:
         /**
          * @brief Indicates that this motion is queued and blocks current task until this motion reaches front of queue
@@ -531,8 +538,9 @@ class Chassis {
 
         float distTraveled = 0;
 
-        ControllerSettings lateralSettings;
-        ControllerSettings angularSettings;
+        std::atomic<float> lateralSlew;
+        std::atomic<float> angularSlew;
+
         Drivetrain drivetrain;
         OdomSensors sensors;
         DriveCurve* throttleCurve;

--- a/include/lemlib/exitcondition.hpp
+++ b/include/lemlib/exitcondition.hpp
@@ -5,6 +5,9 @@
 #include <vector>
 
 namespace lemlib {
+/**
+ * @brief Abstract exit condition. Intended for use only by advanced users / internally.
+ */
 class ExitCondition {
     public:
         /**
@@ -24,8 +27,19 @@ class ExitCondition {
         virtual bool update(const float input) = 0;
 };
 
+/**
+ * @brief Exit condition that exits when input has been in `range` for longer than `time` ms
+ *
+ * @warning Error exit conditions are only intended to be used internally and by advanced users.
+ * Most of the time the user should only need to interact with `ErrorExitCondition::Config`
+ */
 class ErrorExitCondition : public ExitCondition {
     public:
+        /**
+         * @brief Configuration for an `ErrorExitCondition`
+         *
+         * @see ErrorExitCondition
+         */
         struct Config {
                 /** @brief the range where the countdown is allowed to start */
                 float range;
@@ -68,7 +82,8 @@ class ErrorExitCondition : public ExitCondition {
 };
 
 /**
- * @brief exits if any of the children exit
+ * @brief Exits if any of it's children are currently in an exitted state. Intended for use only by advanced users /
+ * internally.
  */
 class ExitConditionGroup : public ExitCondition {
     public:
@@ -97,14 +112,24 @@ class ExitConditionGroup : public ExitCondition {
         std::vector<std::shared_ptr<ExitCondition>> children;
 };
 
+/**
+ * @brief Abstract factory for creating an `ExitCondition`. Intended for use only by advanced users / internally.
+ */
 class ExitConditionFactory {
     public:
         virtual std::unique_ptr<ExitCondition> create() const = 0;
 };
 
+/**
+ * @brief Used by user to configure multiple ErrorExitConditions whilst ensuring atomicity / thread-safety.
+ * Used by the chassis to create exit conditions for motions.
+ *
+ * Intended for use by slightly advanced users
+ */
 class ErrorExitConditionGroupFactory : public ExitConditionFactory {
     public:
         ErrorExitConditionGroupFactory(std::vector<ErrorExitCondition::Config> configs);
+
         /** @brief removes all configs */
         void clear();
 
@@ -114,10 +139,15 @@ class ErrorExitConditionGroupFactory : public ExitConditionFactory {
         /** @brief creates a new ExitConditionGroup with the current configs */
         std::unique_ptr<ExitCondition> create() const override;
 
+        /** @brief modifies the configs whilst ensuring atomicity */
         void setConfigs(std::vector<ErrorExitCondition::Config>& newConfig);
+
+        /** @brief reads the configs whilst ensuring atomicity */
         std::vector<ErrorExitCondition::Config> getConfigs() const;
     private:
+        /** @brief used to ensure atomicity */
         mutable pros::Mutex mutex;
+        /** @brief used to create ErrorExitConditions by `ErrorExitConditionGroupFactory::create()` */
         std::vector<ErrorExitCondition::Config> configs;
 };
 } // namespace lemlib

--- a/include/lemlib/exitcondition.hpp
+++ b/include/lemlib/exitcondition.hpp
@@ -1,15 +1,49 @@
 #pragma once
 
+#include "pros/rtos.hpp"
+#include <memory>
+#include <vector>
+
 namespace lemlib {
 class ExitCondition {
     public:
+        /**
+         * @brief whether the exit condition has been met
+         *
+         * @return true exit condition met
+         * @return false exit condition not met
+         */
+        virtual bool getExit() const = 0;
+        /**
+         * @brief update the exit condition
+         *
+         * @param input the input for the exit condition
+         * @return true exit condition met
+         * @return false exit condition not met
+         */
+        virtual bool update(const float input) = 0;
+};
+
+class ErrorExitCondition : public ExitCondition {
+    public:
+        struct Config {
+                /** @brief the range where the countdown is allowed to start */
+                float range;
+                /** @brief how much time to wait while in range before exiting */
+                int time;
+        };
+
         /**
          * @brief Create a new Exit Condition
          *
          * @param range the range where the countdown is allowed to start
          * @param time how much time to wait while in range before exiting
          */
-        ExitCondition(const float range, const int time);
+        ErrorExitCondition(const float range, const int time);
+        /**
+         * @brief Create a new Exit Condition
+         */
+        ErrorExitCondition(ErrorExitCondition::Config config);
 
         /**
          * @brief whether the exit condition has been met
@@ -17,7 +51,7 @@ class ExitCondition {
          * @return true exit condition met
          * @return false exit condition not met
          */
-        bool getExit();
+        bool getExit() const override;
 
         /**
          * @brief update the exit condition
@@ -26,17 +60,68 @@ class ExitCondition {
          * @return true exit condition met
          * @return false exit condition not met
          */
-        bool update(const float input);
-
-        /**
-         * @brief reset the exit condition timer
-         *
-         */
-        void reset();
+        bool update(const float input) override;
     protected:
-        const float range;
-        const int time;
+        ErrorExitCondition::Config config;
         int startTime = -1;
         bool done = false;
+};
+
+/**
+ * @brief exits if any of the children exit
+ */
+class ExitConditionGroup : public ExitCondition {
+    public:
+        /**
+         * @brief Create a new Exit Condition Group
+         */
+        ExitConditionGroup(std::vector<std::shared_ptr<ExitCondition>> children);
+        /**
+         * @brief Destroys the children
+         */
+        ~ExitConditionGroup();
+
+        /**
+         * @brief whether the exit condition has been met
+         *
+         * @return true exit condition met
+         * @return false exit condition not met
+         */
+        bool getExit() const override;
+
+        /**
+         * @brief update the exit condition
+         *
+         * @param input the input for the exit condition
+         * @return true exit condition met
+         * @return false exit condition not met
+         */
+        bool update(const float input) override;
+    protected:
+        std::vector<std::shared_ptr<ExitCondition>> children;
+};
+
+class ExitConditionFactory {
+    public:
+        virtual std::unique_ptr<ExitCondition> create() const = 0;
+};
+
+class ErrorExitConditionGroupFactory : public ExitConditionFactory {
+    public:
+        ErrorExitConditionGroupFactory(std::vector<ErrorExitCondition::Config> configs);
+        /** @brief removes all configs */
+        void clear();
+
+        /** @brief adds configs to the end of the config vector */
+        void push_back(ErrorExitCondition::Config& newConfigs...);
+
+        /** @brief creates a new ExitConditionGroup with the current configs */
+        std::unique_ptr<ExitCondition> create() const override;
+
+        void setConfigs(std::vector<ErrorExitCondition::Config>& newConfig);
+        std::vector<ErrorExitCondition::Config> getConfigs() const;
+    private:
+        mutable pros::Mutex mutex;
+        std::vector<ErrorExitCondition::Config> configs;
 };
 } // namespace lemlib

--- a/include/lemlib/exitcondition.hpp
+++ b/include/lemlib/exitcondition.hpp
@@ -76,10 +76,6 @@ class ExitConditionGroup : public ExitCondition {
          * @brief Create a new Exit Condition Group
          */
         ExitConditionGroup(std::vector<std::shared_ptr<ExitCondition>> children);
-        /**
-         * @brief Destroys the children
-         */
-        ~ExitConditionGroup();
 
         /**
          * @brief whether the exit condition has been met

--- a/include/lemlib/pid.hpp
+++ b/include/lemlib/pid.hpp
@@ -31,6 +31,8 @@ class PID {
                 std::optional<float> windupRange = 0;
                 /** @brief whether to reset integral when sign of error flips */
                 std::optional<bool> signFlipReset = false;
+
+                static OptionalGains fromGains(const Gains& gains);
         };
 
         /**

--- a/include/lemlib/pid.hpp
+++ b/include/lemlib/pid.hpp
@@ -1,8 +1,38 @@
 #pragma once
 
+#include "pros/rtos.hpp"
+#include <atomic>
+#include <optional>
+
 namespace lemlib {
 class PID {
     public:
+        struct Gains {
+                /** @brief integral gain */
+                float kP;
+                /** @brief proportional gain */
+                float kI;
+                /** @brief derivative gain */
+                float kD;
+                /** @brief integral anti windup range */
+                float windupRange = 0;
+                /** @brief whether to reset integral when sign of error flips */
+                bool signFlipReset = false;
+        };
+
+        struct OptionalGains {
+                /** @brief integral gain */
+                std::optional<float> kP;
+                /** @brief proportional gain */
+                std::optional<float> kI;
+                /** @brief derivative gain */
+                std::optional<float> kD;
+                /** @brief integral anti windup range */
+                std::optional<float> windupRange = 0;
+                /** @brief whether to reset integral when sign of error flips */
+                std::optional<bool> signFlipReset = false;
+        };
+
         /**
          * @brief Construct a new PID
          *
@@ -13,6 +43,16 @@ class PID {
          * @param signFlipReset whether to reset integral when sign of error flips
          */
         PID(float kP, float kI, float kD, float windupRange = 0, bool signFlipReset = false);
+        /**
+         * @brief Construct a new PID
+         *
+         * @param kP proportional gain
+         * @param kI integral gain
+         * @param kD derivative gain
+         * @param windupRange integral anti windup range
+         * @param signFlipReset whether to reset integral when sign of error flips
+         */
+        PID(const PID::Gains& gains);
 
         /**
          * @brief Update the PID
@@ -24,18 +64,25 @@ class PID {
 
         /**
          * @brief reset integral, derivative, and prevTime
-         *
          */
         void reset();
-    protected:
-        // gains
-        const float kP;
-        const float kI;
-        const float kD;
 
-        // optimizations
-        const float windupRange;
-        const bool signFlipReset;
+        /**
+         * @brief update the gains object while only updating the gains that are specified and ensuring atomicity
+         */
+        void setGains(const PID::OptionalGains& gains);
+        /**
+         * @brief update the gains object while and ensuring atomicity
+         */
+        void setGains(const PID::Gains& gains);
+        /**
+         * @brief get the gains object while ensuring atomicity
+         */
+        PID::Gains getGains() const;
+    protected:
+        PID::Gains gains;
+        /** used to ensure the gains' atomicity */
+        mutable pros::Mutex gainsMutex;
 
         float integral = 0;
         float prevError = 0;

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <math.h>
 #include <optional>
+#include "lemlib/exitcondition.hpp"
 #include "pros/motors.h"
 #include "pros/motors.hpp"
 #include "pros/misc.hpp"
@@ -70,12 +71,12 @@ lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings linearSetting
       steerCurve(steerCurve),
       lateralPID(linearSettings.kP, linearSettings.kI, linearSettings.kD, linearSettings.windupRange, true),
       angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
-      lateralLargeExit(linearSettings.largeError, linearSettings.largeErrorTimeout),
-      lateralSmallExit(linearSettings.smallError, linearSettings.smallErrorTimeout),
-      angularLargeExit(angularSettings.largeError, angularSettings.largeErrorTimeout),
-      angularSmallExit(angularSettings.smallError, angularSettings.smallErrorTimeout),
       lateralSlew(linearSettings.slew),
-      angularSlew(angularSettings.slew) {}
+      angularSlew(angularSettings.slew),
+      lateralExitConditionFactory({{linearSettings.smallError, int(linearSettings.smallErrorTimeout)},
+                                   {linearSettings.largeError, int(linearSettings.largeErrorTimeout)}}),
+      angularExitConditionFactory({{angularSettings.smallError, int(angularSettings.smallErrorTimeout)},
+                                   {angularSettings.largeError, int(angularSettings.largeErrorTimeout)}}) {}
 
 /**
  * @brief calibrate the IMU given a sensors struct
@@ -255,3 +256,19 @@ void lemlib::Chassis::setAngularSlew(float slew) { this->angularSlew = slew; }
 float lemlib::Chassis::getLateralSlew() const { return this->lateralSlew; }
 
 float lemlib::Chassis::getAngularSlew() const { return this->angularSlew; }
+
+const lemlib::ErrorExitConditionGroupFactory& lemlib::Chassis::getAngularExitConditionFactory() const {
+    return this->angularExitConditionFactory;
+}
+
+lemlib::ErrorExitConditionGroupFactory& lemlib::Chassis::getAngularExitConditionFactory() {
+    return this->angularExitConditionFactory;
+}
+
+const lemlib::ErrorExitConditionGroupFactory& lemlib::Chassis::getLateralExitConditionFactory() const {
+    return this->lateralExitConditionFactory;
+}
+
+lemlib::ErrorExitConditionGroupFactory& lemlib::Chassis::getLateralExitConditionFactory() {
+    return this->lateralExitConditionFactory;
+}

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -239,3 +239,13 @@ void lemlib::Chassis::setBrakeMode(pros::motor_brake_mode_e mode) {
     drivetrain.leftMotors->set_brake_modes(mode);
     drivetrain.rightMotors->set_brake_modes(mode);
 }
+
+void lemlib::Chassis::setLateralPIDGains(PID::OptionalGains newGains) {
+    this->lateralPID.setGains(newGains);
+}
+void lemlib::Chassis::setAngularPIDGains(PID::OptionalGains newGains) {
+    this->angularPID.setGains(newGains);
+}
+
+lemlib::PID::Gains lemlib::Chassis::getLateralPIDGains() const { return this->lateralPID.getGains(); }
+lemlib::PID::Gains lemlib::Chassis::getAngularPIDGains() const { return this->lateralPID.getGains(); }

--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -65,17 +65,17 @@ lemlib::Drivetrain::Drivetrain(pros::MotorGroup* leftMotors, pros::MotorGroup* r
 lemlib::Chassis::Chassis(Drivetrain drivetrain, ControllerSettings linearSettings, ControllerSettings angularSettings,
                          OdomSensors sensors, DriveCurve* throttleCurve, DriveCurve* steerCurve)
     : drivetrain(drivetrain),
-      lateralSettings(linearSettings),
-      angularSettings(angularSettings),
       sensors(sensors),
       throttleCurve(throttleCurve),
       steerCurve(steerCurve),
       lateralPID(linearSettings.kP, linearSettings.kI, linearSettings.kD, linearSettings.windupRange, true),
       angularPID(angularSettings.kP, angularSettings.kI, angularSettings.kD, angularSettings.windupRange, true),
-      lateralLargeExit(lateralSettings.largeError, lateralSettings.largeErrorTimeout),
-      lateralSmallExit(lateralSettings.smallError, lateralSettings.smallErrorTimeout),
+      lateralLargeExit(linearSettings.largeError, linearSettings.largeErrorTimeout),
+      lateralSmallExit(linearSettings.smallError, linearSettings.smallErrorTimeout),
       angularLargeExit(angularSettings.largeError, angularSettings.largeErrorTimeout),
-      angularSmallExit(angularSettings.smallError, angularSettings.smallErrorTimeout) {}
+      angularSmallExit(angularSettings.smallError, angularSettings.smallErrorTimeout),
+      lateralSlew(linearSettings.slew),
+      angularSlew(angularSettings.slew) {}
 
 /**
  * @brief calibrate the IMU given a sensors struct
@@ -240,12 +240,18 @@ void lemlib::Chassis::setBrakeMode(pros::motor_brake_mode_e mode) {
     drivetrain.rightMotors->set_brake_modes(mode);
 }
 
-void lemlib::Chassis::setLateralPIDGains(PID::OptionalGains newGains) {
-    this->lateralPID.setGains(newGains);
-}
-void lemlib::Chassis::setAngularPIDGains(PID::OptionalGains newGains) {
-    this->angularPID.setGains(newGains);
-}
+void lemlib::Chassis::setLateralPIDGains(PID::OptionalGains newGains) { this->lateralPID.setGains(newGains); }
+
+void lemlib::Chassis::setAngularPIDGains(PID::OptionalGains newGains) { this->angularPID.setGains(newGains); }
 
 lemlib::PID::Gains lemlib::Chassis::getLateralPIDGains() const { return this->lateralPID.getGains(); }
+
 lemlib::PID::Gains lemlib::Chassis::getAngularPIDGains() const { return this->lateralPID.getGains(); }
+
+void lemlib::Chassis::setLateralSlew(float slew) { this->angularSlew = slew; }
+
+void lemlib::Chassis::setAngularSlew(float slew) { this->angularSlew = slew; }
+
+float lemlib::Chassis::getLateralSlew() const { return this->lateralSlew; }
+
+float lemlib::Chassis::getAngularSlew() const { return this->angularSlew; }

--- a/src/lemlib/chassis/motions/moveToPoint.cpp
+++ b/src/lemlib/chassis/motions/moveToPoint.cpp
@@ -29,8 +29,7 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
 
     // reset PIDs and exit conditions
     lateralPID.reset();
-    lateralLargeExit.reset();
-    lateralSmallExit.reset();
+    auto lateralExit = this->lateralExitConditionFactory.create();
     angularPID.reset();
 
     // initialize vars used between iterations
@@ -48,8 +47,7 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
     target.theta = lastPose.angle(target);
 
     // main loop
-    while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close) &&
-           this->motionRunning) {
+    while (!timer.isDone() && (!lateralExit->getExit() || !close) && this->motionRunning) {
         // update position
         const Pose pose = getPose(true, true);
 
@@ -81,8 +79,7 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
         float lateralError = pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
 
         // update exit conditions
-        lateralSmallExit.update(lateralError);
-        lateralLargeExit.update(lateralError);
+        lateralExit->update(lateralError);
 
         // get output from PIDs
         float lateralOut = lateralPID.update(lateralError);

--- a/src/lemlib/chassis/motions/moveToPoint.cpp
+++ b/src/lemlib/chassis/motions/moveToPoint.cpp
@@ -91,13 +91,13 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
 
         // apply restrictions on angular speed
         angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
-        angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
+        angularOut = slew(angularOut, prevAngularOut, this->getAngularSlew());
 
         // apply restrictions on lateral speed
         lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
         // constrain lateral output by max accel
         // but not for decelerating, since that would interfere with settling
-        if (!close) lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+        if (!close) lateralOut = slew(lateralOut, prevLateralOut, this->getLateralSlew());
 
         // prevent moving in the wrong direction
         if (params.forwards && !close) lateralOut = std::fmax(lateralOut, 0);

--- a/src/lemlib/chassis/motions/moveToPose.cpp
+++ b/src/lemlib/chassis/motions/moveToPose.cpp
@@ -122,7 +122,7 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
         lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
 
         // constrain lateral output by max accel
-        if (!close) lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+        if (!close) lateralOut = slew(lateralOut, prevLateralOut, this->getLateralSlew());
 
         // constrain lateral output by the max speed it can travel at without
         // slipping

--- a/src/lemlib/chassis/motions/pursuit.cpp
+++ b/src/lemlib/chassis/motions/pursuit.cpp
@@ -273,7 +273,7 @@ void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bo
 
         // get the target velocity of the robot
         targetVel = pathPoints.at(closestPoint).theta;
-        targetVel = slew(targetVel, prevVel, lateralSettings.slew);
+        targetVel = slew(targetVel, prevVel, this->getLateralSlew());
         prevVel = targetVel;
 
         // calculate target left and right velocities

--- a/src/lemlib/chassis/motions/swingToHeading.cpp
+++ b/src/lemlib/chassis/motions/swingToHeading.cpp
@@ -82,7 +82,7 @@ void lemlib::Chassis::swingToHeading(float theta, DriveSide lockedSide, int time
         // cap the speed
         if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
         else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
-        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
+        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, this->getAngularSlew());
         if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
         else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
         prevMotorPower = motorPower;

--- a/src/lemlib/chassis/motions/swingToPoint.cpp
+++ b/src/lemlib/chassis/motions/swingToPoint.cpp
@@ -86,7 +86,7 @@ void lemlib::Chassis::swingToPoint(float x, float y, DriveSide lockedSide, int t
         // cap the speed
         if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
         else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
-        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
+        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, this->getAngularSlew());
         if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
         else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
         prevMotorPower = motorPower;

--- a/src/lemlib/chassis/motions/turnToHeading.cpp
+++ b/src/lemlib/chassis/motions/turnToHeading.cpp
@@ -75,7 +75,7 @@ void lemlib::Chassis::turnToHeading(float theta, int timeout, TurnToHeadingParam
         // cap the speed
         if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
         else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
-        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
+        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, this->getAngularSlew());
         if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
         else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
         prevMotorPower = motorPower;

--- a/src/lemlib/chassis/motions/turnToHeading.cpp
+++ b/src/lemlib/chassis/motions/turnToHeading.cpp
@@ -38,12 +38,11 @@ void lemlib::Chassis::turnToHeading(float theta, int timeout, TurnToHeadingParam
     std::uint8_t compState = pros::competition::get_status();
     distTraveled = 0;
     Timer timer(timeout);
-    angularLargeExit.reset();
-    angularSmallExit.reset();
+    auto angularExit = this->angularExitConditionFactory.create();
     angularPID.reset();
 
     // main loop
-    while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
+    while (!timer.isDone() && !angularExit->getExit() && this->motionRunning) {
         // update variables
         Pose pose = getPose();
 
@@ -69,8 +68,7 @@ void lemlib::Chassis::turnToHeading(float theta, int timeout, TurnToHeadingParam
 
         // calculate the speed
         motorPower = angularPID.update(deltaTheta);
-        angularLargeExit.update(deltaTheta);
-        angularSmallExit.update(deltaTheta);
+        angularExit->update(deltaTheta);
 
         // cap the speed
         if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;

--- a/src/lemlib/chassis/motions/turnToPoint.cpp
+++ b/src/lemlib/chassis/motions/turnToPoint.cpp
@@ -79,7 +79,7 @@ void lemlib::Chassis::turnToPoint(float x, float y, int timeout, TurnToPointPara
         // cap the speed
         if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
         else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
-        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
+        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, this->getAngularSlew());
         if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
         else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
         prevMotorPower = motorPower;

--- a/src/lemlib/chassis/motions/turnToPoint.cpp
+++ b/src/lemlib/chassis/motions/turnToPoint.cpp
@@ -39,12 +39,11 @@ void lemlib::Chassis::turnToPoint(float x, float y, int timeout, TurnToPointPara
     std::uint8_t compState = pros::competition::get_status();
     distTraveled = 0;
     Timer timer(timeout);
-    angularLargeExit.reset();
-    angularSmallExit.reset();
+    auto angularExit = this->angularExitConditionFactory.create();
     angularPID.reset();
 
     // main loop
-    while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
+    while (!timer.isDone() && !angularExit->getExit() && this->motionRunning) {
         // update variables
         Pose pose = getPose();
         pose.theta = (params.forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
@@ -73,8 +72,7 @@ void lemlib::Chassis::turnToPoint(float x, float y, int timeout, TurnToPointPara
 
         // calculate the speed
         motorPower = angularPID.update(deltaTheta);
-        angularLargeExit.update(deltaTheta);
-        angularSmallExit.update(deltaTheta);
+        angularExit->update(deltaTheta);
 
         // cap the speed
         if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;

--- a/src/lemlib/exitcondition.cpp
+++ b/src/lemlib/exitcondition.cpp
@@ -1,5 +1,7 @@
 #include <cmath>
-#include "pros/rtos.hpp"
+#include <memory>
+#include <mutex>
+#include <vector>
 #include "lemlib/exitcondition.hpp"
 
 namespace lemlib {
@@ -10,9 +12,11 @@ namespace lemlib {
  * @param range the range where the countdown is allowed to start
  * @param time how much time to wait while in range before exiting
  */
-ExitCondition::ExitCondition(const float range, const int time)
-    : range(range),
-      time(time) {}
+ErrorExitCondition::ErrorExitCondition(const float range, const int time)
+    : ErrorExitCondition(ErrorExitCondition::Config {.range = range, .time = time}) {}
+
+ErrorExitCondition::ErrorExitCondition(ErrorExitCondition::Config config)
+    : config(config) {}
 
 /**
  * @brief whether the exit condition has been met
@@ -20,7 +24,7 @@ ExitCondition::ExitCondition(const float range, const int time)
  * @return true exit condition met
  * @return false exit condition not met
  */
-bool ExitCondition::getExit() { return done; }
+bool ErrorExitCondition::getExit() const { return this->done; }
 
 /**
  * @brief update the exit condition
@@ -29,20 +33,60 @@ bool ExitCondition::getExit() { return done; }
  * @return true exit condition met
  * @return false exit condition not met
  */
-bool ExitCondition::update(const float input) {
+bool ErrorExitCondition::update(const float input) {
     const int curTime = pros::millis();
-    if (std::fabs(input) > range) startTime = -1;
-    else if (startTime == -1) startTime = curTime;
-    else if (curTime >= startTime + time) done = true;
-    return done;
+    if (std::fabs(input) > this->config.range) this->startTime = -1;
+    else if (this->startTime == -1) this->startTime = curTime;
+    else if (curTime >= this->startTime + this->config.time) this->done = true;
+    return this->done;
 }
 
-/**
- * @brief reset the exit condition timer
- *
- */
-void ExitCondition::reset() {
-    startTime = -1;
-    done = false;
+ErrorExitConditionGroupFactory::ErrorExitConditionGroupFactory(std::vector<ErrorExitCondition::Config> configs)
+    : configs(configs) {}
+
+std::unique_ptr<ExitCondition> ErrorExitConditionGroupFactory::create() const {
+    std::vector<std::shared_ptr<ExitCondition>> conditions;
+    for (const auto& config : this->getConfigs()) conditions.push_back(std::make_shared<ErrorExitCondition>(config));
+    return std::make_unique<ExitConditionGroup>(conditions);
+}
+
+std::vector<ErrorExitCondition::Config> ErrorExitConditionGroupFactory::getConfigs() const {
+    std::lock_guard guard(this->mutex);
+    return this->configs;
+}
+
+void ErrorExitConditionGroupFactory::setConfigs(std::vector<ErrorExitCondition::Config>& newConfigs) {
+    std::lock_guard guard(this->mutex);
+    this->configs = newConfigs;
+}
+
+void ErrorExitConditionGroupFactory::push_back(ErrorExitCondition::Config& newConfigs...) {
+    auto modifiedConfigs = this->getConfigs();
+    modifiedConfigs.push_back(newConfigs);
+    this->setConfigs(modifiedConfigs);
+}
+
+void ErrorExitConditionGroupFactory::clear() {
+    auto newConfigs = this->getConfigs();
+    newConfigs.clear();
+    this->setConfigs(newConfigs);
+}
+
+ExitConditionGroup::ExitConditionGroup(std::vector<std::shared_ptr<ExitCondition>> children) {
+    children.swap(this->children);
+}
+
+bool ExitConditionGroup::update(const float input) {
+    for (auto child : this->children) {
+        if (child->update(input)) return true;
+    }
+    return false;
+}
+
+bool ExitConditionGroup::getExit() const {
+    for (auto child : this->children) {
+        if (child->getExit()) return true;
+    }
+    return false;
 }
 } // namespace lemlib

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -1,5 +1,6 @@
 #include "pid.hpp"
 #include "util.hpp"
+#include <mutex>
 
 namespace lemlib {
 /**
@@ -12,11 +13,10 @@ namespace lemlib {
  * @param signFlipReset whether to reset integral when sign of error flips
  */
 PID::PID(float kP, float kI, float kD, float windupRange, bool signFlipReset)
-    : kP(kP),
-      kI(kI),
-      kD(kD),
-      windupRange(windupRange),
-      signFlipReset(signFlipReset) {}
+    : PID(PID::Gains {.kP = kP, .kI = kI, .kD = kD, .windupRange = windupRange, .signFlipReset = signFlipReset}) {}
+
+PID::PID(const PID::Gains& gains)
+    : gains(gains) {}
 
 /**
  * @brief Update the PID
@@ -25,17 +25,37 @@ PID::PID(float kP, float kI, float kD, float windupRange, bool signFlipReset)
  * @return float output
  */
 float PID::update(const float error) {
+    const PID::Gains gains = this->getGains();
     // calculate integral
     integral += error;
-    if (sgn(error) != sgn((prevError)) && signFlipReset) integral = 0;
-    if (fabs(error) > windupRange && windupRange != 0) integral = 0;
+    if (sgn(error) != sgn((prevError)) && gains.signFlipReset) integral = 0;
+    if (fabs(error) > gains.windupRange && gains.windupRange != 0) integral = 0;
 
     // calculate derivative
     const float derivative = error - prevError;
     prevError = error;
 
     // calculate output
-    return error * kP + integral * kI + derivative * kD;
+    return error * gains.kP + integral * gains.kI + derivative * gains.kD;
+}
+
+void PID::setGains(const PID::OptionalGains& newGains) {
+    const PID::Gains oldGains = this->getGains();
+    this->setGains(PID::Gains {.kP = newGains.kP.value_or(oldGains.kP),
+                               .kI = newGains.kI.value_or(oldGains.kI),
+                               .kD = newGains.kD.value_or(oldGains.kD),
+                               .windupRange = newGains.windupRange.value_or(oldGains.windupRange),
+                               .signFlipReset = newGains.signFlipReset.value_or(oldGains.signFlipReset)});
+}
+
+void PID::setGains(const PID::Gains& newGains) {
+    std::lock_guard guard(this->gainsMutex);
+    this->gains = newGains;
+}
+
+PID::Gains PID::getGains() const {
+    std::lock_guard guard(this->gainsMutex);
+    return this->gains;
 }
 
 /**

--- a/src/lemlib/pid.cpp
+++ b/src/lemlib/pid.cpp
@@ -66,4 +66,12 @@ void PID::reset() {
     integral = 0;
     prevError = 0;
 }
+
+PID::OptionalGains PID::OptionalGains::fromGains(const PID::Gains& gains) {
+    return OptionalGains {.kP = gains.kP,
+                          .kI = gains.kI,
+                          .kD = gains.kD,
+                          .windupRange = gains.windupRange,
+                          .signFlipReset = gains.signFlipReset};
+}
 } // namespace lemlib


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Allows chassis settings to be modified post-construction of the chassis, all in a thread safe / atomic manner. It also adds the ability to have any number of exit conditions and configure them in a much cleaner manner.

PID gains and slew can be changed mid motion, but changing exit conditions mid motion will not take effect until the next motion runs.

#### Motivation
<!-- Why are you making this pull request? -->
Before, an advanced user would have to edit headers to modify chassis settings after chassis construction, risking headaches due to thread-unsafety, but now it's a built-in thread-safe feature.

Also having two different exit conditions annoyed me.

#### Test Plan
<!-- How did you test / plan to test this pull request? -->
I will not be able to test it, but ideally the following tests should be run:
- [ ] check that the same controller settings behaves the same before this PR and with this PR
- [ ] change all 5 PID gains mid-motion and observe an distinct change in behavior
- [ ] change 1-4 PID gains mid-motion and observe a distinct change in behavior
- [ ] change slew mid-motion and a distinct change in behavior
- [ ] add an exit condition mid-motion and observe a a distinct change in behavior only in the next motion
- [ ] clear all exit conditions and observe the motion running until the its timeout
- [ ] check that PID, slew, and exit conditions persist to the next motion

#### Additional Notes
<!-- Add any other information you think is relevant -->
Needs docs / comments

If exit conditions seem to goof, then just use commit 1409044c5890a647e178bb7e2c4da3450059a131, as I doubt the exit conditions can be fixed in a timely manner.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: a196c1c1ff97bcaf266d2a16304b60acb222f979 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8804672252)
- via manual download: [LemLib@0.5.0-rc.7+a196c1.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1440375098.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+a196c1.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1440375098.zip;
pros c fetch LemLib@0.5.0-rc.7+a196c1.zip;
pros c apply LemLib@0.5.0-rc.7+a196c1;
rm LemLib@0.5.0-rc.7+a196c1.zip;
```