### PR TITLE
docs: Fix incorrect code line in angular motion tutorial

### DIFF
--- a/docs/tutorials/5_angular_motion.md
+++ b/docs/tutorials/5_angular_motion.md
@@ -29,7 +29,7 @@ Here's an example of the same function call from above, but with all of the defa
 chassis.turnToHeading(
     270,
     4000,
-    {.maxSpeed = 120}, // will never exceed 120
+    {.maxSpeed = 127}, // will never exceed 127
     true // this motion will not block execution
 ); 
 ```


### PR DESCRIPTION
#### Summary
In the angular motion tutorial, the code snippet explaining the params struct lists the default value for max speed as 120, when it should be 127.

#### Motivation
N/A

#### Test Plan
N/A

#### Additional Notes
N/A

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 3e8bdefbfb81e9387a3462eda49b5d973712f429 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/12497594497)
- via manual download: [LemLib@0.6.0+3e8bde.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/2362118912.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.6.0+3e8bde.zip https://nightly.link/LemLib/LemLib/actions/artifacts/2362118912.zip;
pros c fetch LemLib@0.6.0+3e8bde.zip;
pros c apply LemLib@0.6.0+3e8bde;
rm LemLib@0.6.0+3e8bde.zip;
```