### PR TITLE
docs: typo update command

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -18,7 +18,7 @@ pros c apply LemLib # applies latest stable version of LemLib
 To update LemLib, all you have to do is run the following command:
 
 ```bash
-pros c update
+pros c upgrade
 ```
 
 ### Beta Depot


### PR DESCRIPTION
changes one word, that's it
![image](https://github.com/user-attachments/assets/36b37d61-58ab-4728-9c81-3bd2d1c6d58b)
![image](https://github.com/user-attachments/assets/1a74caab-678e-4964-b8f9-b242ed0c9fa9)

`pros c update` doesn't exist