### PR TITLE
fix: correct incorrect motor inputs for swing turns

### DIFF
--- a/src/lemlib/motions/follow.cpp
+++ b/src/lemlib/motions/follow.cpp
@@ -91,7 +91,7 @@ static std::vector<Waypoint> getPath(const asset& asset) {
         waypoint.y = from_in(std::stod(pointInput.at(1))); // y position
         waypoint.speed = std::stod(pointInput.at(2)); // velocity
         path.push_back(waypoint); // save data
-        logHelper.debug("read point {}", waypoint);
+        logHelper.debug("read point {}", static_cast<const V2Position&>(waypoint));
     }
 
     return path;

--- a/src/lemlib/motions/turnTo.cpp
+++ b/src/lemlib/motions/turnTo.cpp
@@ -90,6 +90,7 @@ void turnTo(std::variant<Angle, V2Position> target, Time timeout, TurnToParams p
         const Number motorPower = [&] {
             Number raw = settings.angularPID.update(to_stRad(deltaTheta));
             if (!settling) raw = slew(raw, prevMotorPower, params.slew, helper.getDelta(), slewDirection);
+            if (params.lockedSide) raw *= 2;
             return constrainPower(raw, params.maxSpeed, params.minSpeed);
         }();
 
@@ -101,8 +102,12 @@ void turnTo(std::variant<Angle, V2Position> target, Time timeout, TurnToParams p
                         helper.getDelta());
 
         // move the motors
-        settings.leftMotors.move(-motorPower);
-        settings.rightMotors.move(motorPower);
+        if (!params.lockedSide || *params.lockedSide == TurnToParams::LockedSide::RIGHT) {
+            settings.leftMotors.move(-motorPower);
+        }
+        if (!params.lockedSide || *params.lockedSide == TurnToParams::LockedSide::LEFT) {
+            settings.rightMotors.move(motorPower);
+        }
     }
 
     // apply original brake modes

--- a/src/lemlib/motions/turnTo.cpp
+++ b/src/lemlib/motions/turnTo.cpp
@@ -90,7 +90,6 @@ void turnTo(std::variant<Angle, V2Position> target, Time timeout, TurnToParams p
         const Number motorPower = [&] {
             Number raw = settings.angularPID.update(to_stRad(deltaTheta));
             if (!settling) raw = slew(raw, prevMotorPower, params.slew, helper.getDelta(), slewDirection);
-            if (params.lockedSide) raw *= 2;
             return constrainPower(raw, params.maxSpeed, params.minSpeed);
         }();
 

--- a/src/lemlib/motions/turnTo.cpp
+++ b/src/lemlib/motions/turnTo.cpp
@@ -102,11 +102,15 @@ void turnTo(std::variant<Angle, V2Position> target, Time timeout, TurnToParams p
                         helper.getDelta());
 
         // move the motors
-        if (!params.lockedSide || *params.lockedSide == TurnToParams::LockedSide::RIGHT) {
-            settings.leftMotors.move(-motorPower);
-        }
-        if (!params.lockedSide || *params.lockedSide == TurnToParams::LockedSide::LEFT) {
-            settings.rightMotors.move(motorPower);
+        settings.leftMotors.move(-motorPower);
+        settings.rightMotors.move(motorPower);
+        // check which side of the drivetrain to lock, if any
+        if (params.lockedSide) {
+            if (*params.lockedSide == TurnToParams::LockedSide::LEFT) {
+                settings.leftMotors.brake();
+            } else {
+                settings.rightMotors.brake();
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Correctly inputs voltages into the drivetrain sides for when `params.lockedSide` has a value.

#### Motivation
To help fix motion algorithms.

#### Test Plan
Don't have hardware but it compiled successfully (the modified file).

#### Additional Notes
N/A

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 81306c9de7db60b87c8582f6d9b756f02a61fc6a -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/14286155971)
- via manual download: [LemLib@0.6.0+6113bc.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/2888571419.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.6.0+6113bc.zip https://nightly.link/LemLib/LemLib/actions/artifacts/2888571419.zip;
pros c fetch LemLib@0.6.0+6113bc.zip;
pros c apply LemLib@0.6.0+6113bc;
rm LemLib@0.6.0+6113bc.zip;
```