### PR TITLE
docs: :memo: Clarify throttle/steer priority

### DIFF
--- a/docs/tutorials/3_driver_control.md
+++ b/docs/tutorials/3_driver_control.md
@@ -83,7 +83,16 @@ void opcontrol() {
 This section is optional and is not needed to control the robot
 ```
 
-You can prioritize steering over turning, or vice versa. For example, you could fully prioritize steering so that the angular velocity of the robot is guaranteed to be the same for a given steering input, no matter the throttle input. With LemLib, you can prioritize steering over throttle by a set amount, from 0 to 1. 0.5 is the default, where steering and turning have the same priority. 0 fully prioritizes throttle, while 1 fully prioritizes steering. See the code block below:
+When we combine throttle and steering inputs, we can sometimes get a value over the motors' max voltage. 
+For example, if the steering input and throttle input are both maxed out at 127, then the power supplied to the left drive will be 0, and the right drive will get 254, which will be rounded down to 127. 
+This means the drive won't move forward at full speed, nor will it turn at full speed. 
+This can be undesired behavior, as you may want steering to be consistent, no matter what throttle you provide.
+
+Luckily, LemLib provides you the authority to choose your desired behavior through the `desaturateBias` param.
+`desaturateBias` has a range of 0 to 1, and only has an effect if motor output would be above 127.
+If set to 0, steering will be reduced until the motor output is below 127, leaving throttle alone, and vice versa for a value 1.
+The default is 0.5, where steering and throttle have the same priority. 
+See the code block below:
 
 ```cpp
 pros::Controller controller(pros::E_CONTROLLER_MASTER);


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Clarifies what throttle/steer priority does and why it might be necessary.

#### Motivation
<!-- Why are you making this pull request? -->
Before, it was misleading, suggesting that desaturateBias prioritized between steering and turning.
It also didn't address what it actually did and why it might be necessary.

#### Test Plan
<!-- How did you test / plan to test this pull request? -->
N/A

#### Additional Notes
<!-- Add any other information you think is relevant -->

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 8bccff6d8d66f569552fe340be2a6f45df5ff3df -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/11432127540)
- via manual download: [LemLib@0.5.4+8bccff.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/2080233180.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.5.4+8bccff.zip https://nightly.link/LemLib/LemLib/actions/artifacts/2080233180.zip;
pros c fetch LemLib@0.5.4+8bccff.zip;
pros c apply LemLib@0.5.4+8bccff;
rm LemLib@0.5.4+8bccff.zip;
```