### PR TITLE
Always run motions in tasks to avoid mutex being held by deleted comp task

### DIFF
--- a/.github/workflows/pros-build.yml
+++ b/.github/workflows/pros-build.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Run LemLib/pros-build
         id: test
-        uses: LemLib/pros-build@v4.0.0
+        uses: LemLib/pros-build@v4.0.1
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/include/lemlib/chassis/chassis.hpp
+++ b/include/lemlib/chassis/chassis.hpp
@@ -922,7 +922,7 @@ class Chassis {
         bool motionRunning = false;
         bool motionQueued = false;
 
-        float distTraveled = 0;
+        float distTraveled = -1;
 
         ControllerSettings lateralSettings;
         ControllerSettings angularSettings;

--- a/src/lemlib/chassis/motions/moveToPoint.cpp
+++ b/src/lemlib/chassis/motions/moveToPoint.cpp
@@ -135,6 +135,6 @@ void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointPara
     startedMutex.take(TIMEOUT_MAX);
     if (!async) {
         do pros::delay(10);
-        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED || task.get_state() == pros::E_TASK_STATE_DELETED));
     }
 }

--- a/src/lemlib/chassis/motions/moveToPoint.cpp
+++ b/src/lemlib/chassis/motions/moveToPoint.cpp
@@ -6,126 +6,135 @@
 #include "pros/misc.hpp"
 
 void lemlib::Chassis::moveToPoint(float x, float y, int timeout, MoveToPointParams params, bool async) {
-    params.earlyExitRange = fabs(params.earlyExitRange);
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning) return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { moveToPoint(x, y, timeout, params, false); });
+    /**
+     * Mutex that is used to block until the motion has started.
+     */
+    pros::Mutex startedMutex;
+    pros::Task task([&]() {
+        startedMutex.take();
+        this->requestMotionStart();
+        startedMutex.give();
+        // were all motions cancelled?
+        if (!this->motionRunning) return;
+
+        params.earlyExitRange = fabs(params.earlyExitRange);
+
+        // reset PIDs and exit conditions
+        lateralPID.reset();
+        lateralLargeExit.reset();
+        lateralSmallExit.reset();
+        angularPID.reset();
+
+        // initialize vars used between iterations
+        Pose lastPose = getPose();
+        distTraveled = 0;
+        Timer timer(timeout);
+        bool close = false;
+        float prevLateralOut = 0; // previous lateral power
+        float prevAngularOut = 0; // previous angular power
+        const int compState = pros::competition::get_status();
+        std::optional<bool> prevSide = std::nullopt;
+
+        // calculate target pose in standard form
+        Pose target(x, y);
+        target.theta = lastPose.angle(target);
+
+        // main loop
+        while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close) &&
+               this->motionRunning) {
+            // update position
+            const Pose pose = getPose(true, true);
+
+            // update distance traveled
+            distTraveled += pose.distance(lastPose);
+            lastPose = pose;
+
+            // calculate distance to the target point
+            const float distTarget = pose.distance(target);
+
+            // check if the robot is close enough to the target to start settling
+            if (distTarget < 7.5 && close == false) {
+                close = true;
+                params.maxSpeed = fmax(fabs(prevLateralOut), 60);
+            }
+
+            // motion chaining
+            const bool side = (pose.y - target.y) * -sin(target.theta) <=
+                              (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
+            if (prevSide == std::nullopt) prevSide = side;
+            const bool sameSide = side == prevSide;
+            // exit if close
+            if (!sameSide && params.minSpeed != 0) break;
+            prevSide = side;
+
+            // calculate error
+            const float adjustedRobotTheta = params.forwards ? pose.theta : pose.theta + M_PI;
+            const float angularError = angleError(adjustedRobotTheta, pose.angle(target));
+            float lateralError = pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
+
+            // update exit conditions
+            lateralSmallExit.update(lateralError);
+            lateralLargeExit.update(lateralError);
+
+            // get output from PIDs
+            float lateralOut = lateralPID.update(lateralError);
+            float angularOut = angularPID.update(radToDeg(angularError));
+            if (close) angularOut = 0;
+
+            // apply restrictions on angular speed
+            angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
+            angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
+
+            // apply restrictions on lateral speed
+            lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
+            // constrain lateral output by max accel
+            // but not for decelerating, since that would interfere with settling
+            if (!close) lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+
+            // prevent moving in the wrong direction
+            if (params.forwards && !close) lateralOut = std::fmax(lateralOut, 0);
+            else if (!params.forwards && !close) lateralOut = std::fmin(lateralOut, 0);
+
+            // constrain lateral output by the minimum speed
+            if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
+                lateralOut = fabs(params.minSpeed);
+            if (!params.forwards && -lateralOut < fabs(params.minSpeed) && lateralOut < 0)
+                lateralOut = -fabs(params.minSpeed);
+
+            // update previous output
+            prevAngularOut = angularOut;
+            prevLateralOut = lateralOut;
+
+            infoSink()->debug("Angular Out: {}, Lateral Out: {}", angularOut, lateralOut);
+
+            // ratio the speeds to respect the max speed
+            float leftPower = lateralOut + angularOut;
+            float rightPower = lateralOut - angularOut;
+            const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
+            if (ratio > 1) {
+                leftPower /= ratio;
+                rightPower /= ratio;
+            }
+
+            // move the drivetrain
+            drivetrain.leftMotors->move(leftPower);
+            drivetrain.rightMotors->move(rightPower);
+
+            // delay to save resources
+            pros::delay(10);
+        }
+
+        // stop the drivetrain
+        drivetrain.leftMotors->move(0);
+        drivetrain.rightMotors->move(0);
+        // set distTraveled to -1 to indicate that the function has finished
+        distTraveled = -1;
         this->endMotion();
-        pros::delay(10); // delay to give the task time to start
-        return;
+    });
+    pros::delay(10);
+    startedMutex.take(TIMEOUT_MAX);
+    if (!async) {
+        do pros::delay(10);
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
     }
-
-    // reset PIDs and exit conditions
-    lateralPID.reset();
-    lateralLargeExit.reset();
-    lateralSmallExit.reset();
-    angularPID.reset();
-
-    // initialize vars used between iterations
-    Pose lastPose = getPose();
-    distTraveled = 0;
-    Timer timer(timeout);
-    bool close = false;
-    float prevLateralOut = 0; // previous lateral power
-    float prevAngularOut = 0; // previous angular power
-    const int compState = pros::competition::get_status();
-    std::optional<bool> prevSide = std::nullopt;
-
-    // calculate target pose in standard form
-    Pose target(x, y);
-    target.theta = lastPose.angle(target);
-
-    // main loop
-    while (!timer.isDone() && ((!lateralSmallExit.getExit() && !lateralLargeExit.getExit()) || !close) &&
-           this->motionRunning) {
-        // update position
-        const Pose pose = getPose(true, true);
-
-        // update distance traveled
-        distTraveled += pose.distance(lastPose);
-        lastPose = pose;
-
-        // calculate distance to the target point
-        const float distTarget = pose.distance(target);
-
-        // check if the robot is close enough to the target to start settling
-        if (distTarget < 7.5 && close == false) {
-            close = true;
-            params.maxSpeed = fmax(fabs(prevLateralOut), 60);
-        }
-
-        // motion chaining
-        const bool side =
-            (pose.y - target.y) * -sin(target.theta) <= (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
-        if (prevSide == std::nullopt) prevSide = side;
-        const bool sameSide = side == prevSide;
-        // exit if close
-        if (!sameSide && params.minSpeed != 0) break;
-        prevSide = side;
-
-        // calculate error
-        const float adjustedRobotTheta = params.forwards ? pose.theta : pose.theta + M_PI;
-        const float angularError = angleError(adjustedRobotTheta, pose.angle(target));
-        float lateralError = pose.distance(target) * cos(angleError(pose.theta, pose.angle(target)));
-
-        // update exit conditions
-        lateralSmallExit.update(lateralError);
-        lateralLargeExit.update(lateralError);
-
-        // get output from PIDs
-        float lateralOut = lateralPID.update(lateralError);
-        float angularOut = angularPID.update(radToDeg(angularError));
-        if (close) angularOut = 0;
-
-        // apply restrictions on angular speed
-        angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
-        angularOut = slew(angularOut, prevAngularOut, angularSettings.slew);
-
-        // apply restrictions on lateral speed
-        lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
-        // constrain lateral output by max accel
-        // but not for decelerating, since that would interfere with settling
-        if (!close) lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-
-        // prevent moving in the wrong direction
-        if (params.forwards && !close) lateralOut = std::fmax(lateralOut, 0);
-        else if (!params.forwards && !close) lateralOut = std::fmin(lateralOut, 0);
-
-        // constrain lateral output by the minimum speed
-        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0) lateralOut = fabs(params.minSpeed);
-        if (!params.forwards && -lateralOut < fabs(params.minSpeed) && lateralOut < 0)
-            lateralOut = -fabs(params.minSpeed);
-
-        // update previous output
-        prevAngularOut = angularOut;
-        prevLateralOut = lateralOut;
-
-        infoSink()->debug("Angular Out: {}, Lateral Out: {}", angularOut, lateralOut);
-
-        // ratio the speeds to respect the max speed
-        float leftPower = lateralOut + angularOut;
-        float rightPower = lateralOut - angularOut;
-        const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
-        if (ratio > 1) {
-            leftPower /= ratio;
-            rightPower /= ratio;
-        }
-
-        // move the drivetrain
-        drivetrain.leftMotors->move(leftPower);
-        drivetrain.rightMotors->move(rightPower);
-
-        // delay to save resources
-        pros::delay(10);
-    }
-
-    // stop the drivetrain
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTraveled = -1;
-    this->endMotion();
 }

