### PR TITLE
Update README.md links to correct docs version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project is licensed under the MIT license. Check [LICENSE](https://github.c
 You can find a fully annotated example project [here](https://github.com/LemLib/LemLib/blob/stable/src/main.cpp).
 
 ## Tutorials
-The [tutorials](https://lemlib.readthedocs.io/en/v0.5.0/tutorials/1_getting_started.html) provide a detailed walkthrough through all the features of LemLib. It covers everything from installation to Path Following:
+The [tutorials](https://lemlib.readthedocs.io/en/stable/tutorials/1_getting_started.html) provide a detailed walkthrough through all the features of LemLib. It covers everything from installation to Path Following:
 
 ## FAQ
 _**1. Help! Why is my controller vibrating?**_
@@ -63,7 +63,7 @@ Per the RECF student-centred policy, in the context of third-party libraries.
 In other words, you need to know how LemLib works. You don't need to know the details like all the math, just more or less how the algorithm works. If you want to learn more about LemLib, you can look through the documentation and ask questions on our Discord server.
 
 ## Documentation
-Check out the [Documentation](https://lemlib.readthedocs.io/en/v0.5.0/index.html).
+Check out the [Documentation](https://lemlib.readthedocs.io/en/stable/index.html).
 
 ## Contributing
 Want to contribute? Please read [CONTRIBUTING.md](https://github.com/LemLib/LemLib/blob/master/.github/CONTRIBUTING.md) and join our [Discord server](https://discord.gg/pCHr7XZUTj).


### PR DESCRIPTION
#### Summary
Updates docs links in README.md to the correct version

#### Motivation
The links currently go to the docs for v0.5.0, which is an outdated version

#### Test Plan
Click the docs links in README.md and verify that they go to the correct version

#### Additional Notes
N/A
