### PR TITLE
:bug: Match Stable Branch's Gear Ratio

### DIFF
--- a/include/lemlib/tracking/TrackingWheelOdom.hpp
+++ b/include/lemlib/tracking/TrackingWheelOdom.hpp
@@ -20,7 +20,7 @@ class TrackingWheel {
          * @param encoder pointer to the encoder which should be used for tracking
          * @param diameter the diameter of the wheel
          * @param offset how far the tracking wheel is from the turning center
-         * @param ratio the gear ratio, driven gear / driving gear. Defaults to 1
+         * @param ratio the gear ratio, gear attached to sensor / gear attached to wheel. Defaults to 1
          *
          * @b Example:
          * @code {.cpp}
@@ -38,7 +38,7 @@ class TrackingWheel {
          * @param port the port of the rotation sensor. To reverse, make the port negative
          * @param diameter the diameter of the wheel
          * @param offset how far the tracking wheel is from the turning center
-         * @param ratio the gear ratio, driven gear / driving gear. Defaults to 1
+         * @param ratio the gear ratio, gear attached to sensor / gear attached to wheel. Defaults to 1
          *
          * @b Example:
          * @code {.cpp}
@@ -56,7 +56,7 @@ class TrackingWheel {
          * @param reversed whether the encoder should be reversed or not
          * @param diameter the diameter of the wheel
          * @param offset how far the tracking wheel is from the turning center
-         * @param ratio the gear ratio, driven gear / driving gear. Defaults to 1
+         * @param ratio the gear ratio, gear attached to sensor / gear attached to wheel. Defaults to 1
          *
          * @b Example:
          * @code {.cpp}
@@ -77,7 +77,7 @@ class TrackingWheel {
          * @param reversed whether the encoder should be reversed or not
          * @param diameter the diameter of the wheel
          * @param offset how far the tracking wheel is from the turning center
-         * @param ratio the gear ratio, driven gear / driving gear. Defaults to 1
+         * @param ratio the gear ratio, gear attached to sensor / gear attached to wheel. Defaults to 1
          *
          * @b Example:
          * @code {.cpp}

--- a/src/lemlib/tracking/TrackingWheelOdom.cpp
+++ b/src/lemlib/tracking/TrackingWheelOdom.cpp
@@ -40,7 +40,7 @@ TrackingWheel::TrackingWheel(SmartPort expanderPort, ADIPort topPort, ADIPort bo
       m_lastTotal(this->getDistanceTraveled()),
       m_deallocate(true) {}
 
-Length TrackingWheel::getDistanceTraveled() { return to_stRot(m_encoder->getAngle()) * M_PI * m_diameter * m_ratio; }
+Length TrackingWheel::getDistanceTraveled() { return to_stRot(m_encoder->getAngle()) * M_PI * m_diameter / m_ratio; }
 
 Length TrackingWheel::getDistanceDelta() {
     // calculate delta

--- a/src/lemlib/tracking/TrackingWheelOdom.cpp
+++ b/src/lemlib/tracking/TrackingWheelOdom.cpp
@@ -12,14 +12,14 @@ TrackingWheel::TrackingWheel(Encoder* encoder, Length diameter, Length offset, N
       m_diameter(diameter),
       m_offset(offset),
       m_ratio(ratio),
-      m_lastTotal(to_stRot(encoder->getAngle()) * M_PI * diameter * m_ratio) {}
+      m_lastTotal(this->getDistanceTraveled()) {}
 
 TrackingWheel::TrackingWheel(ReversibleSmartPort port, Length diameter, Length offset, Number ratio)
     : m_encoder(new V5RotationSensor(port)),
       m_diameter(diameter),
       m_offset(offset),
       m_ratio(ratio),
-      m_lastTotal(to_stRot(m_encoder->getAngle()) * M_PI * diameter * m_ratio),
+      m_lastTotal(this->getDistanceTraveled()),
       m_deallocate(true) {}
 
 TrackingWheel::TrackingWheel(ADIPort topPort, ADIPort bottomPort, bool reversed, Length diameter, Length offset,
@@ -28,7 +28,7 @@ TrackingWheel::TrackingWheel(ADIPort topPort, ADIPort bottomPort, bool reversed,
       m_diameter(diameter),
       m_offset(offset),
       m_ratio(ratio),
-      m_lastTotal(to_stRot(m_encoder->getAngle()) * M_PI * diameter * m_ratio),
+      m_lastTotal(this->getDistanceTraveled()),
       m_deallocate(true) {}
 
 TrackingWheel::TrackingWheel(SmartPort expanderPort, ADIPort topPort, ADIPort bottomPort, bool reversed,
@@ -37,7 +37,7 @@ TrackingWheel::TrackingWheel(SmartPort expanderPort, ADIPort topPort, ADIPort bo
       m_diameter(diameter),
       m_offset(offset),
       m_ratio(ratio),
-      m_lastTotal(to_stRot(m_encoder->getAngle()) * M_PI * diameter * m_ratio),
+      m_lastTotal(this->getDistanceTraveled()),
       m_deallocate(true) {}
 
 Length TrackingWheel::getDistanceTraveled() { return to_stRot(m_encoder->getAngle()) * M_PI * m_diameter * m_ratio; }


### PR DESCRIPTION
#### Summary
<!-- Provide a brief summary on the pull request -->
Divides the measurement by the gear ratio, just as it is done on the stable branch.

#### Motivation
<!-- Why are you making this pull request? -->
Reduce confusion in the future.

#### Test Plan
<!-- How did you test / plan to test this pull request? -->
nah

#### Additional Notes
<!-- Add any other information you think is relevant -->
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: e3d0d6ed98cca18ce4ab627718b0e238cdb80be3 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/LemLib/actions/runs/26064364620)
- via manual download: [LemLib@0.6.0+82cfb2.zip](https://nightly.link/LemLib/LemLib/actions/artifacts/7070620711.zip)
- via PROS Integrated Terminal: 
 ```
curl -o LemLib@0.6.0+82cfb2.zip https://nightly.link/LemLib/LemLib/actions/artifacts/7070620711.zip;
pros c fetch LemLib@0.6.0+82cfb2.zip;
pros c apply LemLib@0.6.0+82cfb2;
rm LemLib@0.6.0+82cfb2.zip;
```