--- a/src/lemlib/chassis/motions/moveToPose.cpp
+++ b/src/lemlib/chassis/motions/moveToPose.cpp
@@ -7,6 +7,7 @@
 
 void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, MoveToPoseParams params, bool async) {
     // take the mutex
+    this->waitUntilDone();
     pros::Task task([&]() {
         this->requestMotionStart();
         // were all motions cancelled?

--- a/src/lemlib/chassis/motions/moveToPose.cpp
+++ b/src/lemlib/chassis/motions/moveToPose.cpp
@@ -7,155 +7,156 @@
 
 void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, MoveToPoseParams params, bool async) {
     // take the mutex
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning) return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { moveToPose(x, y, theta, timeout, params, false); });
+    pros::Task task([&]() {
+        this->requestMotionStart();
+        // were all motions cancelled?
+        if (!this->motionRunning) return;
+        // reset PIDs and exit conditions
+        lateralPID.reset();
+        lateralLargeExit.reset();
+        lateralSmallExit.reset();
+        angularPID.reset();
+        angularLargeExit.reset();
+        angularSmallExit.reset();
+
+        // calculate target pose in standard form
+        Pose target(x, y, M_PI_2 - degToRad(theta));
+        if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
+
+        // use global horizontalDrift is horizontalDrift is 0
+        if (params.horizontalDrift == 0) params.horizontalDrift = drivetrain.horizontalDrift;
+
+        // initialize vars used between iterations
+        Pose lastPose = getPose();
+        distTraveled = 0;
+        Timer timer(timeout);
+        bool close = false;
+        bool lateralSettled = false;
+        bool prevSameSide = false;
+        float prevLateralOut = 0; // previous lateral power
+        float prevAngularOut = 0; // previous angular power
+        const int compState = pros::competition::get_status();
+
+        // main loop
+        while (!timer.isDone() &&
+               ((!lateralSettled || (!angularLargeExit.getExit() && !angularSmallExit.getExit())) || !close) &&
+               this->motionRunning) {
+            // update position
+            const Pose pose = getPose(true, true);
+
+            // update distance traveled
+            distTraveled += pose.distance(lastPose);
+            lastPose = pose;
+
+            // calculate distance to the target point
+            const float distTarget = pose.distance(target);
+
+            // check if the robot is close enough to the target to start settling
+            if (distTarget < 7.5 && close == false) {
+                close = true;
+                params.maxSpeed = fmax(fabs(prevLateralOut), 60);
+            }
+
+            // check if the lateral controller has settled
+            if (lateralLargeExit.getExit() && lateralSmallExit.getExit()) lateralSettled = true;
+
+            // calculate the carrot point
+            Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget;
+            if (close) carrot = target; // settling behavior
+
+            // calculate if the robot is on the same side as the carrot point
+            const bool robotSide = (pose.y - target.y) * -sin(target.theta) <=
+                                   (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
+            const bool carrotSide = (carrot.y - target.y) * -sin(target.theta) <=
+                                    (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
+            const bool sameSide = robotSide == carrotSide;
+            // exit if close
+            if (!sameSide && prevSameSide && close && params.minSpeed != 0) break;
+            prevSameSide = sameSide;
+
+            // calculate error
+            const float adjustedRobotTheta = params.forwards ? pose.theta : pose.theta + M_PI;
+            const float angularError = close ? angleError(adjustedRobotTheta, target.theta)
+                                             : angleError(adjustedRobotTheta, pose.angle(carrot));
+            float lateralError = pose.distance(carrot);
+            // only use cos when settling
+            // otherwise just multiply by the sign of cos
+            // maxSlipSpeed takes care of lateralOut
+            if (close) lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
+            else lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
+
+            // update exit conditions
+            lateralSmallExit.update(lateralError);
+            lateralLargeExit.update(lateralError);
+            angularSmallExit.update(radToDeg(angularError));
+            angularLargeExit.update(radToDeg(angularError));
+
+            // get output from PIDs
+            float lateralOut = lateralPID.update(lateralError);
+            float angularOut = angularPID.update(radToDeg(angularError));
+
+            // apply restrictions on angular speed
+            angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
+
+            // apply restrictions on lateral speed
+            lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
+
+            // constrain lateral output by max accel
+            if (!close) lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
+
+            // constrain lateral output by the max speed it can travel at without
+            // slipping
+            const float radius = 1 / fabs(getCurvature(pose, carrot));
+            const float maxSlipSpeed(sqrt(params.horizontalDrift * radius * 9.8));
+            lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
+            // prioritize angular movement over lateral movement
+            const float overturn = fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
+            if (overturn > 0) lateralOut -= lateralOut > 0 ? overturn : -overturn;
+
+            // prevent moving in the wrong direction
+            if (params.forwards && !close) lateralOut = std::fmax(lateralOut, 0);
+            else if (!params.forwards && !close) lateralOut = std::fmin(lateralOut, 0);
+
+            // constrain lateral output by the minimum speed
+            if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0)
+                lateralOut = fabs(params.minSpeed);
+            if (!params.forwards && -lateralOut < fabs(params.minSpeed) && lateralOut < 0)
+                lateralOut = -fabs(params.minSpeed);
+
+            // update previous output
+            prevAngularOut = angularOut;
+            prevLateralOut = lateralOut;
+
+            infoSink()->debug("lateralOut: {} angularOut: {}", lateralOut, angularOut);
+
+            // ratio the speeds to respect the max speed
+            float leftPower = lateralOut + angularOut;
+            float rightPower = lateralOut - angularOut;
+            const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
+            if (ratio > 1) {
+                leftPower /= ratio;
+                rightPower /= ratio;
+            }
+
+            // move the drivetrain
+            drivetrain.leftMotors->move(leftPower);
+            drivetrain.rightMotors->move(rightPower);
+
+            // delay to save resources
+            pros::delay(10);
+        }
+
+        // stop the drivetrain
+        drivetrain.leftMotors->move(0);
+        drivetrain.rightMotors->move(0);
+        // set distTraveled to -1 to indicate that the function has finished
+        distTraveled = -1;
         this->endMotion();
+    });
+    if (async) {
         pros::delay(10); // delay to give the task time to start
         return;
+    } else {
+        this->waitUntilDone();
     }
-
-    // reset PIDs and exit conditions
-    lateralPID.reset();
-    lateralLargeExit.reset();
-    lateralSmallExit.reset();
-    angularPID.reset();
-    angularLargeExit.reset();
-    angularSmallExit.reset();
-
-    // calculate target pose in standard form
-    Pose target(x, y, M_PI_2 - degToRad(theta));
-    if (!params.forwards) target.theta = fmod(target.theta + M_PI, 2 * M_PI); // backwards movement
-
-    // use global horizontalDrift is horizontalDrift is 0
-    if (params.horizontalDrift == 0) params.horizontalDrift = drivetrain.horizontalDrift;
-
-    // initialize vars used between iterations
-    Pose lastPose = getPose();
-    distTraveled = 0;
-    Timer timer(timeout);
-    bool close = false;
-    bool lateralSettled = false;
-    bool prevSameSide = false;
-    float prevLateralOut = 0; // previous lateral power
-    float prevAngularOut = 0; // previous angular power
-    const int compState = pros::competition::get_status();
-
-    // main loop
-    while (!timer.isDone() &&
-           ((!lateralSettled || (!angularLargeExit.getExit() && !angularSmallExit.getExit())) || !close) &&
-           this->motionRunning) {
-        // update position
-        const Pose pose = getPose(true, true);
-
-        // update distance traveled
-        distTraveled += pose.distance(lastPose);
-        lastPose = pose;
-
-        // calculate distance to the target point
-        const float distTarget = pose.distance(target);
-
-        // check if the robot is close enough to the target to start settling
-        if (distTarget < 7.5 && close == false) {
-            close = true;
-            params.maxSpeed = fmax(fabs(prevLateralOut), 60);
-        }
-
-        // check if the lateral controller has settled
-        if (lateralLargeExit.getExit() && lateralSmallExit.getExit()) lateralSettled = true;
-
-        // calculate the carrot point
-        Pose carrot = target - Pose(cos(target.theta), sin(target.theta)) * params.lead * distTarget;
-        if (close) carrot = target; // settling behavior
-
-        // calculate if the robot is on the same side as the carrot point
-        const bool robotSide =
-            (pose.y - target.y) * -sin(target.theta) <= (pose.x - target.x) * cos(target.theta) + params.earlyExitRange;
-        const bool carrotSide = (carrot.y - target.y) * -sin(target.theta) <=
-                                (carrot.x - target.x) * cos(target.theta) + params.earlyExitRange;
-        const bool sameSide = robotSide == carrotSide;
-        // exit if close
-        if (!sameSide && prevSameSide && close && params.minSpeed != 0) break;
-        prevSameSide = sameSide;
-
-        // calculate error
-        const float adjustedRobotTheta = params.forwards ? pose.theta : pose.theta + M_PI;
-        const float angularError =
-            close ? angleError(adjustedRobotTheta, target.theta) : angleError(adjustedRobotTheta, pose.angle(carrot));
-        float lateralError = pose.distance(carrot);
-        // only use cos when settling
-        // otherwise just multiply by the sign of cos
-        // maxSlipSpeed takes care of lateralOut
-        if (close) lateralError *= cos(angleError(pose.theta, pose.angle(carrot)));
-        else lateralError *= sgn(cos(angleError(pose.theta, pose.angle(carrot))));
-
-        // update exit conditions
-        lateralSmallExit.update(lateralError);
-        lateralLargeExit.update(lateralError);
-        angularSmallExit.update(radToDeg(angularError));
-        angularLargeExit.update(radToDeg(angularError));
-
-        // get output from PIDs
-        float lateralOut = lateralPID.update(lateralError);
-        float angularOut = angularPID.update(radToDeg(angularError));
-
-        // apply restrictions on angular speed
-        angularOut = std::clamp(angularOut, -params.maxSpeed, params.maxSpeed);
-
-        // apply restrictions on lateral speed
-        lateralOut = std::clamp(lateralOut, -params.maxSpeed, params.maxSpeed);
-
-        // constrain lateral output by max accel
-        if (!close) lateralOut = slew(lateralOut, prevLateralOut, lateralSettings.slew);
-
-        // constrain lateral output by the max speed it can travel at without
-        // slipping
-        const float radius = 1 / fabs(getCurvature(pose, carrot));
-        const float maxSlipSpeed(sqrt(params.horizontalDrift * radius * 9.8));
-        lateralOut = std::clamp(lateralOut, -maxSlipSpeed, maxSlipSpeed);
-        // prioritize angular movement over lateral movement
-        const float overturn = fabs(angularOut) + fabs(lateralOut) - params.maxSpeed;
-        if (overturn > 0) lateralOut -= lateralOut > 0 ? overturn : -overturn;
-
-        // prevent moving in the wrong direction
-        if (params.forwards && !close) lateralOut = std::fmax(lateralOut, 0);
-        else if (!params.forwards && !close) lateralOut = std::fmin(lateralOut, 0);
-
-        // constrain lateral output by the minimum speed
-        if (params.forwards && lateralOut < fabs(params.minSpeed) && lateralOut > 0) lateralOut = fabs(params.minSpeed);
-        if (!params.forwards && -lateralOut < fabs(params.minSpeed) && lateralOut < 0)
-            lateralOut = -fabs(params.minSpeed);
-
-        // update previous output
-        prevAngularOut = angularOut;
-        prevLateralOut = lateralOut;
-
-        infoSink()->debug("lateralOut: {} angularOut: {}", lateralOut, angularOut);
-
-        // ratio the speeds to respect the max speed
-        float leftPower = lateralOut + angularOut;
-        float rightPower = lateralOut - angularOut;
-        const float ratio = std::max(std::fabs(leftPower), std::fabs(rightPower)) / params.maxSpeed;
-        if (ratio > 1) {
-            leftPower /= ratio;
-            rightPower /= ratio;
-        }
-
-        // move the drivetrain
-        drivetrain.leftMotors->move(leftPower);
-        drivetrain.rightMotors->move(rightPower);
-
-        // delay to save resources
-        pros::delay(10);
-    }
-
-    // stop the drivetrain
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTraveled = -1;
-    this->endMotion();
 }

--- a/src/lemlib/chassis/motions/moveToPose.cpp
+++ b/src/lemlib/chassis/motions/moveToPose.cpp
@@ -7,6 +7,9 @@
 #include "pros/rtos.h"
 
 void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, MoveToPoseParams params, bool async) {
+    /**
+     * Mutex that is used to block until the motion has started.
+     */
     pros::Mutex startedMutex;
     pros::Task task([&]() {
         startedMutex.take();

--- a/src/lemlib/chassis/motions/moveToPose.cpp
+++ b/src/lemlib/chassis/motions/moveToPose.cpp
@@ -164,6 +164,6 @@ void lemlib::Chassis::moveToPose(float x, float y, float theta, int timeout, Mov
     startedMutex.take(TIMEOUT_MAX);
     if (!async) {
         do pros::delay(10);
-        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED || task.get_state() == pros::E_TASK_STATE_DELETED));
     }
 }

--- a/src/lemlib/chassis/motions/pursuit.cpp
+++ b/src/lemlib/chassis/motions/pursuit.cpp
@@ -305,6 +305,6 @@ void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bo
     startedMutex.take(TIMEOUT_MAX);
     if (!async) {
         do pros::delay(10);
-        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED || task.get_state() == pros::E_TASK_STATE_DELETED));
     }
 }

