### PR TITLE
:memo: tweak the content of the documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!-- omit in toc -->
-# Contributing to LemLib
+# Contributing
 
 First off, thanks for taking the time to contribute! ❤️
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,3 +1,3 @@
-# Contribute
+```{include} ../.github/CONTRIBUTING.md
 
-This is how you contribute
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Lemlib: Documentation Home
+# Documentation Home
 
 ```{toctree}
 :hidden:
@@ -18,11 +18,11 @@ self
 :maxdepth: 2
 :caption: Tutorials
 
-./tutorials/1_getting_started
-./tutorials/2_setting_up_the_chassis
-./tutorials/3_driver_control
-./tutorials/4_auto_and_tuning
-./tutorials/5_pure_pursuit
+./tutorials/1_getting_started.md
+./tutorials/2_configuration.md
+./tutorials/3_driver_control.md
+./tutorials/4_auto_and_tuning.md
+./tutorials/5_pure_pursuit.md
 ```
 
 ```{toctree}
@@ -32,3 +32,23 @@ self
 
 ./api/index
 ```
+
+```{image} ./assets/LemLib_Banner_V3.png
+```
+<p align="center">
+    <img src="https://img.shields.io/github/contributors/LemLib/LemLib?style=for-the-badge">
+    <img src="https://img.shields.io/github/stars/LemLib/LemLib?style=for-the-badge">
+    <img src="https://img.shields.io/github/downloads/LemLib/LemLib/total?style=for-the-badge">
+    <img src="https://img.shields.io/github/actions/workflow/status/LemLib/LemLib/pros-build.yml?style=for-the-badge">
+    <img src="https://img.shields.io/badge/version-v0.4.9-blue?style=for-the-badge">
+    <img src="https://img.shields.io/badge/pre_release-v0.5.0-blue?style=for-the-badge">
+</p>
+<hr>
+
+Welcome to the documentation for LemLib!
+
+<!--Welcome to LemLib! This open-source PROS template aims to introduce common algorithms like Pure Pursuit and Odometry for new and experienced teams alike.-->
+
+
+
+

--- a/docs/tutorials/1_getting_started.md
+++ b/docs/tutorials/1_getting_started.md
@@ -1,11 +1,11 @@
 # 1 - Getting Started
 
-### Installation - VS Code
+## Installation - VS Code
 
 We recommend using [Visual Studio Code](https://code.visualstudio.com/) as a code editor. Click on the link and click the download button, as shown in the image below:
 ![vscode](../assets/1_getting_started/download-visual-studio-code.png)
 
-### Installation - PROS
+## Installation - PROS
 
 [PROS](https://pros.cs.purdue.edu/) provides the tooling needed to build and upload programs. It can be installed as a VSCode [Extension](https://marketplace.visualstudio.com/items?itemName=sigbots.pros). Simply click on the blocks at the bottom of the sidebar on the left in VSCode, search up `PROS`, and click `install`, as shown in the image below:
 
@@ -17,13 +17,13 @@ After the extension has been downloaded, you should see a notification as seen i
 
 After the toolchain has been installed, you can create a new PROS project. Select the PROS logo in the sidebar, click `Create Project`, select an empty folder for the project, give it a suitable name, e.g `1010N-Spin-Up`, select `v5`, and for kernel version select `3.8.3`. A notification in the bottom right will pop up notifying you that the project is being created. VSCode will open a new window as soon as it is ready. There will be a popup asking whether to "trust" the folder, click `yes`. You have now installed PROS and created your first project!
 
-### Installation - clangd
+## Installation - clangd
 
 [clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) is a linter and provides code completion, and is essential for any programmer. We recommend this over the [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) extension as its much faster.
 
 To install clangd, repeat the steps to install the PROS extension, but search up `clangd` instead of `PROS`. After it has been installed, open the `main.cpp` file in your project. A notification from clangd will appear in the bottom right stating that it needs to install. Click `install` and wait for it to finish installing. If the notification does not appear, ensure you have clangd installed and reopen `main.cpp`. You have now installed clangd!
 
-### LemLib Installation
+## LemLib Installation
 
 To install LemLib, first need to open the PROS integrated terminal. This can be done by clicking on the PROS icon on the left of the screen and clicking `integrated terminal`
 
@@ -39,5 +39,3 @@ finally, put this at the top of your main.cpp file
 ```
 
 You've now installed LemLib, and you're ready to configure your robot!
-
-> Next: [Configuration](../tutorials/2_setting_up_the_chassis.md)

