### PR TITLE
Fix Documentation Links in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,7 +34,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 ## 🙋I Have a Question
 
-> If you want to ask a question, we assume that you have read the available [Documentation](https://lemlib.github.io/LemLib/).
+> If you want to ask a question, we assume that you have read the available [Documentation](https://lemlib.readthedocs.io/en/latest/).
 
 Before you ask a question, it is best to search for existing [Issues](https://github.com/LemLib/LemLib/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. In addition, you can also search for existing questions in the [Vex Discord](https://discord.gg/VUStG8p), the [VEX Forum](https://www.vexforum.com/), or our [Discord](https://discord.gg/pCHr7XZUTj).
 
@@ -65,7 +65,7 @@ We will then take care of the issue as soon as possible.
 A good bug report shouldn't leave others needing to chase you up for more information. Therefore, we ask you to investigate carefully, collect information and describe the issue in detail in your report. Please complete the following steps in advance to help us fix any potential bug as fast as possible.
 
 - Make sure that you are using the latest version of LemLib, PROS, and the CLI.
-- Determine if your bug is really a bug and not an error on your side e.g. incorrect chassis setup (Make sure that you have read the [documentation](https://lemlib.github.io/LemLib/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
+- Determine if your bug is really a bug and not an error on your side e.g. incorrect chassis setup (Make sure that you have read the [documentation](https://lemlib.readthedocs.io/en/latest/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
 - To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/LemLib/LemLib/issues?q=label%3Abug).
 - Collect information about the bug:
   - Logger Messages
@@ -104,7 +104,7 @@ This section guides you through submitting an enhancement suggestion for LemLib,
 #### ✨Before Submitting an Enhancement
 
 - Make sure that you are using the latest version.
-- Read the [documentation](https://lemlib.github.io/LemLib/) carefully and find out if the functionality is already covered, maybe by an individual configuration.
+- Read the [documentation](https://lemlib.readthedocs.io/en/latest/) carefully and find out if the functionality is already covered, maybe by an individual configuration.
 - Perform a [search](https://github.com/LemLib/LemLib/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset.
 


### PR DESCRIPTION
#### Summary
Changed `https://lemlib.github.io/LemLib` to `https://lemlib.readthedocs.io/en/latest/index.html`

#### Motivation
To fix the documentation links

#### Test Plan
Clicking on the Contributing.md links

#### Additional Notes
No additional relevant info that I can think of.
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: b1988c64a957a1e6b15cf752d879bbc51cc79ec6 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/8975385964)
- via manual download: [LemLib@0.5.0+b1988c.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1477870840.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0+b1988c.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1477870840.zip;
pros c fetch LemLib@0.5.0+b1988c.zip;
pros c apply LemLib@0.5.0+b1988c;
rm LemLib@0.5.0+b1988c.zip;
```