--- a/src/lemlib/chassis/motions/pursuit.cpp
+++ b/src/lemlib/chassis/motions/pursuit.cpp
@@ -202,102 +202,109 @@ float findLookaheadCurvature(lemlib::Pose pose, float heading, lemlib::Pose look
 }
 
 void lemlib::Chassis::follow(const asset& path, float lookahead, int timeout, bool forwards, bool async) {
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning) return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { follow(path, lookahead, timeout, forwards, false); });
-        this->endMotion();
-        pros::delay(10); // delay to give the task time to start
-        return;
-    }
+    /**
+     * Mutex that is used to block until the motion has started.
+     */
+    pros::Mutex startedMutex;
+    pros::Task task([&]() {
+        startedMutex.take();
+        this->requestMotionStart();
+        startedMutex.give();
+        // were all motions cancelled?
+        if (!this->motionRunning) return;
 
-    std::vector<lemlib::Pose> pathPoints = getData(path); // get list of path points
-    if (pathPoints.size() == 0) {
-        infoSink()->error("No points in path! Do you have the right format? Skipping motion");
+        std::vector<lemlib::Pose> pathPoints = getData(path); // get list of path points
+        if (pathPoints.size() == 0) {
+            infoSink()->error("No points in path! Do you have the right format? Skipping motion");
+            // set distTraveled to -1 to indicate that the function has finished
+            distTraveled = -1;
+            // give the mutex back
+            this->endMotion();
+            return;
+        }
+        Pose pose = this->getPose(true);
+        Pose lastPose = pose;
+        Pose lookaheadPose(0, 0, 0);
+        Pose lastLookahead = pathPoints.at(0);
+        lastLookahead.theta = 0;
+        float curvature;
+        float targetVel;
+        float prevLeftVel = 0;
+        float prevRightVel = 0;
+        int closestPoint;
+        float leftInput = 0;
+        float rightInput = 0;
+        float prevVel = 0;
+        int compState = pros::competition::get_status();
+        distTraveled = 0;
+
+        // loop until the robot is within the end tolerance
+        for (int i = 0; i < timeout / 10 && pros::competition::get_status() == compState && this->motionRunning; i++) {
+            // get the current position of the robot
+            pose = this->getPose(true);
+            if (!forwards) pose.theta -= M_PI;
+
+            // update completion vars
+            distTraveled += pose.distance(lastPose);
+            lastPose = pose;
+
+            // find the closest point on the path to the robot
+            closestPoint = findClosest(pose, pathPoints);
+            // if the robot is at the end of the path, then stop
+            if (pathPoints.at(closestPoint).theta == 0) break;
+
+            // find the lookahead point
+            lookaheadPose = lookaheadPoint(lastLookahead, pose, pathPoints, closestPoint, lookahead);
+            lastLookahead = lookaheadPose; // update last lookahead position
+
+            // get the curvature of the arc between the robot and the lookahead point
+            float curvatureHeading = M_PI / 2 - pose.theta;
+            curvature = findLookaheadCurvature(pose, curvatureHeading, lookaheadPose);
+
+            // get the target velocity of the robot
+            targetVel = pathPoints.at(closestPoint).theta;
+            targetVel = slew(targetVel, prevVel, lateralSettings.slew);
+            prevVel = targetVel;
+
+            // calculate target left and right velocities
+            float targetLeftVel = targetVel * (2 + curvature * drivetrain.trackWidth) / 2;
+            float targetRightVel = targetVel * (2 - curvature * drivetrain.trackWidth) / 2;
+
+            // ratio the speeds to respect the max speed
+            float ratio = std::max(std::fabs(targetLeftVel), std::fabs(targetRightVel)) / 127;
+            if (ratio > 1) {
+                targetLeftVel /= ratio;
+                targetRightVel /= ratio;
+            }
+
+            // update previous velocities
+            prevLeftVel = targetLeftVel;
+            prevRightVel = targetRightVel;
+
+            // move the drivetrain
+            if (forwards) {
+                drivetrain.leftMotors->move(targetLeftVel);
+                drivetrain.rightMotors->move(targetRightVel);
+            } else {
+                drivetrain.leftMotors->move(-targetRightVel);
+                drivetrain.rightMotors->move(-targetLeftVel);
+            }
+
+            pros::delay(10);
+        }
+
+        // stop the robot
+        drivetrain.leftMotors->move(0);
+        drivetrain.rightMotors->move(0);
         // set distTraveled to -1 to indicate that the function has finished
         distTraveled = -1;
         // give the mutex back
         this->endMotion();
-        return;
+    });
+    pros::delay(10);
+    startedMutex.take(TIMEOUT_MAX);
+    if (!async) {
+        do pros::delay(10);
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
     }
-    Pose pose = this->getPose(true);
-    Pose lastPose = pose;
-    Pose lookaheadPose(0, 0, 0);
-    Pose lastLookahead = pathPoints.at(0);
-    lastLookahead.theta = 0;
-    float curvature;
-    float targetVel;
-    float prevLeftVel = 0;
-    float prevRightVel = 0;
-    int closestPoint;
-    float leftInput = 0;
-    float rightInput = 0;
-    float prevVel = 0;
-    int compState = pros::competition::get_status();
-    distTraveled = 0;
-
-    // loop until the robot is within the end tolerance
-    for (int i = 0; i < timeout / 10 && pros::competition::get_status() == compState && this->motionRunning; i++) {
-        // get the current position of the robot
-        pose = this->getPose(true);
-        if (!forwards) pose.theta -= M_PI;
-
-        // update completion vars
-        distTraveled += pose.distance(lastPose);
-        lastPose = pose;
-
-        // find the closest point on the path to the robot
-        closestPoint = findClosest(pose, pathPoints);
-        // if the robot is at the end of the path, then stop
-        if (pathPoints.at(closestPoint).theta == 0) break;
-
-        // find the lookahead point
-        lookaheadPose = lookaheadPoint(lastLookahead, pose, pathPoints, closestPoint, lookahead);
-        lastLookahead = lookaheadPose; // update last lookahead position
-
-        // get the curvature of the arc between the robot and the lookahead point
-        float curvatureHeading = M_PI / 2 - pose.theta;
-        curvature = findLookaheadCurvature(pose, curvatureHeading, lookaheadPose);
-
-        // get the target velocity of the robot
-        targetVel = pathPoints.at(closestPoint).theta;
-        targetVel = slew(targetVel, prevVel, lateralSettings.slew);
-        prevVel = targetVel;
-
-        // calculate target left and right velocities
-        float targetLeftVel = targetVel * (2 + curvature * drivetrain.trackWidth) / 2;
-        float targetRightVel = targetVel * (2 - curvature * drivetrain.trackWidth) / 2;
-
-        // ratio the speeds to respect the max speed
-        float ratio = std::max(std::fabs(targetLeftVel), std::fabs(targetRightVel)) / 127;
-        if (ratio > 1) {
-            targetLeftVel /= ratio;
-            targetRightVel /= ratio;
-        }
-
-        // update previous velocities
-        prevLeftVel = targetLeftVel;
-        prevRightVel = targetRightVel;
-
-        // move the drivetrain
-        if (forwards) {
-            drivetrain.leftMotors->move(targetLeftVel);
-            drivetrain.rightMotors->move(targetRightVel);
-        } else {
-            drivetrain.leftMotors->move(-targetRightVel);
-            drivetrain.rightMotors->move(-targetLeftVel);
-        }
-
-        pros::delay(10);
-    }
-
-    // stop the robot
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTraveled = -1;
-    // give the mutex back
-    this->endMotion();
 }

