### PR TITLE
Fix pros::Motor capitalization in 2_configuration.md

### DIFF
--- a/docs/tutorials/2_configuration.md
+++ b/docs/tutorials/2_configuration.md
@@ -24,7 +24,7 @@ pros::Motor middle_left_motor(2); // middle left motor on port 2
 pros::Motor back_left_motor(3); // back left motor on port 3
 pros::Motor front_right_motor(4); // front right motor on port 4
 pros::Motor middle_right_motor(5); // middle right motor on port 5
-pros::motor back_right_motor(6); // back right motor on port 6
+pros::Motor back_right_motor(6); // back right motor on port 6
 ```
 
 ```{tip}
@@ -50,7 +50,7 @@ pros::Motor middle_left_motor(-2); // reversed
 pros::Motor back_left_motor(-3); // reversed
 pros::Motor front_right_motor(4); // forwards
 pros::Motor middle_right_motor(5); // forwards
-pros::motor back_right_motor(6); // forwards
+pros::Motor back_right_motor(6); // forwards
 ```
 
 Now, we need to specify what cartridge is used by every motor. The cartridge can be checked by looking at the area below the shaft of the motor. A motor can have one of three cartridges:
@@ -69,7 +69,7 @@ pros::Motor middle_left_motor(-2, pros::E_MOTOR_GEAR_BLUE); // blue cartridge
 pros::Motor back_left_motor(-3, pros::E_MOTOR_GEAR_RED); // red cartridge
 pros::Motor front_right_motor(4, pros::E_MOTOR_GEAR_GREEN); // green cartridge
 pros::Motor middle_right_motor(5, pros::E_MOTOR_GEAR_BLUE); // blue cartridge
-pros::motor back_right_motor(6, pros::E_MOTOR_GEAR_RED); // red cartridge
+pros::Motor back_right_motor(6, pros::E_MOTOR_GEAR_RED); // red cartridge
 ```
 
 Now, all our motors are configured. However, we need to add them to motor groups so LemLib can interface with them. See the code below:
@@ -80,7 +80,7 @@ pros::Motor middle_left_motor(-2, pros::E_MOTOR_GEAR_BLUE); // left_motor_group
 pros::Motor back_left_motor(-3, pros::E_MOTOR_GEAR_RED); // left_motor_group
 pros::Motor front_right_motor(4, pros::E_MOTOR_GEAR_GREEN); // right_motor_group
 pros::Motor middle_right_motor(5, pros::E_MOTOR_GEAR_BLUE); // right_motor_group
-pros::motor back_right_motor(6, pros::E_MOTOR_GEAR_RED); // right_motor_group
+pros::Motor back_right_motor(6, pros::E_MOTOR_GEAR_RED); // right_motor_group
 
 // left motor group
 pros::MotorGroup left_motor_group({ front_left_motor, middle_left_motor, back_left_motor });
@@ -386,7 +386,7 @@ pros::Motor middle_left_motor(-2, pros::E_MOTOR_GEAR_BLUE); // left_motor_group
 pros::Motor back_left_motor(-3, pros::E_MOTOR_GEAR_RED); // left_motor_group
 pros::Motor front_right_motor(4, pros::E_MOTOR_GEAR_GREEN); // right_motor_group
 pros::Motor middle_right_motor(5, pros::E_MOTOR_GEAR_BLUE); // right_motor_group
-pros::motor back_right_motor(6, pros::E_MOTOR_GEAR_RED); // right_motor_group
+pros::Motor back_right_motor(6, pros::E_MOTOR_GEAR_RED); // right_motor_group
 
 // left motor group
 pros::MotorGroup left_motor_group({ front_left_motor, middle_left_motor, back_left_motor });


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
At the end of each cpp code block where motors were set, pros::motor was used instead of pros::Motor. (pros::motor is invalid, pros::Motor is proper)

#### Motivation
<!-- Why are you making this pull request? -->
Fix the Docs

#### Test Plan
<!-- How did you test / plan to test this pull request? -->
Reading the PROS docs.

#### Additional Notes
<!-- Add any other information you think is relevant -->

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: bcc5bb1a523ca19241269937fe134577539bb353 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/9037045802)
- via manual download: [LemLib@0.5.0+bcc5bb.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1492264139.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0+bcc5bb.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1492264139.zip;
pros c fetch LemLib@0.5.0+bcc5bb.zip;
pros c apply LemLib@0.5.0+bcc5bb;
rm LemLib@0.5.0+bcc5bb.zip;
```