--- a/docs/tutorials/2_configuration.md
+++ b/docs/tutorials/2_configuration.md
@@ -1,23 +1,26 @@
-# 02 - Setting Up The Chassis
+# 2 - Setting Up The Chassis
 
-### Introduction
+## Introduction
 
 Now that LemLib has been installed, we need to configure it before we can start using it. Most mistakes happen during configuration, so pay close attention to the instructions.
 
-### The Drivetrain
+## The Drivetrain
 
 First, we need to configure the motors on our drivetrain. Each motor has 3 properties: the port its connected to, whether its reversed or not, and what cartridge is installed (AKA gearbox).
 
-> [!IMPORTANT]
-> Motors are on the left side of the robot from the robot's point of view
+```{important}
+Motors are on the left side of the robot from the robot's point of view.
+```
 
 Let's start off by identifying the motors on the robot. We need to figure out what ports they are connected to. This can be done by entering the devices menu on the brain, and observing what port disappears when you unplug a motor. Record what motor is connected to what port. Now, instantiate the motor objects:
 
-> [!IMPORTANT]
-> Motors should be created outside of a function, near the top of the file
+```{important}
+Motors should be created outside of a function, near the top of the file.
+```
 
-> [!INFO]
-> [pros::Motor documentation](https://pros.cs.purdue.edu/v5/api/cpp/motors.html)
+```{seealso}
+[pros::Motor documentation](https://pros.cs.purdue.edu/v5/api/cpp/motors.html)
+```
 
 ```cpp
 pros::Motor front_left_motor(1); // front left motor on port 1
@@ -30,8 +33,9 @@ pros::motor back_right_motor(6); // back right motor on port 6
 
 Now, we need to determine which way the motors spin when we apply a positive voltage. This can be done by moving the motor through the devices menu on the brain screen and observing how the drive wheels move. See the table below for determining whether a motor is reversed or not:
 
-> [!IMPORTANT]
-> This needs to be done for all motors on the drivetrain
+```{important}
+This needs to be done for all motors on the drivetrain
+```
 
 |                   | **Clockwise**         | **Counter-Clockwise** |
 | ----------------- | --------------------- | --------------------- |
@@ -70,8 +74,9 @@ pros::motor back_right_motor(6, pros::E_MOTOR_GEARSET_36); // red cartridge
 
 Now, all our motors are configured. However, we need to add them to motor groups so LemLib can interface with them. See the code below:
 
-> [!INFO]
-> [pros::MotorGroup documentation](https://pros.cs.purdue.edu/v5/api/cpp/motor_groups.html)
+```{seealso}
+[pros::MotorGroup documentation](https://pros.cs.purdue.edu/v5/api/cpp/motor_groups.html)
+```
 
 ```cpp
 pros::Motor front_left_motor(-1, pros::E_MOTOR_GEARSET_18); // left_motor_group
@@ -106,8 +111,9 @@ Record the track width, we'll need it soon.
 
 This one should be self-explanatory. Its the diameter of the wheels on your drivetrain. The diameter on the wheels are actually slightly different than the diameter advertised by Vex (and, as is typical of Vex, this is not documented anywhere). For that reason, LemLib includes constants for all the different wheels, as follows:
 
-> [!NOTE]
-> If, for whatever reason, you want a custom wheel size: you can input a number instead of a constant
+```{note}
+If, for whatever reason, you want a custom wheel size: you can input a number instead of a constant
+```
 
 | **Wheel Type**     | **Actual Size** | **LemLib Constant**               |
 | ------------------ | --------------- | --------------------------------- |
@@ -127,7 +133,7 @@ This one should be self-explanatory. Its the diameter of the wheels on your driv
 
 Record the wheel diameter, we'll need it soon.
 
-#### Horizontal Drift
+### Horizontal Drift
 
  [//]: # (TODO: Link tuning tutorial here) 
 Don't worry about horizontal drift, we'll cover it in the tuning tutorial. For now, just set it to 2.
@@ -136,8 +142,9 @@ Don't worry about horizontal drift, we'll cover it in the tuning tutorial. For n
 
 We now have all the necessary information to configure the drivetrain. We will use the `Drivetrain` class to store this info, see the example below:
 
-> [!IMPORTANT]
-> This needs to be created after the motors and motor groups have been created, and has to be outside of a function
+```{important}
+This needs to be created after the motors and motor groups have been created, and has to be outside of a function
+```
 
 ```cpp
 // drivetrain settings
@@ -153,11 +160,11 @@ lemlib::Drivetrain drivetrain(&left_motor_group, // left motor group
 
 Odometry is the algorithm that tracks the robots position. It does this through internal motors encoders (IME) and/or tracking wheels and/or V5 Inertial Sensors (IMU). We need to configure these sensors so LemLib can interact with them
 
-#### IMU
+### IMU
 
 For the IMU, all we need to do is find the port it is connected to. Enter the devices menu on the brain screen, and see what port the IMU is connected to. Record this, we will need it soon.
 
-#### Tracking Wheels
+### Tracking Wheels
 
 Tracking wheels are independent wheels that have an encoder attached to them. See the image below:
 
@@ -165,13 +172,13 @@ Tracking wheels are independent wheels that have an encoder attached to them. Se
 
 LemLib can work on any tracking setup, but some setups perform much better than others. See the table below:
 
-###### Heading Tracking:
+##### Heading Tracking:
 
 | Recommended | Acceptable                  | Not Recommended   |
 | ----------- | --------------------------- | ----------------- |
 | 1x IMU      | 2x parallel tracking wheels | IMEs              |
 
-###### Lateral Position Tracking
+##### Lateral Position Tracking
 
 There are more possible configs for lateral position tracking. Let's start with the recommended vertical tracking:
 
@@ -187,9 +194,9 @@ Recommended horizontal tracking:
 
 It's recommended to use a horizontal tracking wheel even you have traction wheels, since even with traction wheels the robot can still slide horizontally slightly. It is strongly recommended to use a horizontal tracking wheel if your drivetrain only uses omniwheels, since the robot can drift horizontally a lot.
 
-> [!INFO]
-> the optimal tracking setup is 1x IMU, 1x vertical tracking wheel, 1x horizontal tracking wheel
-
+```{seealso}
+The optimal tracking setup is 1x IMU, 1x vertical tracking wheel, 1x horizontal tracking wheel
+```
 #### Code Config
 
 ##### Tracking Wheels
@@ -200,14 +207,17 @@ Tracking wheels require encoders, and encoders have 2 properties we need to know
 
 First, we need to create the encoders. The process is different for the 2 different sensors:
 
-###### Optical Shaft Encoder
+##### Optical Shaft Encoder
 
-> [!IMPORTANT]
-> The optical shat encoder uses 2 ADI (tri-port) ports. However, there are only a few valid port combinations, they are as follows:
-> ('A', 'B'); ('C', 'D'); ('E', 'F'); ('G', 'H')
+```{important}
+The optical shat encoder uses 2 ADI (tri-port) ports. However, there are only a few valid port combinations, they are as follows:
+('A', 'B'); ('C', 'D'); ('E', 'F'); ('G', 'H')
+```
 
-> [!INFO]
-> [pros::ADIEncoder documentation](https://pros.cs.purdue.edu/v5/api/cpp/adi.html#pros-adiencoder)
+```{seealso}
+[pros::ADIEncoder documentation](https://pros.cs.purdue.edu/v5/api/cpp/adi.html#pros-adiencoder)
+```
+
 
 ```cpp
 // create an optical shaft encoder connected to ports 'A' and 'B'

--- a/docs/tutorials/3_driver_control.md
+++ b/docs/tutorials/3_driver_control.md
@@ -1,4 +1,4 @@
-# 03 - Driver Control
+# 3 - Driver Control
 
 ## Introduction
 In this tutorial, we will be learning how to program the drivetrain to allow for controller joystick inputs.

--- a/docs/tutorials/4_auto_and_tuning.md
+++ b/docs/tutorials/4_auto_and_tuning.md
@@ -1,4 +1,4 @@
-# 04 - Tuning and Moving
+# 4 - Tuning and Moving
 
 ## Introduction
 In this tutorial, we will be learning how to tune the PIDs, move the robot autonomously, and use odometry.

--- a/docs/tutorials/5_pure_pursuit.md
+++ b/docs/tutorials/5_pure_pursuit.md
@@ -1,4 +1,4 @@
-# 05 - Pure Pursuit
+# 5 - Pure Pursuit
 
 ## Introduction
 


### PR DESCRIPTION
#### Summary

I've made some small changes to the docs to make them more complete/render better.

- All of the admonitions are now done with MyST and render correctly
- I removed the next tutorial link on the first tutorial since sphinx makes it redundant
- I linked the contributing guide so that the contributing page actually has content
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: ce6d799a9e75fde1fc2cf7d4db6525bfb379a30b -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8917067970)
- via manual download: [LemLib@0.5.0-rc.7+ce6d79.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1465503032.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+ce6d79.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1465503032.zip;
pros c fetch LemLib@0.5.0-rc.7+ce6d79.zip;
pros c apply LemLib@0.5.0-rc.7+ce6d79;
rm LemLib@0.5.0-rc.7+ce6d79.zip;
```