--- a/src/lemlib/chassis/motions/swingToHeading.cpp
+++ b/src/lemlib/chassis/motions/swingToHeading.cpp
@@ -109,6 +109,6 @@ void lemlib::Chassis::swingToHeading(float theta, DriveSide lockedSide, int time
     startedMutex.take(TIMEOUT_MAX);
     if (!async) {
         do pros::delay(10);
-        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED || task.get_state() == pros::E_TASK_STATE_DELETED));
     }
 }

--- a/src/lemlib/chassis/motions/swingToHeading.cpp
+++ b/src/lemlib/chassis/motions/swingToHeading.cpp
@@ -7,100 +7,108 @@
 
 void lemlib::Chassis::swingToHeading(float theta, DriveSide lockedSide, int timeout, SwingToHeadingParams params,
                                      bool async) {
-    params.minSpeed = fabs(params.minSpeed);
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning) return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { swingToHeading(theta, lockedSide, timeout, params, false); });
-        this->endMotion();
-        pros::delay(10); // delay to give the task time to start
-        return;
-    }
-    float targetTheta;
-    float deltaTheta;
-    float motorPower;
-    float prevMotorPower = 0;
-    float startTheta = getPose().theta;
-    bool settling = false;
-    std::optional<float> prevRawDeltaTheta = std::nullopt;
-    std::optional<float> prevDeltaTheta = std::nullopt;
-    std::uint8_t compState = pros::competition::get_status();
-    distTraveled = 0;
-    Timer timer(timeout);
-    angularLargeExit.reset();
-    angularSmallExit.reset();
-    angularPID.reset();
-    // get original braking mode of that side of the drivetrain so we can set it back to it after this motion ends
-    pros::MotorBrake brakeMode = (lockedSide == DriveSide::LEFT)
-                                     ? this->drivetrain.leftMotors->get_brake_mode_all().at(0)
-                                     : this->drivetrain.rightMotors->get_brake_mode_all().at(0);
-    // set brake mode of the locked side to hold
-    if (lockedSide == DriveSide::LEFT) this->drivetrain.leftMotors->set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
-    else this->drivetrain.rightMotors->set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
+    /**
+     * Mutex that is used to block until the motion has started.
+     */
+    pros::Mutex startedMutex;
+    pros::Task task([&]() {
+        startedMutex.take();
+        this->requestMotionStart();
+        startedMutex.give();
+        // were all motions cancelled?
+        if (!this->motionRunning) return;
 
-    // main loop
-    while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
-        // update variables
-        Pose pose = getPose();
-        pose.theta = fmod(pose.theta, 360);
+        params.minSpeed = fabs(params.minSpeed);
+        float targetTheta;
+        float deltaTheta;
+        float motorPower;
+        float prevMotorPower = 0;
+        float startTheta = getPose().theta;
+        bool settling = false;
+        std::optional<float> prevRawDeltaTheta = std::nullopt;
+        std::optional<float> prevDeltaTheta = std::nullopt;
+        std::uint8_t compState = pros::competition::get_status();
+        distTraveled = 0;
+        Timer timer(timeout);
+        angularLargeExit.reset();
+        angularSmallExit.reset();
+        angularPID.reset();
+        // get original braking mode of that side of the drivetrain so we can set it back to it after this motion ends
+        pros::MotorBrake brakeMode = (lockedSide == DriveSide::LEFT)
+                                         ? this->drivetrain.leftMotors->get_brake_mode_all().at(0)
+                                         : this->drivetrain.rightMotors->get_brake_mode_all().at(0);
+        // set brake mode of the locked side to hold
+        if (lockedSide == DriveSide::LEFT) this->drivetrain.leftMotors->set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
+        else this->drivetrain.rightMotors->set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
 
-        // update completion vars
-        distTraveled = fabs(angleError(pose.theta, startTheta, false));
-        targetTheta = theta;
+        // main loop
+        while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
+            // update variables
+            Pose pose = getPose();
+            pose.theta = fmod(pose.theta, 360);
 
-        // check if settling
-        const float rawDeltaTheta = angleError(targetTheta, pose.theta, false);
-        if (prevRawDeltaTheta == std::nullopt) prevRawDeltaTheta = rawDeltaTheta;
-        if (sgn(rawDeltaTheta) != sgn(prevRawDeltaTheta)) settling = true;
-        prevRawDeltaTheta = rawDeltaTheta;
+            // update completion vars
+            distTraveled = fabs(angleError(pose.theta, startTheta, false));
+            targetTheta = theta;
 
-        // calculate deltaTheta
-        if (settling) deltaTheta = angleError(targetTheta, pose.theta, false);
-        else deltaTheta = angleError(targetTheta, pose.theta, false, params.direction);
-        if (prevDeltaTheta == std::nullopt) prevDeltaTheta = deltaTheta;
+            // check if settling
+            const float rawDeltaTheta = angleError(targetTheta, pose.theta, false);
+            if (prevRawDeltaTheta == std::nullopt) prevRawDeltaTheta = rawDeltaTheta;
+            if (sgn(rawDeltaTheta) != sgn(prevRawDeltaTheta)) settling = true;
+            prevRawDeltaTheta = rawDeltaTheta;
 
-        // motion chaining
-        if (params.minSpeed != 0 && fabs(deltaTheta) < params.earlyExitRange) break;
-        if (params.minSpeed != 0 && sgn(deltaTheta) != sgn(prevDeltaTheta)) break;
+            // calculate deltaTheta
+            if (settling) deltaTheta = angleError(targetTheta, pose.theta, false);
+            else deltaTheta = angleError(targetTheta, pose.theta, false, params.direction);
+            if (prevDeltaTheta == std::nullopt) prevDeltaTheta = deltaTheta;
 
-        // calculate the speed
-        motorPower = angularPID.update(deltaTheta);
-        angularLargeExit.update(deltaTheta);
-        angularSmallExit.update(deltaTheta);
+            // motion chaining
+            if (params.minSpeed != 0 && fabs(deltaTheta) < params.earlyExitRange) break;
+            if (params.minSpeed != 0 && sgn(deltaTheta) != sgn(prevDeltaTheta)) break;
 
-        // cap the speed
-        if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
-        else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
-        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
-        if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
-        else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
-        prevMotorPower = motorPower;
+            // calculate the speed
+            motorPower = angularPID.update(deltaTheta);
+            angularLargeExit.update(deltaTheta);
+            angularSmallExit.update(deltaTheta);
 
-        infoSink()->debug("Turn Motor Power: {} ", motorPower);
+            // cap the speed
+            if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
+            else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
+            if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
+            if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
+            else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
+            prevMotorPower = motorPower;
 
-        // move the drivetrain
-        if (lockedSide == DriveSide::LEFT) {
-            drivetrain.rightMotors->move(-motorPower);
-            drivetrain.leftMotors->brake();
-        } else {
-            drivetrain.leftMotors->move(motorPower);
-            drivetrain.rightMotors->brake();
+            infoSink()->debug("Turn Motor Power: {} ", motorPower);
+
+            // move the drivetrain
+            if (lockedSide == DriveSide::LEFT) {
+                drivetrain.rightMotors->move(-motorPower);
+                drivetrain.leftMotors->brake();
+            } else {
+                drivetrain.leftMotors->move(motorPower);
+                drivetrain.rightMotors->brake();
+            }
+
+            // delay to save resources
+            pros::delay(10);
         }
 
-        // delay to save resources
-        pros::delay(10);
+        // set the brake mode of the locked side of the drivetrain to its
+        // original value
+        if (lockedSide == DriveSide::LEFT) this->drivetrain.leftMotors->set_brake_mode_all(brakeMode);
+        else this->drivetrain.rightMotors->set_brake_mode_all(brakeMode);
+        // stop the drivetrain
+        drivetrain.leftMotors->move(0);
+        drivetrain.rightMotors->move(0);
+        // set distTraveled to -1 to indicate that the function has finished
+        distTraveled = -1;
+        this->endMotion();
+    });
+    pros::delay(10);
+    startedMutex.take(TIMEOUT_MAX);
+    if (!async) {
+        do pros::delay(10);
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
     }
