### PR TITLE
Fixed typo

### DIFF
--- a/docs/tutorials/5_angular_motion.md
+++ b/docs/tutorials/5_angular_motion.md
@@ -54,7 +54,7 @@ Here's an example of how you'd use it:
 
 ```cpp
 // turn to the point (53, 53) with a timeout of 1000 ms
-chassis.turnTo(53, 53, 1000);
+chassis.turnToPoint(53, 53, 1000);
 ```
 
 Similar to `turnToHeading`, the motion also takes two optional arguments, `params` and `async`. 


### PR DESCRIPTION

#### Summary
<!-- Provide a brief summary on the pull request -->
`turnToPoint()` seems to be incorrectly entered as `turnTo()` in the example code for turning to a point. 
#### Motivation
<!-- Why are you making this pull request? -->
The example `chassis.turnTo(53, 53, 1000);` fails to compile because `turnTo()` doesn't exist.
#### Test Plan
<!-- How did you test / plan to test this pull request? -->

#### Additional Notes
<!-- Add any other information you think is relevant -->
