### PR TITLE
[FIX] Add E_CONTROLLER_MASTER to controllers in 3 - Driver Control

### DIFF
--- a/docs/tutorials/3_driver_control.md
+++ b/docs/tutorials/3_driver_control.md
@@ -10,7 +10,7 @@ The controller has 2 joysticks. A `left` one and a `right` one. Each joystick ha
 Tank drive is a simple method of controlling the drivetrain. You give it the power for the left wheels and the power for the right wheels. In this example, we will use the `left y` axis and the `right y` axis.
 
 ```cpp
-pros::Controller controller();
+pros::Controller controller(E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -34,7 +34,7 @@ Arcade drive is the most popular form of controlling the robot. In arcade contro
 ### Single Stick Arcade
 
 ```cpp
-pros::Controller controller();
+pros::Controller controller(E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -55,7 +55,7 @@ void opcontrol() {
 ### Double Stick Arcade
 
 ```cpp
-pros::Controller controller();
+pros::Controller controller(E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -82,7 +82,7 @@ This section is optional and is not needed to control the robot
 You can prioritize steering over turning, or vice versa. For example, you could fully prioritize steering so that the angular velocity of the robot is guaranteed to be the same for a given steering input, no matter the throttle input. With LemLib, you can prioritize steering over throttle by a set amount, from 0 to 1. 0.5 is the default, where steering and turning have the same priority. 0 fully prioritizes throttle, while 1 fully prioritizes steering. See the code block below:
 
 ```cpp
-pros::Controller controller();
+pros::Controller controller(E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -107,7 +107,7 @@ Curvature drive is a lesser-know, yet powerful, method. We give the robot a forw
 ### Single Stick Curvature
 
 ```cpp
-pros::Controller controller();
+pros::Controller controller(E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -128,7 +128,7 @@ void opcontrol() {
 ### Double Stick Curvature
 
 ```cpp
-pros::Controller controller();
+pros::Controller controller(E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever

--- a/docs/tutorials/3_driver_control.md
+++ b/docs/tutorials/3_driver_control.md
@@ -10,7 +10,7 @@ The controller has 2 joysticks. A `left` one and a `right` one. Each joystick ha
 Tank drive is a simple method of controlling the drivetrain. You give it the power for the left wheels and the power for the right wheels. In this example, we will use the `left y` axis and the `right y` axis.
 
 ```cpp
-pros::Controller controller(E_CONTROLLER_MASTER);
+pros::Controller controller(pros::E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -34,7 +34,7 @@ Arcade drive is the most popular form of controlling the robot. In arcade contro
 ### Single Stick Arcade
 
 ```cpp
-pros::Controller controller(E_CONTROLLER_MASTER);
+pros::Controller controller(pros::E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -55,7 +55,7 @@ void opcontrol() {
 ### Double Stick Arcade
 
 ```cpp
-pros::Controller controller(E_CONTROLLER_MASTER);
+pros::Controller controller(pros::E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -82,7 +82,7 @@ This section is optional and is not needed to control the robot
 You can prioritize steering over turning, or vice versa. For example, you could fully prioritize steering so that the angular velocity of the robot is guaranteed to be the same for a given steering input, no matter the throttle input. With LemLib, you can prioritize steering over throttle by a set amount, from 0 to 1. 0.5 is the default, where steering and turning have the same priority. 0 fully prioritizes throttle, while 1 fully prioritizes steering. See the code block below:
 
 ```cpp
-pros::Controller controller(E_CONTROLLER_MASTER);
+pros::Controller controller(pros::E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -107,7 +107,7 @@ Curvature drive is a lesser-know, yet powerful, method. We give the robot a forw
 ### Single Stick Curvature
 
 ```cpp
-pros::Controller controller(E_CONTROLLER_MASTER);
+pros::Controller controller(pros::E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever
@@ -128,7 +128,7 @@ void opcontrol() {
 ### Double Stick Curvature
 
 ```cpp
-pros::Controller controller(E_CONTROLLER_MASTER);
+pros::Controller controller(pros::E_CONTROLLER_MASTER);
 
 void opcontrol() {
     // loop forever


### PR DESCRIPTION
#### Summary
The tutorials have `pros::Controller controller();`, which isn't valid in PROS since it needs E_CONTROLLER_MASTER

#### Motivation
So we don't keep getting support requests with this exact problem in the LemLib discord.

#### Test Plan
I didn't, though this is just documentation edits

#### Additional Notes
<!-- Add any other information you think is relevant -->

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 4c8d597724524722eb464ab2c439c03063d1e75a -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/9021096582)
- via manual download: [LemLib@0.5.0+4c8d59.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1488552061.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0+4c8d59.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1488552061.zip;
pros c fetch LemLib@0.5.0+4c8d59.zip;
pros c apply LemLib@0.5.0+4c8d59;
rm LemLib@0.5.0+4c8d59.zip;
```