-
-    // set the brake mode of the locked side of the drivetrain to its
-    // original value
-    if (lockedSide == DriveSide::LEFT) this->drivetrain.leftMotors->set_brake_mode_all(brakeMode);
-    else this->drivetrain.rightMotors->set_brake_mode_all(brakeMode);
-    // stop the drivetrain
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTraveled = -1;
-    this->endMotion();
 }

--- a/src/lemlib/chassis/motions/swingToPoint.cpp
+++ b/src/lemlib/chassis/motions/swingToPoint.cpp
@@ -113,6 +113,6 @@ void lemlib::Chassis::swingToPoint(float x, float y, DriveSide lockedSide, int t
     startedMutex.take(TIMEOUT_MAX);
     if (!async) {
         do pros::delay(10);
-        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED || task.get_state() == pros::E_TASK_STATE_DELETED));
     }
 }

--- a/src/lemlib/chassis/motions/swingToPoint.cpp
+++ b/src/lemlib/chassis/motions/swingToPoint.cpp
@@ -7,102 +7,112 @@
 
 void lemlib::Chassis::swingToPoint(float x, float y, DriveSide lockedSide, int timeout, SwingToPointParams params,
                                    bool async) {
-    params.minSpeed = fabs(params.minSpeed);
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning) return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { swingToPoint(x, y, lockedSide, timeout, params, false); });
-        this->endMotion();
-        pros::delay(10); // delay to give the task time to start
-        return;
-    }
-    float targetTheta;
-    float deltaX, deltaY, deltaTheta;
-    float motorPower;
-    float prevMotorPower = 0;
-    float startTheta = getPose().theta;
-    bool settling = false;
-    std::optional<float> prevRawDeltaTheta = std::nullopt;
-    std::optional<float> prevDeltaTheta = std::nullopt;
-    std::uint8_t compState = pros::competition::get_status();
-    distTraveled = 0;
-    Timer timer(timeout);
-    angularLargeExit.reset();
-    angularSmallExit.reset();
-    angularPID.reset();
-    // get original braking mode of that side of the drivetrain so we can set it back to it after this motion ends
-    pros::MotorBrake brakeMode = (lockedSide == DriveSide::LEFT)
-                                     ? this->drivetrain.leftMotors->get_brake_mode_all().at(0)
-                                     : this->drivetrain.rightMotors->get_brake_mode_all().at(0);
-    // set brake mode of the locked side to hold
-    if (lockedSide == DriveSide::LEFT) this->drivetrain.leftMotors->set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
-    else this->drivetrain.rightMotors->set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
+    /**
+     * Mutex that is used to block until the motion has started.
+     */
+    pros::Mutex startedMutex;
+    pros::Task task([&]() {
+        startedMutex.take();
+        this->requestMotionStart();
+        startedMutex.give();
+        // were all motions cancelled?
+        if (!this->motionRunning) return;
 
-    // main loop
-    while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
-        // update variables
-        Pose pose = getPose();
-        pose.theta = (params.forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
+        params.minSpeed = fabs(params.minSpeed);
 
-        // update completion vars
-        distTraveled = fabs(angleError(pose.theta, startTheta, false));
+        float targetTheta;
+        float deltaX, deltaY, deltaTheta;
+        float motorPower;
+        float prevMotorPower = 0;
+        float startTheta = getPose().theta;
+        bool settling = false;
+        std::optional<float> prevRawDeltaTheta = std::nullopt;
+        std::optional<float> prevDeltaTheta = std::nullopt;
+        std::uint8_t compState = pros::competition::get_status();
+        distTraveled = 0;
+        Timer timer(timeout);
+        angularLargeExit.reset();
+        angularSmallExit.reset();
+        angularPID.reset();
+        // get original braking mode of that side of the drivetrain so we can set it back to it after this motion ends
+        pros::MotorBrake brakeMode = (lockedSide == DriveSide::LEFT)
+                                         ? this->drivetrain.leftMotors->get_brake_mode_all().at(0)
+                                         : this->drivetrain.rightMotors->get_brake_mode_all().at(0);
+        // set brake mode of the locked side to hold
+        if (lockedSide == DriveSide::LEFT) this->drivetrain.leftMotors->set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
+        else this->drivetrain.rightMotors->set_brake_mode_all(pros::E_MOTOR_BRAKE_HOLD);
 
-        deltaX = x - pose.x;
-        deltaY = y - pose.y;
-        targetTheta = fmod(radToDeg(M_PI_2 - atan2(deltaY, deltaX)), 360);
+        // main loop
+        while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
+            // update variables
+            Pose pose = getPose();
+            pose.theta = (params.forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
 
-        // check if settling
-        const float rawDeltaTheta = angleError(targetTheta, pose.theta, false);
-        if (prevRawDeltaTheta == std::nullopt) prevRawDeltaTheta = rawDeltaTheta;
-        if (sgn(rawDeltaTheta) != sgn(prevRawDeltaTheta)) settling = true;
-        prevRawDeltaTheta = rawDeltaTheta;
+            // update completion vars
+            distTraveled = fabs(angleError(pose.theta, startTheta, false));
 
-        // calculate deltaTheta
-        if (settling) deltaTheta = angleError(targetTheta, pose.theta, false);
-        else deltaTheta = angleError(targetTheta, pose.theta, false, params.direction);
-        if (prevDeltaTheta == std::nullopt) prevDeltaTheta = deltaTheta;
+            deltaX = x - pose.x;
+            deltaY = y - pose.y;
+            targetTheta = fmod(radToDeg(M_PI_2 - atan2(deltaY, deltaX)), 360);
 
-        // motion chaining
-        if (params.minSpeed != 0 && fabs(deltaTheta) < params.earlyExitRange) break;
-        if (params.minSpeed != 0 && sgn(deltaTheta) != sgn(prevDeltaTheta)) break;
+            // check if settling
+            const float rawDeltaTheta = angleError(targetTheta, pose.theta, false);
+            if (prevRawDeltaTheta == std::nullopt) prevRawDeltaTheta = rawDeltaTheta;
+            if (sgn(rawDeltaTheta) != sgn(prevRawDeltaTheta)) settling = true;
+            prevRawDeltaTheta = rawDeltaTheta;
 
-        // calculate the speed
-        motorPower = angularPID.update(deltaTheta);
-        angularLargeExit.update(deltaTheta);
-        angularSmallExit.update(deltaTheta);
+            // calculate deltaTheta
+            if (settling) deltaTheta = angleError(targetTheta, pose.theta, false);
+            else deltaTheta = angleError(targetTheta, pose.theta, false, params.direction);
+            if (prevDeltaTheta == std::nullopt) prevDeltaTheta = deltaTheta;
 
-        // cap the speed
-        if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
-        else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
-        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
-        if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
-        else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
-        prevMotorPower = motorPower;
+            // motion chaining
+            if (params.minSpeed != 0 && fabs(deltaTheta) < params.earlyExitRange) break;
+            if (params.minSpeed != 0 && sgn(deltaTheta) != sgn(prevDeltaTheta)) break;
 
-        infoSink()->debug("Turn Motor Power: {} ", motorPower);
+            // calculate the speed
+            motorPower = angularPID.update(deltaTheta);
+            angularLargeExit.update(deltaTheta);
+            angularSmallExit.update(deltaTheta);
 
-        // move the drivetrain
-        if (lockedSide == DriveSide::LEFT) {
-            drivetrain.rightMotors->move(-motorPower);
-            drivetrain.leftMotors->brake();
-        } else {
-            drivetrain.leftMotors->move(motorPower);
-            drivetrain.rightMotors->brake();
+            // cap the speed
+            if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
+            else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
+            if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
+            if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
+            else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
+            prevMotorPower = motorPower;
+
+            infoSink()->debug("Turn Motor Power: {} ", motorPower);
+
+            // move the drivetrain
+            if (lockedSide == DriveSide::LEFT) {
+                drivetrain.rightMotors->move(-motorPower);
+                drivetrain.leftMotors->brake();
+            } else {
+                drivetrain.leftMotors->move(motorPower);
+                drivetrain.rightMotors->brake();
+            }
+
+            pros::delay(10);
         }
 
-        pros::delay(10);
-    }
+        // set the brake mode of the locked side of the drivetrain to its
+        // original value
+        if (lockedSide == DriveSide::LEFT) this->drivetrain.leftMotors->set_brake_mode_all(brakeMode);
+        else this->drivetrain.rightMotors->set_brake_mode_all(brakeMode);
 
-    // set the brake mode of the locked side of the drivetrain to its
-    // original value
-    if (lockedSide == DriveSide::LEFT) this->drivetrain.leftMotors->set_brake_mode_all(brakeMode);
-    else this->drivetrain.rightMotors->set_brake_mode_all(brakeMode);
-    // stop the drivetrain
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTraveled = -1;
-    this->endMotion();
+        // stop the drivetrain
+        drivetrain.leftMotors->move(0);
+        drivetrain.rightMotors->move(0);
+        // set distTraveled to -1 to indicate that the function has finished
+        distTraveled = -1;
+        this->endMotion();
+    });
+    pros::delay(10);
+    startedMutex.take(TIMEOUT_MAX);
+    if (!async) {
+        do pros::delay(10);
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
+    }
 }

