### PR TITLE
Add fmtlib license

### DIFF
--- a/include/fmt/LICENSE
+++ b/include/fmt/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 - present, Victor Zverovich and {fmt} contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--- Optional exception to the license ---
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into a machine-executable object form of such
+source code, you may redistribute such embedded portions in such object form
+without including the above copyright and permission notices.


### PR DESCRIPTION
#### Summary
Add the license for the fmt library.

#### Test Plan
LemLib works.

#### Additional Notes
Sorry fmt devs!
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 1ae2907a48092b1330bd1cd4ff52d6696528faac -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/9053746800)
- via manual download: [LemLib@0.5.0+1ae290.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/1495157230.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.0+1ae290.zip https://nightly.link/LemLib/LemLib/actions/artifacts/1495157230.zip;
pros c fetch LemLib@0.5.0+1ae290.zip;
pros c apply LemLib@0.5.0+1ae290;
rm LemLib@0.5.0+1ae290.zip;
```