### PR TITLE
:memo: write the empty pages in the docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -159,7 +159,7 @@ You can apply the kernel to your project with the following commands
 - Apply the kernel: `pros c apply LemLib@a.b.c-d`
 - Remove the template: `pros c remove LemLib@a.b.c-d`
 
-In order to contribute to LemLib, you will need to [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository and clone it to your local machine. You can then [commit](#commit-messages) your changes to your fork. Once you are done, you can [create a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the master branch. You can use the [Pull Request Template](PULL_REQUEST_TEMPLATE.md) to structure your pull request.
+In order to contribute to LemLib, you will need to [fork](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) the repository and clone it to your local machine. You can then [commit](#commit-messages) your changes to your fork. Once you are done, you can [create a pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the master branch. You can use the [Pull Request Template](https://github.com/LemLib/LemLib/blob/master/.github/PULL_REQUEST_TEMPLATE.md) to structure your pull request.
 
 
 ### Improving The Documentation
@@ -168,12 +168,11 @@ We use a combination of [Doxygen](http://www.doxygen.nl/), [Breathe](https://www
 You can improve the documentation by:
 - Editing the [README](../README.md)
 - Adding/Editing comments in the source code
-- Editing the [Doxygen configuration file](../docs/Doxyfile)
-- Changing the [Header HTML file](../docs/doxygen-awesome/header.html) and the [Footer HTML file](../docs/doxygen-awesome/footer.html)
-- Adding/Editing [Tutorials](../docs/tutorials)
+- Editing the [Doxygen configuration file](https://github.com/LemLib/LemLib/blob/master/docs/Doxyfile)
+- Adding/Editing [Tutorials](https://github.com/LemLib/LemLib/tree/master/docs/tutorials)
 - Opening an [Issue](https://github.com/LemLib/LemLib/issues) to suggest a change or to report a bug
 
-Changes should be requested via a [Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the LemLib repository. You can use the [Pull Request Template](PULL_REQUEST_TEMPLATE.md) to structure your pull request. Additionally, you should verify that the documentation builds correctly on your machine.
+Changes should be requested via a [Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) to the LemLib repository. You can use the [Pull Request Template](https://github.com/LemLib/LemLib/blob/master/.github/PULL_REQUEST_TEMPLATE.md) to structure your pull request. Additionally, you should verify that the documentation builds correctly on your machine.
 
 You can do so by installing Doxygen, and all of the python dependencies listed in `docs/requirements.txt`. Once you've done that, run the following commands to render the documentation:
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,5 +1,49 @@
 # About
 
-```{tip}
-Here's an example of a tip
-```
+This open-source PROS template aims to introduce common algorithms like Pure Pursuit and Odometry for new and experienced teams alike.
+
+The creation of this template was inspired by [EZ-Template](https://github.com/EZ-Robotics/EZ-Template) and [OkapiLib](https://github.com/OkapiLib/OkapiLib). We aim to develop a library that strikes a balance between ease-of-use, akin to that of EZ-Template, and comprehensive functionality, similar to that of OkapiLib.
+
+
+## License
+This project is licensed under the MIT license. Check [LICENSE](https://github.com/LemLib/LemLib/blob/master/LICENSE) for more details.
+
+## Features
+- Generic PID class
+- Odometry
+- Odom turn to face point
+- [Boomerang controller](https://www.desmos.com/calculator/sptjw5szex) (Beta)
+- Pure Pursuit
+- [Path Generator](https://github.com/LemLib/Path-Gen) support
+
+## FAQ
+_**1. Help! Why is my controller vibrating?**_
+Your inertial sensor calibration failed.
+Check if its connected to the right port and try again.
+
+_**2. What drivetrains are supported?**_
+Only tank/differential.
+This is not going to change, as other drivetrains simply aren't popular enough.
+
+_**3. Do I need tracking wheels?**_
+No, but it is recommended.
+You should absolutely have a horizontal tracking wheel if you don't have traction wheels, and you have to spend extra effort tuning your movements to prevent any wheel slip.
+
+_**4. Do I need an inertial sensor?**_
+No, but it is highly recommended.
+The one exception to this would be if you have 2 parallel tracking wheels which are tuned well and are perfectly square. LemLib will work without it, but the accuracy will be compromised. 
+
+_**5. Do I need an SD card?**_
+As of the `v0.5.0` release, paths are directly embedded in the binary, meaning an SD card is no longer required.
+
+_**6. What are the units?**_
+The units are inches and degrees.
+In a future release, Qunits will be used so you can use whatever units you like.
+
+_**7. Is LemLib VRC legal?**_
+Yes.
+Per the RECF student-centred policy, in the context of third-party libraries.
+> Students should be able to understand and explain the code used on their robots
+
+In other words, you need to know how LemLib works. You don't need to know the details like all the math, just more or less how the algorithm works. If you want to learn more about LemLib, you can look through the documentation and ask questions on our Discord server.
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,8 @@ extensions = [
     'breathe',
     'myst_parser',
     'sphinx_copybutton',
+    'sphinx.ext.autosectionlabel',
+    'sphinx.ext.todo',
 ]
 
 templates_path = ['_templates']
@@ -68,7 +70,7 @@ myst_enable_extensions = [
     "fieldlist",
     "html_admonition",
     "html_image",
-    #"linkify",
+    "linkify",
     "replacements",
     "smartquotes",
     "strikethrough",

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,2 +1,38 @@
-Download
-========
+# Download
+
+## Manual Download
+
+LemLib can be downloaded as a [PROS](https://pros.cs.purdue.edu/) template from the [releases](https://github.com/LemLib/LemLib/releases) tab in the LemLib github repository.
+
+## Depot Download
+
+If you don't want to re-download LemLib every time a new release comes out, we've set up a depot to make the updating process easier.
+
+You can use the following commands to add the depot to your `pros-cli` installation.
+
+```bash
+pros c add-depot LemLib https://raw.githubusercontent.com/LemLib/LemLib/depot/stable.json # adds LemLib's stable depot
+pros c apply LemLib # applies latest stable version of LemLib
+```
+
+To update LemLib, all you have to do is run the following command:
+
+```bash
+pros c update
+```
+
+### Beta Depot
+
+```{warning}
+Beta versions of LemLib may not be fully tested or documented. Use at your own risk.
+```
+
+If you'd like to use a beta version of LemLib you can add our beta depot like so:
+
+```bash
+pros c add-depot LemLib https://raw.githubusercontent.com/LemLib/LemLib/depot/beta.json # adds LemLib's beta depot
+```
+
+## Further steps
+
+Once you've downloaded LemLib we recommend you take a look at our [tutorials](./tutorials/1_getting_started.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,13 @@
 # Documentation Home
 
+Welcome to the documentation for LemLib! This site contains everything you'd need to use to use or contribute to the LemLib template.
+
+If you're new to LemLib, and are looking for an introduction, check out the introductory [tutorials](./tutorials/1_getting_started.md).
+
+If you already know what you're doing, and just need a specific piece of information, check out the [API reference](./api/index.md).
+
+If you'd like to contribute to LemLib, we ask that you read the [contributing guide](./contribute.md) first.
+
 ```{toctree}
 :hidden:
 :maxdepth: 2
@@ -32,23 +40,5 @@ self
 
 ./api/index
 ```
-
-```{image} ./assets/LemLib_Banner_V3.png
-```
-<p align="center">
-    <img src="https://img.shields.io/github/contributors/LemLib/LemLib?style=for-the-badge">
-    <img src="https://img.shields.io/github/stars/LemLib/LemLib?style=for-the-badge">
-    <img src="https://img.shields.io/github/downloads/LemLib/LemLib/total?style=for-the-badge">
-    <img src="https://img.shields.io/github/actions/workflow/status/LemLib/LemLib/pros-build.yml?style=for-the-badge">
-    <img src="https://img.shields.io/badge/version-v0.4.9-blue?style=for-the-badge">
-    <img src="https://img.shields.io/badge/pre_release-v0.5.0-blue?style=for-the-badge">
-</p>
-<hr>
-
-Welcome to the documentation for LemLib!
-
-<!--Welcome to LemLib! This open-source PROS template aims to introduce common algorithms like Pure Pursuit and Odometry for new and experienced teams alike.-->
-
-
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ breathe
 myst-parser
 furo
 sphinx-copybutton
+linkify-it-py

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,1 +1,18 @@
 # Support
+
+If you love LemLib, and want to give back to the community, there are many ways to do so.
+
+## Testing
+
+Testing is a great way to help us speed up development. Testing is required for all of our pull requests in order to assure the quality of our software, but lack of access to V5 hardware and time constraints can often make it difficult to get things tested quickly.
+
+To get started, join our [Discord](https://discord.gg/pCHr7XZUTj), and check out the pull requests that need testing [here](https://github.com/LemLib/LemLib/pulls?q=is%3Aopen+is%3Apr+label%3A%22Needs+Testing%22).
+
+## Contributing
+
+Contributing is another great way to help us improve LemLib. All contributions are welcome, no matter how large or small. We ask that before you contribute, you read the [contributing guide](./contribute.md).
+
+## Donating
+
+> TODO: write this
+


### PR DESCRIPTION
#### Summary

I wrote all of the pages that were blank in the new documentation.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 1328d30572f45a36242b7db568499bd6414f914c -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8931258284)
- via manual download: [LemLib@0.5.0-rc.7+1328d3.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1468878709.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0-rc.7+1328d3.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1468878709.zip;
pros c fetch LemLib@0.5.0-rc.7+1328d3.zip;
pros c apply LemLib@0.5.0-rc.7+1328d3;
rm LemLib@0.5.0-rc.7+1328d3.zip;
```