### PR TITLE
Update `auto-format.yml` to clang-format version 19

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Format code # Outputs the correctly formatted code
-      uses: d-griet/clang-format-lint-action@master
+      uses: d-griet/clang-format-lint-action@99a106be2f3f1a92d9783ea7c744fde62d8ce1fa
       with:
         source: './src/lemlib ./include/lemlib'
         extensions: 'hpp,cpp'

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -19,11 +19,11 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Format code # Outputs the correctly formatted code
-      uses: DoozyX/clang-format-lint-action@v0.18 
+      uses: DoozyX/clang-format-lint-action@v0.18.1 
       with:
         source: './src/lemlib ./include/lemlib'
         extensions: 'hpp,cpp'
-        clangFormatVersion: 18
+        clangFormatVersion: 19
         inplace: true # Same as `clang-format -i`
         
     # Commits the correctly formatted files to the repository

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         source: './src/lemlib ./include/lemlib'
         extensions: 'hpp,cpp'
-        clangFormatVersion: 18
+        clangFormatVersion: 19
         inplace: true # Same as `clang-format -i`
         
     # Commits the correctly formatted files to the repository

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Format code # Outputs the correctly formatted code
-      uses: DoozyX/clang-format-lint-action@v0.18.1 
+      uses: d-griet/clang-format-lint-action@master
       with:
         source: './src/lemlib ./include/lemlib'
         extensions: 'hpp,cpp'

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         source: './src/lemlib ./include/lemlib'
         extensions: 'hpp,cpp'
-        clangFormatVersion: 19
+        clangFormatVersion: 18
         inplace: true # Same as `clang-format -i`
         
     # Commits the correctly formatted files to the repository


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Updates Clang Format to version 19 in the auto-format workflow.
#### Motivation
<!-- Why are you making this pull request? -->
Gamepad CI uses clang format v19
#### Test Plan
<!-- How did you test / plan to test this pull request? -->
I formatted random files randomly and then ran the workflow. It worked as expected.

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 4be79027e166d21390dd28a0cd6876fb9f76d295 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/12920708696)
- via manual download: [LemLib@0.6.0+140df8.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/2471940400.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.6.0+140df8.zip https://nightly.link/LemLib/LemLib/actions/artifacts/2471940400.zip;
pros c fetch LemLib@0.6.0+140df8.zip;
pros c apply LemLib@0.6.0+140df8;
rm LemLib@0.6.0+140df8.zip;
```