### PR TITLE
:children_crossing: include remote url in template artifact

### DIFF
--- a/firmware/remote-source-map.mk
+++ b/firmware/remote-source-map.mk
@@ -1,0 +1,13 @@
+ifneq (,$(filter template,$(MAKECMDGOALS)))
+REMOTE_URL?=$(shell (git remote get-url upstream 2>/dev/null || git remote get-url origin 2>/dev/null) | sed 's/\.git$$//')
+REMOTE_REF?=$(shell git rev-parse HEAD)
+PREFIX_MAP_FLAG=-ffile-prefix-map=$(abspath $(ROOT))=$(REMOTE_URL)/blob/$(REMOTE_REF)
+ASMFLAGS+=$(PREFIX_MAP_FLAG)
+CFLAGS+=$(PREFIX_MAP_FLAG)
+CXXFLAGS+=$(PREFIX_MAP_FLAG)
+LDFLAGS+=$(PREFIX_MAP_FLAG)
+
+ifneq ($(wildcard .d),)
+  $(error Error: `make template` must be run on a clean slate (Run `make clean` first))
+endif
+endif


### PR DESCRIPTION
Enables tools like the V5 Symbolizer VSCode extension to easily determine where to point the user when they are debugging crashes involving LemLib..
Ideally, the `remote-source-map.mk` file can also be added to other templates to easily implement this feature.

What still needs to be done:
- [ ] Fix CI - Right now, the prefixes are only mapped when building the template so as to make debugging the main.cpp program easier, but this requires that the entire library be built when running `make template`. 
- [ ] Determine if raw.githubusercontent.com url should be used instead - This would be better if the goal was to render the remote file in vscode.
  - Why is the distinction important? The hope is that many templates could use this, no matter what VCS that project uses. If we pick the html url, then there will need to be mappings for each VCS (github,gitlab,...) from the html to the raw url if the symbolizer uses the raw file.
- [ ] Investigate correct flag - Idk if `-ffile-prefix-map` is the correct flag for our usecase. It may be better to use `-fdebug-prefix-map` or something else.
- [ ] Fully check that this works in a user project using both V5 Symbolizer and `addr2line`
- [ ] Document variables used, what this is, and a how it works.
- [ ] Check that this works for other templates, like EZ template
- [ ] Implement on master branch as well