--- a/src/lemlib/chassis/motions/turnToHeading.cpp
+++ b/src/lemlib/chassis/motions/turnToHeading.cpp
@@ -92,6 +92,6 @@ void lemlib::Chassis::turnToHeading(float theta, int timeout, TurnToHeadingParam
     startedMutex.take(TIMEOUT_MAX);
     if (!async) {
         do pros::delay(10);
-        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED || task.get_state() == pros::E_TASK_STATE_DELETED));
     }
 }

--- a/src/lemlib/chassis/motions/turnToHeading.cpp
+++ b/src/lemlib/chassis/motions/turnToHeading.cpp
@@ -6,83 +6,92 @@
 #include "pros/misc.hpp"
 
 void lemlib::Chassis::turnToHeading(float theta, int timeout, TurnToHeadingParams params, bool async) {
-    params.minSpeed = std::abs(params.minSpeed);
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning) return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { turnToHeading(theta, timeout, params, false); });
+    /**
+     * Mutex that is used to block until the motion has started.
+     */
+    pros::Mutex startedMutex;
+    pros::Task task([&]() {
+        startedMutex.take();
+        this->requestMotionStart();
+        startedMutex.give();
+        // were all motions cancelled?
+        if (!this->motionRunning) return;
+
+        params.minSpeed = std::abs(params.minSpeed);
+
+        float targetTheta;
+        float deltaTheta;
+        float motorPower;
+        float prevMotorPower = 0;
+        float startTheta = getPose().theta;
+        bool settling = false;
+        std::optional<float> prevRawDeltaTheta = std::nullopt;
+        std::optional<float> prevDeltaTheta = std::nullopt;
+        std::uint8_t compState = pros::competition::get_status();
+        distTraveled = 0;
+        Timer timer(timeout);
+        angularLargeExit.reset();
+        angularSmallExit.reset();
+        angularPID.reset();
+
+        // main loop
+        while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
+            // update variables
+            Pose pose = getPose();
+
+            // update completion vars
+            distTraveled = fabs(angleError(pose.theta, startTheta, false));
+
+            targetTheta = theta;
+
+            // check if settling
+            const float rawDeltaTheta = angleError(targetTheta, pose.theta, false);
+            if (prevRawDeltaTheta == std::nullopt) prevRawDeltaTheta = rawDeltaTheta;
+            if (sgn(rawDeltaTheta) != sgn(prevRawDeltaTheta)) settling = true;
+            prevRawDeltaTheta = rawDeltaTheta;
+
+            // calculate deltaTheta
+            if (settling) deltaTheta = angleError(targetTheta, pose.theta, false);
+            else deltaTheta = angleError(targetTheta, pose.theta, false, params.direction);
+            if (prevDeltaTheta == std::nullopt) prevDeltaTheta = deltaTheta;
+
+            // motion chaining
+            if (params.minSpeed != 0 && fabs(deltaTheta) < params.earlyExitRange) break;
+            if (params.minSpeed != 0 && sgn(deltaTheta) != sgn(prevDeltaTheta)) break;
+
+            // calculate the speed
+            motorPower = angularPID.update(deltaTheta);
+            angularLargeExit.update(deltaTheta);
+            angularSmallExit.update(deltaTheta);
+
+            // cap the speed
+            if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
+            else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
+            if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
+            if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
+            else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
+            prevMotorPower = motorPower;
+
+            infoSink()->debug("Turn Motor Power: {} ", motorPower);
+
+            // move the drivetrain
+            drivetrain.leftMotors->move(motorPower);
+            drivetrain.rightMotors->move(-motorPower);
+
+            pros::delay(10);
+        }
+
+        // stop the drivetrain
+        drivetrain.leftMotors->move(0);
+        drivetrain.rightMotors->move(0);
+        // set distTraveled to -1 to indicate that the function has finished
+        distTraveled = -1;
         this->endMotion();
-        pros::delay(10); // delay to give the task time to start
-        return;
+    });
+    pros::delay(10);
+    startedMutex.take(TIMEOUT_MAX);
+    if (!async) {
+        do pros::delay(10);
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
     }
