### PR TITLE
Unitize lead

### DIFF
--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -240,8 +240,8 @@ struct SwingToHeadingParams {
  * @param forwards whether the robot should move forwards or backwards. True by default
  * @param horizontalDrift how fast the robot will move around corners. Recommended value 2-15.
  *  0 means use horizontalDrift set in chassis class. 0 by default.
- * @param lead carrot point multiplier. value between 0 and 1. Higher values result in
- *  curvier movements. 0.6 by default
+ * @param lead how far from the target the carrot point will start. Higher values result in
+ *  curvier movements. defaults to 60% of the distance to the target point
  * @param maxSpeed the maximum speed the robot can travel at. Value between 0-127.
  *  127 by default
  * @param minSpeed the minimum speed the robot can travel at. If set to a non-zero value,
@@ -253,7 +253,7 @@ struct SwingToHeadingParams {
 struct MoveToPoseParams {
         bool forwards = true;
         float horizontalDrift = 0;
-        float lead = 0.6;
+        float lead = 0;
         float maxSpeed = 127;
         float minSpeed = 0;
         float earlyExitRange = 0;

--- a/src/lemlib/chassis/motions/moveToPose.cpp
+++ b/src/lemlib/chassis/motions/moveToPose.cpp
@@ -44,8 +44,8 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
     if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 
     const float initialDistance = getPose().distance(target);
-    if(params.lead/initialDistance>0.95) params.lead = 0.95*initialDistance; // prevents lead from being too high
-    if(params.lead == 0) params.lead = 0.6*initialDistance; //default lead value
+    if(params.lead / initialDistance > 0.95) params.lead = 0.95 * initialDistance; // prevents lead from being too high
+    if(params.lead == 0) params.lead = 0.6 * initialDistance; // default lead value
     
     // use global horizontalDrift is horizontalDrift is 0
     if (params.horizontalDrift == 0) params.horizontalDrift = drivetrain.horizontalDrift;

--- a/src/lemlib/chassis/motions/moveToPose.cpp
+++ b/src/lemlib/chassis/motions/moveToPose.cpp
@@ -85,7 +85,7 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
         if (lateralLargeExit.getExit() && lateralSmallExit.getExit()) lateralSettled = true;
 
         // calculate the carrot point
-        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget/initialDistance;
+        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget / initialDistance;
         if (close) carrot = target; // settling behavior
 
         // calculate if the robot is on the same side as the carrot point

--- a/src/lemlib/chassis/motions/moveToPose.cpp
+++ b/src/lemlib/chassis/motions/moveToPose.cpp
@@ -43,6 +43,10 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
     Pose target(x, y, M_PI_2 - degToRad(theta));
     if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
 
+    const float initialDistance = getPose().distance(target);
+    if(params.lead/initialDistance>0.95) params.lead = 0.95*initialDistance; // prevents lead from being too high
+    if(params.lead == 0) params.lead = 0.6*initialDistance; //default lead value
+    
     // use global horizontalDrift is horizontalDrift is 0
     if (params.horizontalDrift == 0) params.horizontalDrift = drivetrain.horizontalDrift;
 
@@ -81,7 +85,7 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
         if (lateralLargeExit.getExit() && lateralSmallExit.getExit()) lateralSettled = true;
 
         // calculate the carrot point
-        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget;
+        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget/initialDistance;
         if (close) carrot = target; // settling behavior
 
         // calculate if the robot is on the same side as the carrot point


### PR DESCRIPTION
#### Summary
Changes lead parameter to be the distance from the carrot instead of percentage of the initial distance

#### Motivation
Should make it easier to tune boomerang movements

#### Test Plan
ran it on a bot, seemed to work as intended
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 175c6b571b4bbc752e9333db6b8f40857585d55d -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8842596091)
- via manual download: [LemLib@0.5.0-rc.7+175c6b.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1449513456.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+175c6b.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1449513456.zip;
pros c fetch LemLib@0.5.0-rc.7+175c6b.zip;
pros c apply LemLib@0.5.0-rc.7+175c6b;
rm LemLib@0.5.0-rc.7+175c6b.zip;
```