### PR TITLE
⚡ Don't start a new task for every motion

### DIFF
--- a/include/lemlib/MotionHandler.hpp
+++ b/include/lemlib/MotionHandler.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
+#include <optional>
 
 namespace lemlib::motion_handler {
 /**
@@ -35,7 +37,7 @@ namespace lemlib::motion_handler {
  * }
  * @endcode
  */
-void move(std::function<void(void)> f);
+void move(std::function<void(void)> _motion, std::optional<uint32_t> _priority);
 /**
  * @brief cancel the currently running motion, if it exists
  *

--- a/src/lemlib/MotionHandler.cpp
+++ b/src/lemlib/MotionHandler.cpp
@@ -1,30 +1,47 @@
 #include "lemlib/MotionHandler.hpp"
+#include "LemLog/logger/Helper.hpp"
 #include "pros/rtos.hpp"
+#include <mutex>
 
 namespace lemlib::motion_handler {
-// initialize tasks
-static std::optional<pros::Task> motionTask = std::nullopt;
 
-void move(std::function<void(void)> f) {
-    // wait until there is no motion running
-    while (isMoving()) pros::delay(5);
-    // start the new motion
-    motionTask = pros::Task([=] {
-        // only start the motion if it hasn't been cancelled yet
-        if (pros::Task::notify_take(true, 0) == 0) f();
-    });
+constexpr uint32_t NOTIFICATION_TIMEOUT = std::numeric_limits<std::uint32_t>::max();
+
+static logger::Helper logHelper("lemlib/motions");
+
+static std::optional<std::function<void(void)>> motion;
+static pros::Mutex mutex;
+static uint32_t priority = TASK_PRIORITY_DEFAULT;
+
+// motion task
+static pros::Task motionTask([] {
+    while (pros::Task::notify_take(true, NOTIFICATION_TIMEOUT)) {
+        std::lock_guard lock(mutex); // get mutex
+        pros::Task::current().set_priority(priority); // set priority back to regular value
+        // run motion
+        if (motion) (*motion)();
+        else logHelper.error("motion task notified, but no motion to run! This is a bug and should be reported");
+        // set motion to nullopt
+        motion = std::nullopt;
+    }
+});
+
+void move(std::function<void(void)> _motion, std::optional<uint32_t> _priority) {
+    // check for a very improbable edge case
+    if (mutex.take(0) && !motion) pros::delay(10);
+    if (mutex.take(0) && !motion) {
+        logHelper.error("mutex error! This is a bug and should be reported! Skipping queued motion");
+        return;
+    }
+    std::lock_guard lock(mutex); // wait for the motion to finish
+    // run the motion
+    motion = _motion;
+    // set the priority of the task
+    priority = _priority ? *_priority : pros::Task::current().get_priority();
+    motionTask.set_priority(TASK_PRIORITY_MAX); // temporarily set the motion task priority to max
+    motionTask.notify(); // tell the motion handler it can run
+    pros::delay(1); // force context switch, so the motion starts running immediately
 }
 
-bool isMoving() {
-    // check if the task exists
-    if (motionTask == std::nullopt) return false;
-    // check if the task is currently running
-    const std::uint32_t state = motionTask->get_state();
-    return state != pros::E_TASK_STATE_DELETED && state != pros::E_TASK_STATE_INVALID;
-}
-
-void cancel() {
-    // if the task is currently running, notify the task
-    if (isMoving()) motionTask->notify();
-}
+void cancel() {}
 } // namespace lemlib::motion_handler

--- a/src/lemlib/MotionHandler.cpp
+++ b/src/lemlib/MotionHandler.cpp
@@ -7,40 +7,40 @@ namespace lemlib::motion_handler {
 
 constexpr uint32_t NOTIFICATION_TIMEOUT = std::numeric_limits<std::uint32_t>::max();
 
-static logger::Helper logHelper("lemlib/motions");
+static logger::Helper _logHelper("lemlib/motions");
 
-static std::optional<std::function<void(void)>> motion;
-static pros::Mutex mutex;
-static uint32_t priority = TASK_PRIORITY_DEFAULT;
+static std::optional<std::function<void(void)>> _motion;
+static pros::Mutex _mutex;
+static uint32_t _priority = TASK_PRIORITY_DEFAULT;
 
 // motion task
-static pros::Task motionTask([] {
+static pros::Task _motionTask([] {
     while (pros::Task::notify_take(true, NOTIFICATION_TIMEOUT)) {
-        std::lock_guard lock(mutex); // get mutex
-        pros::Task::current().set_priority(priority); // set priority back to regular value
+        std::lock_guard lock(_mutex); // get mutex
+        pros::Task::current().set_priority(_priority); // set priority back to regular value
         // run motion
-        if (motion) (*motion)();
-        else logHelper.error("motion task notified, but no motion to run! This is a bug and should be reported");
+        if (_motion) (*_motion)();
+        else _logHelper.error("motion task notified, but no motion to run! This is a bug and should be reported");
         // set motion to nullopt
-        motion = std::nullopt;
+        _motion = std::nullopt;
     }
 });
 
-void move(std::function<void(void)> _motion, std::optional<uint32_t> _priority) {
-    std::lock_guard lock(mutex); // wait for any running motion to finish
+void move(std::function<void(void)> motion, std::optional<uint32_t> priority) {
+    std::lock_guard lock(_mutex); // wait for any running motion to finish
     // run the motion
-    motion = _motion;
+    _motion = motion;
     // set the priority of the task
-    priority = _priority ? *_priority : pros::Task::current().get_priority();
-    motionTask.set_priority(TASK_PRIORITY_MAX); // temporarily set the motion task priority to max
-    motionTask.notify(); // tell the motion handler it can run
+    _priority = priority ? *priority : pros::Task::current().get_priority();
+    _motionTask.set_priority(TASK_PRIORITY_MAX); // temporarily set the motion task priority to max
+    _motionTask.notify(); // tell the motion handler it can run
     pros::delay(1); // force context switch, so the motion starts running immediately
 }
 
 bool isMoving() {
     // if the mutex is free, no motion is running
-    if (mutex.take(0)) {
-        mutex.give();
+    if (_mutex.take(0)) {
+        _mutex.give();
         return false;
     }
     return true;
@@ -48,7 +48,7 @@ bool isMoving() {
 
 void cancel() {
     // if the task is currently running a motion, notify it so the motion can break out of its loop
-    if (isMoving()) motionTask.notify();
+    if (isMoving()) _motionTask.notify();
 }
 
 void waitUntilPoint(units::V2Position target, Length radius, std::function<units::Pose()> poseGetter) {

--- a/src/lemlib/MotionHandler.cpp
+++ b/src/lemlib/MotionHandler.cpp
@@ -18,9 +18,17 @@ static pros::Task _motionTask([] {
     while (pros::Task::notify_take(true, NOTIFICATION_TIMEOUT)) {
         std::lock_guard lock(_mutex); // get mutex
         pros::Task::current().set_priority(_priority); // set priority back to regular value
-        // run motion
-        if (_motion) (*_motion)();
-        else _logHelper.error("motion task notified, but no motion to run! This is a bug and should be reported");
+        // run motion. _motion may legitimately be nullopt here if cancel() notified after the
+        // previous motion completed naturally (benign race), so just skip in that case.
+        if (_motion.has_value()) {
+            try {
+                _motion.value()();
+            } catch (const std::exception& e) {
+                _logHelper.error("motion threw an exception: {}", e.what());
+            } catch (...) {
+                _logHelper.error("motion threw an unknown exception");
+            }
+        }
         // set motion to nullopt
         _motion = std::nullopt;
     }
@@ -31,10 +39,11 @@ void move(std::function<void(void)> motion, std::optional<uint32_t> priority) {
     // run the motion
     _motion = motion;
     // set the priority of the task
-    _priority = priority ? *priority : pros::Task::current().get_priority();
+    _priority = priority.value_or(pros::Task::current().get_priority());
     _motionTask.set_priority(TASK_PRIORITY_MAX); // temporarily set the motion task priority to max
-    _motionTask.notify(); // tell the motion handler it can run
-    pros::delay(1); // force context switch, so the motion starts running immediately
+    // notify the motion task. Since it's at MAX priority, it will preempt and start running
+    // as soon as this function returns and the lock_guard releases the mutex.
+    _motionTask.notify();
 }
 
 bool isMoving() {

--- a/src/lemlib/MotionHandler.cpp
+++ b/src/lemlib/MotionHandler.cpp
@@ -27,13 +27,7 @@ static pros::Task motionTask([] {
 });
 
 void move(std::function<void(void)> _motion, std::optional<uint32_t> _priority) {
-    // check for a very improbable edge case
-    if (mutex.take(0) && !motion) pros::delay(10);
-    if (mutex.take(0) && !motion) {
-        logHelper.error("mutex error! This is a bug and should be reported! Skipping queued motion");
-        return;
-    }
-    std::lock_guard lock(mutex); // wait for the motion to finish
+    std::lock_guard lock(mutex); // wait for any running motion to finish
     // run the motion
     motion = _motion;
     // set the priority of the task


### PR DESCRIPTION
#### Summary
Make a single long-living task for motions.

#### Motivation
Creating a new task allocates 80KB of memory for it's stack. This introduces almost noticeable latency. Over the course of a complex autonomous routine, it could make a noticeable difference

#### Test Plan
- [ ] Task only runs when it needs to
- [ ] motions wait properly

#### Additional Notes
also fixes possible thread safety issues

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: a332232f113fbffff521081b9e21725f68c117df -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/25590534822)
- via manual download: [LemLib@0.6.0+a33223.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/6892485811.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.6.0+a33223.zip https://nightly.link/LemLib/LemLib/actions/artifacts/6892485811.zip;
pros c fetch LemLib@0.6.0+a33223.zip;
pros c apply LemLib@0.6.0+a33223;
rm LemLib@0.6.0+a33223.zip;
```