### PR TITLE
Update github pages redirect to correct docs version

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
 <head>
     <title>Old Page</title>
     <meta charset="UTF-8" />
-    <meta http-equiv="refresh" content="3; URL=https://lemlib.readthedocs.io/en/v0.5.0/index.html" />
+    <meta http-equiv="refresh" content="3; URL=https://lemlib.readthedocs.io/en/stable/index.html" />
 </head>
 
 <body>
     <p>The documentation has been moved from GitHub pages to ReadTheDocs. If you are not redirected within 3 seconds,
-        click <a href="https://lemlib.readthedocs.io/en/v0.5.0/index.html">here</a> to go to the LemLib Documentation.</p>
+        click <a href="https://lemlib.readthedocs.io/en/stable/index.html">here</a> to go to the LemLib Documentation.</p>
 </body>
 
 </html>


### PR DESCRIPTION
#### Summary
Updates the github pages redirect to the correct docs version

#### Motivation
The redirect currently goes to the docs for v0.5.0, which is an outdated version

#### Test Plan
Go to the github pages site and verify that the redirect goes to the correct docs version

#### Additional Notes
N/A
