### PR TITLE
Fix TrackingWheel::getDistanceTraveled() Not Taking Into Account Gear Ratio

### DIFF
--- a/src/lemlib/tracking/TrackingWheelOdom.cpp
+++ b/src/lemlib/tracking/TrackingWheelOdom.cpp
@@ -40,7 +40,7 @@ TrackingWheel::TrackingWheel(SmartPort expanderPort, ADIPort topPort, ADIPort bo
       m_lastTotal(to_stRot(m_encoder->getAngle()) * M_PI * diameter * m_ratio),
       m_deallocate(true) {}
 
-Length TrackingWheel::getDistanceTraveled() { return to_stRot(m_encoder->getAngle()) * M_PI * m_diameter; }
+Length TrackingWheel::getDistanceTraveled() { return to_stRot(m_encoder->getAngle()) * M_PI * m_diameter * m_ratio; }
 
 Length TrackingWheel::getDistanceDelta() {
     // calculate delta


### PR DESCRIPTION
#### Summary
Fixes a bug where the rotations calculated by getDistanceTraveled isn't multiplied by the gear ratio of the tracking wheel leading to false readings.

#### Motivation
Was reviewing master branch odom code and comparing it to my own when I noticed that it lacked multiplying by the ratio.


Fixes: #292 

<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: e6a872f55f9c5b46d2dc63101cde2e7d5d4af0d5 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/25775960143)
- via manual download: [LemLib@0.6.0+163b4f.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/6960817818.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.6.0+163b4f.zip https://nightly.link/LemLib/LemLib/actions/artifacts/6960817818.zip;
pros c fetch LemLib@0.6.0+163b4f.zip;
pros c apply LemLib@0.6.0+163b4f;
rm LemLib@0.6.0+163b4f.zip;
```