-    float targetTheta;
-    float deltaTheta;
-    float motorPower;
-    float prevMotorPower = 0;
-    float startTheta = getPose().theta;
-    bool settling = false;
-    std::optional<float> prevRawDeltaTheta = std::nullopt;
-    std::optional<float> prevDeltaTheta = std::nullopt;
-    std::uint8_t compState = pros::competition::get_status();
-    distTraveled = 0;
-    Timer timer(timeout);
-    angularLargeExit.reset();
-    angularSmallExit.reset();
-    angularPID.reset();
-
-    // main loop
-    while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
-        // update variables
-        Pose pose = getPose();
-
-        // update completion vars
-        distTraveled = fabs(angleError(pose.theta, startTheta, false));
-
-        targetTheta = theta;
-
-        // check if settling
-        const float rawDeltaTheta = angleError(targetTheta, pose.theta, false);
-        if (prevRawDeltaTheta == std::nullopt) prevRawDeltaTheta = rawDeltaTheta;
-        if (sgn(rawDeltaTheta) != sgn(prevRawDeltaTheta)) settling = true;
-        prevRawDeltaTheta = rawDeltaTheta;
-
-        // calculate deltaTheta
-        if (settling) deltaTheta = angleError(targetTheta, pose.theta, false);
-        else deltaTheta = angleError(targetTheta, pose.theta, false, params.direction);
-        if (prevDeltaTheta == std::nullopt) prevDeltaTheta = deltaTheta;
-
-        // motion chaining
-        if (params.minSpeed != 0 && fabs(deltaTheta) < params.earlyExitRange) break;
-        if (params.minSpeed != 0 && sgn(deltaTheta) != sgn(prevDeltaTheta)) break;
-
-        // calculate the speed
-        motorPower = angularPID.update(deltaTheta);
-        angularLargeExit.update(deltaTheta);
-        angularSmallExit.update(deltaTheta);
-
-        // cap the speed
-        if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
-        else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
-        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
-        if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
-        else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
-        prevMotorPower = motorPower;
-
-        infoSink()->debug("Turn Motor Power: {} ", motorPower);
-
-        // move the drivetrain
-        drivetrain.leftMotors->move(motorPower);
-        drivetrain.rightMotors->move(-motorPower);
-
-        pros::delay(10);
-    }
-
-    // stop the drivetrain
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTraveled = -1;
-    this->endMotion();
 }

