### PR TITLE
Remove redundant imu status check

### DIFF
--- a/src/lemlib/chassis/chassis.cpp
+++ b/src/lemlib/chassis/chassis.cpp
@@ -55,7 +55,7 @@ void calibrateIMU(lemlib::OdomSensors& sensors) {
         sensors.imu->reset();
         // wait until IMU is calibrated
         do pros::delay(10);
-        while (sensors.imu->get_status() != 0xFF && sensors.imu->is_calibrating());
+        while (sensors.imu->is_calibrating());
         // exit if imu has been calibrated
         if (!isnanf(sensors.imu->get_heading()) && !isinf(sensors.imu->get_heading())) {
             calibrated = true;


### PR DESCRIPTION
#### Summary
Removes the `sensors.imu->get_status() != 0xFF` from the loop that blocks until imu calibration is done.

#### Motivation
PROS has that [condition](https://github.com/purduesigbots/pros/blob/develop/src/devices/vdml_imu.cpp#L65) to their `is_calibrating()` method so there is no need for it to be there anymore.

#### Test Plan
Idk if testing is needed for this, but I don't have access to a bot rn if it is 

#### Additional Notes
It's interesting to note that the `imu.reset()` method with the `blocking` parameter set to `true` does not include [this](https://github.com/purduesigbots/pros/blob/develop/src/devices/vdml_imu.c#L66) condition for some reason so it can't be used in place of the current blocking while loop. 

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: b92e0d6d2b935cd55a4605d04cdbd5a474c4be81 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/9045634106)
- via manual download: [LemLib@0.5.0+b92e0d.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1493869145.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0+b92e0d.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1493869145.zip;
pros c fetch LemLib@0.5.0+b92e0d.zip;
pros c apply LemLib@0.5.0+b92e0d;
rm LemLib@0.5.0+b92e0d.zip;
```