--- a/src/lemlib/chassis/motions/turnToPoint.cpp
+++ b/src/lemlib/chassis/motions/turnToPoint.cpp
@@ -6,86 +6,95 @@
 #include "pros/misc.hpp"
 
 void lemlib::Chassis::turnToPoint(float x, float y, int timeout, TurnToPointParams params, bool async) {
-    params.minSpeed = std::abs(params.minSpeed);
-    this->requestMotionStart();
-    // were all motions cancelled?
-    if (!this->motionRunning) return;
-    // if the function is async, run it in a new task
-    if (async) {
-        pros::Task task([&]() { turnToPoint(x, y, timeout, params, false); });
+    /**
+     * Mutex that is used to block until the motion has started.
+     */
+    pros::Mutex startedMutex;
+    pros::Task task([&]() {
+        startedMutex.take();
+        this->requestMotionStart();
+        startedMutex.give();
+        // were all motions cancelled?
+        if (!this->motionRunning) return;
+
+        params.minSpeed = std::abs(params.minSpeed);
+
+        float targetTheta;
+        float deltaX, deltaY, deltaTheta;
+        float motorPower;
+        float prevMotorPower = 0;
+        float startTheta = getPose().theta;
+        bool settling = false;
+        std::optional<float> prevRawDeltaTheta = std::nullopt;
+        std::optional<float> prevDeltaTheta = std::nullopt;
+        std::uint8_t compState = pros::competition::get_status();
+        distTraveled = 0;
+        Timer timer(timeout);
+        angularLargeExit.reset();
+        angularSmallExit.reset();
+        angularPID.reset();
+
+        // main loop
+        while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
+            // update variables
+            Pose pose = getPose();
+            pose.theta = (params.forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
+
+            // update completion vars
+            distTraveled = fabs(angleError(pose.theta, startTheta, false));
+
+            deltaX = x - pose.x;
+            deltaY = y - pose.y;
+            targetTheta = fmod(radToDeg(M_PI_2 - atan2(deltaY, deltaX)), 360);
+
+            // check if settling
+            const float rawDeltaTheta = angleError(targetTheta, pose.theta, false);
+            if (prevRawDeltaTheta == std::nullopt) prevRawDeltaTheta = rawDeltaTheta;
+            if (sgn(rawDeltaTheta) != sgn(prevRawDeltaTheta)) settling = true;
+            prevRawDeltaTheta = rawDeltaTheta;
+
+            // calculate deltaTheta
+            if (settling) deltaTheta = angleError(targetTheta, pose.theta, false);
+            else deltaTheta = angleError(targetTheta, pose.theta, false, params.direction);
+            if (prevDeltaTheta == std::nullopt) prevDeltaTheta = deltaTheta;
+
+            // motion chaining
+            if (params.minSpeed != 0 && fabs(deltaTheta) < params.earlyExitRange) break;
+            if (params.minSpeed != 0 && sgn(deltaTheta) != sgn(prevDeltaTheta)) break;
+
+            // calculate the speed
+            motorPower = angularPID.update(deltaTheta);
+            angularLargeExit.update(deltaTheta);
+            angularSmallExit.update(deltaTheta);
+
+            // cap the speed
+            if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
+            else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
+            if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
+            if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
+            else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
+            prevMotorPower = motorPower;
+
+            infoSink()->debug("Turn Motor Power: {} ", motorPower);
+
+            // move the drivetrain
+            drivetrain.leftMotors->move(motorPower);
+            drivetrain.rightMotors->move(-motorPower);
+
+            pros::delay(10);
+        }
+
+        // stop the drivetrain
+        drivetrain.leftMotors->move(0);
+        drivetrain.rightMotors->move(0);
+        // set distTraveled to -1 to indicate that the function has finished
+        distTraveled = -1;
         this->endMotion();
-        pros::delay(10); // delay to give the task time to start
-        return;
+    });
+    pros::delay(10);
+    startedMutex.take(TIMEOUT_MAX);
+    if (!async) {
+        do pros::delay(10);
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
     }
-    float targetTheta;
-    float deltaX, deltaY, deltaTheta;
-    float motorPower;
-    float prevMotorPower = 0;
-    float startTheta = getPose().theta;
-    bool settling = false;
-    std::optional<float> prevRawDeltaTheta = std::nullopt;
-    std::optional<float> prevDeltaTheta = std::nullopt;
-    std::uint8_t compState = pros::competition::get_status();
-    distTraveled = 0;
-    Timer timer(timeout);
-    angularLargeExit.reset();
-    angularSmallExit.reset();
-    angularPID.reset();
-
-    // main loop
-    while (!timer.isDone() && !angularLargeExit.getExit() && !angularSmallExit.getExit() && this->motionRunning) {
-        // update variables
-        Pose pose = getPose();
-        pose.theta = (params.forwards) ? fmod(pose.theta, 360) : fmod(pose.theta - 180, 360);
-
-        // update completion vars
-        distTraveled = fabs(angleError(pose.theta, startTheta, false));
-
-        deltaX = x - pose.x;
-        deltaY = y - pose.y;
-        targetTheta = fmod(radToDeg(M_PI_2 - atan2(deltaY, deltaX)), 360);
-
-        // check if settling
-        const float rawDeltaTheta = angleError(targetTheta, pose.theta, false);
-        if (prevRawDeltaTheta == std::nullopt) prevRawDeltaTheta = rawDeltaTheta;
-        if (sgn(rawDeltaTheta) != sgn(prevRawDeltaTheta)) settling = true;
-        prevRawDeltaTheta = rawDeltaTheta;
-
-        // calculate deltaTheta
-        if (settling) deltaTheta = angleError(targetTheta, pose.theta, false);
-        else deltaTheta = angleError(targetTheta, pose.theta, false, params.direction);
-        if (prevDeltaTheta == std::nullopt) prevDeltaTheta = deltaTheta;
-
-        // motion chaining
-        if (params.minSpeed != 0 && fabs(deltaTheta) < params.earlyExitRange) break;
-        if (params.minSpeed != 0 && sgn(deltaTheta) != sgn(prevDeltaTheta)) break;
-
-        // calculate the speed
-        motorPower = angularPID.update(deltaTheta);
-        angularLargeExit.update(deltaTheta);
-        angularSmallExit.update(deltaTheta);
-
-        // cap the speed
-        if (motorPower > params.maxSpeed) motorPower = params.maxSpeed;
-        else if (motorPower < -params.maxSpeed) motorPower = -params.maxSpeed;
-        if (fabs(deltaTheta) > 20) motorPower = slew(motorPower, prevMotorPower, angularSettings.slew);
-        if (motorPower < 0 && motorPower > -params.minSpeed) motorPower = -params.minSpeed;
-        else if (motorPower > 0 && motorPower < params.minSpeed) motorPower = params.minSpeed;
-        prevMotorPower = motorPower;
-
-        infoSink()->debug("Turn Motor Power: {} ", motorPower);
-
-        // move the drivetrain
-        drivetrain.leftMotors->move(motorPower);
-        drivetrain.rightMotors->move(-motorPower);
-
-        pros::delay(10);
-    }
-
-    // stop the drivetrain
-    drivetrain.leftMotors->move(0);
-    drivetrain.rightMotors->move(0);
-    // set distTraveled to -1 to indicate that the function has finished
-    distTraveled = -1;
-    this->endMotion();
 }

--- a/src/lemlib/chassis/motions/turnToPoint.cpp
+++ b/src/lemlib/chassis/motions/turnToPoint.cpp
@@ -95,6 +95,6 @@ void lemlib::Chassis::turnToPoint(float x, float y, int timeout, TurnToPointPara
     startedMutex.take(TIMEOUT_MAX);
     if (!async) {
         do pros::delay(10);
-        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED));
+        while (!(task.get_state() == pros::E_TASK_STATE_INVALID || task.get_state() == pros::E_TASK_STATE_SUSPENDED || task.get_state() == pros::E_TASK_STATE_DELETED));
     }
 }


### PR DESCRIPTION
#### Summary
* In the current (stable -- I have verified the issue with v0.5.4) version of LemLib, calling a motion synchronously directly runs it.
* This PR changes this so that, regardless of the value of the `async` param, a task is always spawned. The function, outside of the motion task, then blocks until the task has started (to avoid another motion being called while LemLib internal variables are in an intermediate state) using a `pros::Mutex`. If `async = false`, the function also blocks until the motion task exits. 
* We also initialize `distTraveled` at -1 instead of 0, resolving a separate bug where calling `waitUntilDone` when no motion has run before would block until a motion is run/completed.

#### Motivation

Also see #273.

This function takes `Chassis::mutex` (which is marked as held by the task that called the motion -- most likely the autonomous task). However, if the motion was ran from a competition task that subsequently got canceled (because of a change in the competition state), `Chassis::mutex` is still marked as held, but by a task that is now canceled ([source](https://www.freertos.org/FreeRTOS_Support_Forum_Archive/May_2011/freertos_Delete_task_holding_a_mutex._Is_it_released_4546788.html)). Any other motions ran after this will block indefinitely (for TIMEOUT_MAX, which is dozens of days), which is obviously unexpected behavior.

This PR fixes this by always running motions in a separate task. This way, even if the original task that called the motion (i.e., `autonomous`) is cancelled, the motion task continues to run separately until the completion of the motion, at which point it releases `Chassis::mutex`.

#### Test Plan

After much discussion, I believe this is the most likely cause of what I described in #273 and aligns with testing I did (in which calling with `async = true` does not have this problem, as expected). I do not have a drivetrain available to test this right now, unfortunately. All code compiles.

#### Additional Notes
Thanks @meisZWFLZ!